### PR TITLE
Apply markdownlint to all markdown files

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Testing frameworks on testing frameworks",
   "private": true,
   "scripts": {
-    "lint:md": "markdownlint **/*.md --ignore node_modules",
+    "lint:md": "markdownlint '**/*.md' --ignore node_modules",
     "repo:clean-merged-branches": "git remote update origin --prune; npm run --silent repo:list-merged-branches | xargs --no-run-if-empty git branch -d; echo Done",
     "repo:list-merged-branches": "git branch --merged | grep --invert-match --extended-regexp \"(^\\*|main)\""
   },


### PR DESCRIPTION
Fix the [glob syntax](https://www.npmjs.com/package/markdownlint-cli#globbing-examples) for linting all markdown files.