### PR TITLE
Start a rudimentary implementation of json-schema with open-schema

### DIFF
--- a/packages/constraint-engine/src/engine/applyRules.ts
+++ b/packages/constraint-engine/src/engine/applyRules.ts
@@ -29,6 +29,7 @@ export const applyRules = ({
             targetTypeId: targetReference.typeId,
             normalizedTargetPath: targetReference.normalizedPath,
             targetInstancePath: targetReference.instancePath,
+            targetInstance: targetReference.instance,
             isTargetValid,
           } satisfies UnknownNormalizedAppliedRuleResult;
         });

--- a/packages/constraint-engine/src/json-schema/example/run.ts
+++ b/packages/constraint-engine/src/json-schema/example/run.ts
@@ -1,0 +1,20 @@
+import { constraintEngine } from '../../engine/constraintEngine';
+import { getTargetReferenceConfigurationsFromJson } from '../utils/getTargetReferenceConfigurationsFromData';
+import { getRuleConfigurationsFromJsonSchema } from '../utils/getRuleConfigurationsFromJsonSchema';
+import { JsonTarget } from '../types/targets';
+
+const inputData: JsonTarget = 'hello!';
+
+const inputSchema: JsonTarget = {
+  type: 'boolean',
+};
+
+const targetReferenceConfigurations =
+  getTargetReferenceConfigurationsFromJson(inputData);
+
+const ruleConfigurations = getRuleConfigurationsFromJsonSchema(inputSchema);
+
+constraintEngine.run({
+  targetReferenceConfigurations,
+  ruleConfigurations,
+});

--- a/packages/constraint-engine/src/json-schema/referenceBuilders/buildDerivedTypedJsonReference.ts
+++ b/packages/constraint-engine/src/json-schema/referenceBuilders/buildDerivedTypedJsonReference.ts
@@ -1,0 +1,37 @@
+import { DerivedReferenceBuilder } from '../../types/builder';
+import { UnknownTargetPath } from '../../types/targetPath';
+import { TargetReference } from '../../types/targetReference';
+import { JsonMetaTargetTypeId } from '../types/constants';
+import { JsonTypedTargetTarget } from '../types/targets';
+import {
+  JsonMetaUnknownTypedTarget,
+  JsonMetaKnownTypedTarget,
+} from '../types/typedTargets';
+import { getJsonDataType } from '../utils/getJsonDataType';
+
+export const buildDerivedTypedJsonReference = (<
+  TInputTargetPath extends UnknownTargetPath,
+>(
+  inputReference: TargetReference<JsonMetaUnknownTypedTarget, TInputTargetPath>,
+): TargetReference<JsonMetaKnownTypedTarget, TInputTargetPath> => {
+  const jsonDataType = getJsonDataType(inputReference.instance);
+
+  const outputReference: TargetReference<
+    JsonMetaKnownTypedTarget,
+    TInputTargetPath
+  > = {
+    typeId: JsonMetaTargetTypeId.KnownType,
+    instance: {
+      typeId: jsonDataType,
+      instance: inputReference.instance,
+    } as JsonTypedTargetTarget,
+    path: inputReference.path,
+  };
+
+  return outputReference;
+}) satisfies DerivedReferenceBuilder<
+  JsonMetaUnknownTypedTarget,
+  UnknownTargetPath,
+  JsonMetaKnownTypedTarget,
+  UnknownTargetPath
+>;

--- a/packages/constraint-engine/src/json-schema/referenceBuilders/buildRootUntypedJsonReference.ts
+++ b/packages/constraint-engine/src/json-schema/referenceBuilders/buildRootUntypedJsonReference.ts
@@ -1,0 +1,19 @@
+import { ReferenceBuilder } from '../../types/builder';
+import { JsonMetaTargetTypeId } from '../types/constants';
+import { JsonTarget } from '../types/targets';
+import { JsonMetaUnknownTypedTarget } from '../types/typedTargets';
+
+const ROOT_JSON_TARGET_PATH = 'data' as const;
+type RootJsonTargetPath = typeof ROOT_JSON_TARGET_PATH;
+
+export const buildRootJsonReference: ReferenceBuilder<
+  JsonTarget,
+  JsonMetaUnknownTypedTarget,
+  RootJsonTargetPath
+> = (inputData) => {
+  return {
+    typeId: JsonMetaTargetTypeId.UnknownType,
+    instance: inputData,
+    path: ROOT_JSON_TARGET_PATH,
+  };
+};

--- a/packages/constraint-engine/src/json-schema/rules/buildDataIsType.ts
+++ b/packages/constraint-engine/src/json-schema/rules/buildDataIsType.ts
@@ -1,0 +1,16 @@
+import { Rule } from '../../types/rule';
+import { JsonDataType } from '../types/constants';
+import { JsonTypedTargetTarget } from '../types/targets';
+
+export const buildDataIsType = (
+  expectedJsonDataType: JsonDataType,
+): Rule<JsonTypedTargetTarget> => {
+  const dataIsType: Rule<JsonTypedTargetTarget> = (target) => {
+    return target.typeId === expectedJsonDataType;
+  };
+
+  Object.defineProperty(dataIsType, 'name', {
+    value: `dataIsType:${expectedJsonDataType}`,
+  });
+  return dataIsType;
+};

--- a/packages/constraint-engine/src/json-schema/types/constants.ts
+++ b/packages/constraint-engine/src/json-schema/types/constants.ts
@@ -1,0 +1,7 @@
+export const ROOT_JSON_DATA_TARGET_PATH = 'data';
+export type RootJsonDataTargetPath = typeof ROOT_JSON_DATA_TARGET_PATH;
+
+export enum JsonMetaTargetTypeId {
+  UnknownType = 'JSON:UnknownType',
+  KnownType = 'JSON:KnownType',
+}

--- a/packages/constraint-engine/src/json-schema/types/constants.ts
+++ b/packages/constraint-engine/src/json-schema/types/constants.ts
@@ -1,6 +1,15 @@
 export const ROOT_JSON_DATA_TARGET_PATH = 'data';
 export type RootJsonDataTargetPath = typeof ROOT_JSON_DATA_TARGET_PATH;
 
+export enum JsonDataType {
+  String = 'string',
+  Number = 'number',
+  Boolean = 'boolean',
+  Array = 'array',
+  Object = 'object',
+  Null = 'null',
+}
+
 export enum JsonMetaTargetTypeId {
   UnknownType = 'JSON:UnknownType',
   KnownType = 'JSON:KnownType',

--- a/packages/constraint-engine/src/json-schema/types/targets.ts
+++ b/packages/constraint-engine/src/json-schema/types/targets.ts
@@ -1,3 +1,6 @@
+import { TypedTarget } from '../../types/typedTarget';
+import { JsonDataType } from './constants';
+
 export type JsonStringTarget = string;
 
 export type JsonNumberTarget = number;
@@ -19,3 +22,41 @@ export type JsonTarget =
   | JsonNullTarget
   | JsonArrayTarget
   | JsonObjectTarget;
+
+export type JsonStringTypedTargetTarget = TypedTarget<
+  JsonDataType.String,
+  JsonStringTarget
+>;
+
+export type JsonNumberTypedTargetTarget = TypedTarget<
+  JsonDataType.Number,
+  JsonNumberTarget
+>;
+
+export type JsonBooleanTypedTargetTarget = TypedTarget<
+  JsonDataType.Boolean,
+  JsonBooleanTarget
+>;
+
+export type JsonNullTypedTargetTarget = TypedTarget<
+  JsonDataType.Null,
+  JsonNullTarget
+>;
+
+export type JsonArrayTypedTargetTarget = TypedTarget<
+  JsonDataType.Array,
+  JsonArrayTarget
+>;
+
+export type JsonObjectTypedTargetTarget = TypedTarget<
+  JsonDataType.Object,
+  JsonObjectTarget
+>;
+
+export type JsonTypedTargetTarget =
+  | JsonStringTypedTargetTarget
+  | JsonNumberTypedTargetTarget
+  | JsonBooleanTypedTargetTarget
+  | JsonNullTypedTargetTarget
+  | JsonArrayTypedTargetTarget
+  | JsonObjectTypedTargetTarget;

--- a/packages/constraint-engine/src/json-schema/types/targets.ts
+++ b/packages/constraint-engine/src/json-schema/types/targets.ts
@@ -1,0 +1,21 @@
+export type JsonStringTarget = string;
+
+export type JsonNumberTarget = number;
+
+export type JsonBooleanTarget = boolean;
+
+export type JsonNullTarget = null;
+
+// eslint-disable-next-line @typescript-eslint/no-use-before-define
+export type JsonArrayTarget = JsonTarget[];
+
+// eslint-disable-next-line @typescript-eslint/no-use-before-define
+export type JsonObjectTarget = { [key: string]: JsonTarget };
+
+export type JsonTarget =
+  | JsonStringTarget
+  | JsonNumberTarget
+  | JsonBooleanTarget
+  | JsonNullTarget
+  | JsonArrayTarget
+  | JsonObjectTarget;

--- a/packages/constraint-engine/src/json-schema/types/typedTargets.ts
+++ b/packages/constraint-engine/src/json-schema/types/typedTargets.ts
@@ -1,0 +1,8 @@
+import { TypedTarget } from '../../types/typedTarget';
+import { JsonMetaTargetTypeId } from './constants';
+import { JsonTarget } from './targets';
+
+export type JsonMetaUnknownTypedTarget = TypedTarget<
+  JsonMetaTargetTypeId.UnknownType,
+  JsonTarget
+>;

--- a/packages/constraint-engine/src/json-schema/types/typedTargets.ts
+++ b/packages/constraint-engine/src/json-schema/types/typedTargets.ts
@@ -1,8 +1,13 @@
 import { TypedTarget } from '../../types/typedTarget';
 import { JsonMetaTargetTypeId } from './constants';
-import { JsonTarget } from './targets';
+import { JsonTarget, JsonTypedTargetTarget } from './targets';
 
 export type JsonMetaUnknownTypedTarget = TypedTarget<
   JsonMetaTargetTypeId.UnknownType,
   JsonTarget
+>;
+
+export type JsonMetaKnownTypedTarget = TypedTarget<
+  JsonMetaTargetTypeId.KnownType,
+  JsonTypedTargetTarget
 >;

--- a/packages/constraint-engine/src/json-schema/utils/getJsonDataType.ts
+++ b/packages/constraint-engine/src/json-schema/utils/getJsonDataType.ts
@@ -1,0 +1,39 @@
+import { JsonDataType } from '../types/constants';
+import { JsonTarget } from '../types/targets';
+
+enum DataType {
+  string = 'string',
+  number = 'number',
+  bigint = 'bigint',
+  boolean = 'boolean',
+  symbol = 'symbol',
+  undefined = 'undefined',
+  object = 'object',
+  function = 'function',
+}
+
+type JsonCompatibleDataType = Extract<
+  DataType,
+  DataType.string | DataType.number | DataType.boolean | DataType.object
+>;
+
+export const getJsonDataType = (data: JsonTarget): JsonDataType => {
+  const dataType = typeof data as JsonCompatibleDataType;
+
+  let jsonDataType: JsonDataType;
+  if (dataType === DataType.string) {
+    jsonDataType = JsonDataType.String;
+  } else if (dataType === DataType.number) {
+    jsonDataType = JsonDataType.Number;
+  } else if (dataType === DataType.boolean) {
+    jsonDataType = JsonDataType.Boolean;
+  } else if (dataType === DataType.object && data === null) {
+    jsonDataType = JsonDataType.Null;
+  } else if (dataType === DataType.object && Array.isArray(data)) {
+    jsonDataType = JsonDataType.Array;
+  } else {
+    jsonDataType = JsonDataType.Object;
+  }
+
+  return jsonDataType;
+};

--- a/packages/constraint-engine/src/json-schema/utils/getRuleConfigurationsFromJsonSchema.ts
+++ b/packages/constraint-engine/src/json-schema/utils/getRuleConfigurationsFromJsonSchema.ts
@@ -1,0 +1,16 @@
+import { UnknownRuleConfiguration } from '../../types/ruleConfiguration';
+import { buildDataIsType } from '../rules/buildDataIsType';
+import { JsonDataType, JsonMetaTargetTypeId } from '../types/constants';
+import { JsonObjectTarget } from '../types/targets';
+
+export const getRuleConfigurationsFromJsonSchema = (
+  inputSchema: JsonObjectTarget,
+): UnknownRuleConfiguration[] => {
+  return [
+    {
+      rule: buildDataIsType(inputSchema.type as JsonDataType),
+      targetTypeId: JsonMetaTargetTypeId.KnownType,
+      normalizedTargetPath: 'data',
+    },
+  ] as unknown as UnknownRuleConfiguration[];
+};

--- a/packages/constraint-engine/src/json-schema/utils/getTargetReferenceConfigurationsFromData.ts
+++ b/packages/constraint-engine/src/json-schema/utils/getTargetReferenceConfigurationsFromData.ts
@@ -1,0 +1,44 @@
+import { buildDerivedTargetReferenceConfiguration } from '../../configurationHelpers/buildDerivedTargetReferenceConfiguration';
+import { buildRootTargetReferenceConfiguration } from '../../configurationHelpers/buildRootTargetReferenceConfiguration';
+import { UnknownTargetReferenceConfiguration } from '../../types/targetReferenceConfiguration/unknownTargetReferenceConfiguration';
+import { buildDerivedTypedJsonReference } from '../referenceBuilders/buildDerivedTypedJsonReference';
+import { buildRootJsonReference } from '../referenceBuilders/buildRootUntypedJsonReference';
+import {
+  RootJsonDataTargetPath,
+  JsonMetaTargetTypeId,
+} from '../types/constants';
+import { JsonTarget } from '../types/targets';
+import {
+  JsonMetaUnknownTypedTarget,
+  JsonMetaKnownTypedTarget,
+} from '../types/typedTargets';
+
+export const getTargetReferenceConfigurationsFromJson = (
+  data: JsonTarget,
+): UnknownTargetReferenceConfiguration[] => {
+  return [
+    buildRootTargetReferenceConfiguration<
+      JsonTarget,
+      JsonMetaUnknownTypedTarget,
+      RootJsonDataTargetPath
+    >({
+      buildReference: buildRootJsonReference,
+      inputData: data,
+      normalizedInputTargetPath: '',
+      outputTargetTypeId: JsonMetaTargetTypeId.UnknownType,
+      normalizedOutputTargetPath: 'data',
+    }),
+    buildDerivedTargetReferenceConfiguration<
+      JsonMetaUnknownTypedTarget,
+      RootJsonDataTargetPath,
+      JsonMetaKnownTypedTarget,
+      RootJsonDataTargetPath
+    >({
+      buildReference: buildDerivedTypedJsonReference,
+      inputTargetTypeId: JsonMetaTargetTypeId.UnknownType,
+      normalizedInputTargetPath: 'data',
+      outputTargetTypeId: JsonMetaTargetTypeId.KnownType,
+      normalizedOutputTargetPath: 'data',
+    }),
+  ] as unknown as UnknownTargetReferenceConfiguration[];
+};

--- a/packages/constraint-engine/src/types/rule.ts
+++ b/packages/constraint-engine/src/types/rule.ts
@@ -13,5 +13,6 @@ export type UnknownNormalizedAppliedRuleResult = {
   targetTypeId: UnknownTargetTypeId;
   normalizedTargetPath: UnknownTargetPath;
   targetInstancePath: UnknownTargetPath;
+  targetInstance: UnknownTargetInstance;
   isTargetValid: boolean;
 };


### PR DESCRIPTION
## Example

1. Optionally modify the schema in `packages/constraint-engine/src/json-schema/example/run.ts`
2. Then run (from the root) `npx ts-node packages/constraint-engine/src/json-schema/example/run.ts`
3a. If the data matches the schema then expect to see "All 1 checks passed"
3b. If the data does not match the schema then expect to see failure information

## Limitations

- The input json-schema must be an object
- the system only checks the root input data
- only the "type" keyword is partially implemented
    - the "type" keyword can only have a single string value, and not a list

