### PR TITLE
Update derived reference builder output typed target type

### DIFF
--- a/packages/constraint-engine/src/configurationHelpers/buildDerivedTargetReferenceConfiguration.ts
+++ b/packages/constraint-engine/src/configurationHelpers/buildDerivedTargetReferenceConfiguration.ts
@@ -10,7 +10,7 @@ import { UnknownTypedTarget } from '../types/typedTarget';
 export const buildDerivedTargetReferenceConfiguration = <
   TInputTypedTarget extends UnknownTypedTarget,
   TInputTargetPath extends UnknownTargetPath,
-  TOutputTypedTarget extends UnknownTypedTarget,
+  TOutputTypedTargetOptions extends readonly UnknownTypedTarget[],
   TOutputTargetPath extends UnknownTargetPath,
 >({
   inputTargetTypeId,
@@ -22,14 +22,14 @@ export const buildDerivedTargetReferenceConfiguration = <
   KnownDerivedTargetReferenceConfiguration<
     TInputTypedTarget,
     TInputTargetPath,
-    TOutputTypedTarget,
+    TOutputTypedTargetOptions,
     TOutputTargetPath
   >,
   'typeId'
 >): PartiallyKnownDerivedTargetReferenceConfiguration<
   TInputTypedTarget,
   TInputTargetPath,
-  TOutputTypedTarget,
+  TOutputTypedTargetOptions,
   TOutputTargetPath
 > => ({
   typeId:
@@ -39,7 +39,7 @@ export const buildDerivedTargetReferenceConfiguration = <
   outputTargetTypeId,
   normalizedOutputTargetPath,
   buildReference: buildReference as PartiallyKnownDerivedReferenceBuilder<
-    TOutputTypedTarget,
+    TOutputTypedTargetOptions,
     TOutputTargetPath
   >,
 });

--- a/packages/constraint-engine/src/customTargets/testingPlatformPackage/buildTestingPlatformPackageReference.ts
+++ b/packages/constraint-engine/src/customTargets/testingPlatformPackage/buildTestingPlatformPackageReference.ts
@@ -54,6 +54,6 @@ export const buildTestingPlatformPackageReference = (<
 }) satisfies KnownDerivedReferenceBuilder<
   TestingPlatformPackageDirectoryTypedTarget,
   TestingPlatformPackageTargetPath<string>,
-  TestingPlatformPackageTypedTarget,
+  [TestingPlatformPackageTypedTarget],
   UnknownTargetPath
 >;

--- a/packages/constraint-engine/src/engine/normalizedReferenceBuilders/buildNormalizedDerivedTargetReferences.test.ts
+++ b/packages/constraint-engine/src/engine/normalizedReferenceBuilders/buildNormalizedDerivedTargetReferences.test.ts
@@ -42,7 +42,7 @@ orchestrate()
         }),
         inputTargetTypeId: 'Foo',
         normalizedInputTargetPath: 'foo/:index',
-        outputTargetTypeId: 'Bar',
+        outputTargetTypeId: ['Bar'],
         normalizedOutputTargetPath: 'foo/:index/bar',
       },
       normalizedTargetReferenceMap,

--- a/packages/constraint-engine/src/example/targetReferenceConfigurations.ts
+++ b/packages/constraint-engine/src/example/targetReferenceConfigurations.ts
@@ -49,13 +49,13 @@ export const targetReferenceConfigurations = [
   buildDerivedTargetReferenceConfiguration<
     TestingPlatformPackageDirectoryTypedTarget,
     TestingPlatformPackageDirectoryTargetPath<TestingPlatformPackageDirectorySetTargetPath>,
-    TestingPlatformPackageTypedTarget,
+    [TestingPlatformPackageTypedTarget],
     TestingPlatformPackageTargetPath<TestingPlatformPackageDirectorySetTargetPath>
   >({
     buildReference: buildTestingPlatformPackageReference,
     inputTargetTypeId: TestingPlatformTargetTypeId.PackageDirectory,
     normalizedInputTargetPath: 'testingPlatformPackageDirectorySet/:index',
-    outputTargetTypeId: TestingPlatformTargetTypeId.Package,
+    outputTargetTypeId: [TestingPlatformTargetTypeId.Package],
     normalizedOutputTargetPath:
       'testingPlatformPackageDirectorySet/:directoryName',
   }),

--- a/packages/constraint-engine/src/json-schema/referenceBuilders/buildDerivedTypedJsonReference.ts
+++ b/packages/constraint-engine/src/json-schema/referenceBuilders/buildDerivedTypedJsonReference.ts
@@ -4,6 +4,7 @@ import { TargetReference } from '../../types/targetReference';
 import { JSON_DATA_TYPE_TO_TARGET_TYPE_ID } from '../types/constants';
 import {
   JsonKnownTypedTarget,
+  JsonKnownTypedTargetOptions,
   JsonUnknownTypedTarget,
 } from '../types/typedTargets';
 import { getJsonDataType } from '../utils/getJsonDataType';
@@ -28,6 +29,6 @@ export const buildDerivedTypedJsonReference = (<
 }) satisfies KnownDerivedReferenceBuilder<
   JsonUnknownTypedTarget,
   UnknownTargetPath,
-  JsonKnownTypedTarget,
+  JsonKnownTypedTargetOptions,
   UnknownTargetPath
 >;

--- a/packages/constraint-engine/src/json-schema/types/typedTargets.ts
+++ b/packages/constraint-engine/src/json-schema/types/typedTargets.ts
@@ -45,10 +45,13 @@ export type JsonObjectTypedTarget = TypedTarget<
   JsonObjectTarget
 >;
 
-export type JsonKnownTypedTarget =
-  | JsonStringTypedTarget
-  | JsonNumberTypedTarget
-  | JsonBooleanTypedTarget
-  | JsonNullTypedTarget
-  | JsonArrayTypedTarget
-  | JsonObjectTypedTarget;
+export type JsonKnownTypedTargetOptions = readonly [
+  JsonStringTypedTarget,
+  JsonNumberTypedTarget,
+  JsonBooleanTypedTarget,
+  JsonNullTypedTarget,
+  JsonArrayTypedTarget,
+  JsonObjectTypedTarget,
+];
+
+export type JsonKnownTypedTarget = JsonKnownTypedTargetOptions[number];

--- a/packages/constraint-engine/src/json-schema/utils/getTargetReferenceConfigurationsFromData.ts
+++ b/packages/constraint-engine/src/json-schema/utils/getTargetReferenceConfigurationsFromData.ts
@@ -6,7 +6,7 @@ import { buildRootJsonReference } from '../referenceBuilders/buildRootUntypedJso
 import { JsonTargetTypeId, RootJsonDataTargetPath } from '../types/constants';
 import { JsonTarget } from '../types/targets';
 import {
-  JsonKnownTypedTarget,
+  JsonKnownTypedTargetOptions,
   JsonUnknownTypedTarget,
 } from '../types/typedTargets';
 
@@ -28,14 +28,20 @@ export const getTargetReferenceConfigurationsFromJson = (
     buildDerivedTargetReferenceConfiguration<
       JsonUnknownTypedTarget,
       RootJsonDataTargetPath,
-      JsonKnownTypedTarget,
+      JsonKnownTypedTargetOptions,
       RootJsonDataTargetPath
     >({
       buildReference: buildDerivedTypedJsonReference,
       inputTargetTypeId: JsonTargetTypeId.Unknown,
       normalizedInputTargetPath: 'data',
-      // FIXME: outputTargetTypeId should be a list
-      outputTargetTypeId: JsonTargetTypeId.Object,
+      outputTargetTypeId: [
+        JsonTargetTypeId.String,
+        JsonTargetTypeId.Number,
+        JsonTargetTypeId.Boolean,
+        JsonTargetTypeId.Null,
+        JsonTargetTypeId.Array,
+        JsonTargetTypeId.Object,
+      ],
       normalizedOutputTargetPath: 'data',
     }),
   ] as unknown as UnknownTargetReferenceConfiguration[];

--- a/packages/constraint-engine/src/types/builders/derivedReferenceBuilder.ts
+++ b/packages/constraint-engine/src/types/builders/derivedReferenceBuilder.ts
@@ -5,18 +5,18 @@ import { UnknownTypedTarget } from '../typedTarget';
 export type KnownDerivedReferenceBuilder<
   TInputTypedTarget extends UnknownTypedTarget,
   TInputTargetPath extends UnknownTargetPath,
-  TOutputTypedTarget extends UnknownTypedTarget,
+  TOutputTypedTargetOptions extends readonly UnknownTypedTarget[],
   TOutputTargetPath extends UnknownTargetPath,
 > = (
   inputReference: TargetReference<TInputTypedTarget, TInputTargetPath>,
-) => TargetReference<TOutputTypedTarget, TOutputTargetPath>;
+) => TargetReference<TOutputTypedTargetOptions[number], TOutputTargetPath>;
 
 export type PartiallyKnownDerivedReferenceBuilder<
-  TOutputTypedTarget extends UnknownTypedTarget,
+  TOutputTypedTargetOptions extends readonly UnknownTypedTarget[],
   TOutputTargetPath extends UnknownTargetPath,
 > = KnownDerivedReferenceBuilder<
   UnknownTypedTarget,
   UnknownTargetPath,
-  TOutputTypedTarget,
+  TOutputTypedTargetOptions,
   TOutputTargetPath
 >;

--- a/packages/constraint-engine/src/types/ruleConfiguration.ts
+++ b/packages/constraint-engine/src/types/ruleConfiguration.ts
@@ -48,11 +48,11 @@ type RuleConfigurationFromTargetReferenceConfiguration<
     : TTargetReferenceConfiguration extends PartiallyKnownDerivedTargetReferenceConfiguration<
         UnknownTypedTarget,
         UnknownTargetPath,
-        infer TOutputTypedTarget,
+        infer TOutputTypedTargetOptions,
         infer TOutputTargetPath
       >
     ? KnownRuleConfiguration<
-        TOutputTypedTarget,
+        TOutputTypedTargetOptions[number],
         NormalizedTargetPath<TOutputTargetPath>
       >
     : TTargetReferenceConfiguration extends PartiallyKnownDerivedTargetReferenceSetConfiguration<

--- a/packages/constraint-engine/src/types/targetReferenceConfiguration/derivedTargetReferenceConfiguration.ts
+++ b/packages/constraint-engine/src/types/targetReferenceConfiguration/derivedTargetReferenceConfiguration.ts
@@ -8,47 +8,49 @@ type DerivedTargetReferenceConfiguration<
   TActualInputTargetPath extends UnknownTargetPath,
   TExpectedInputTypedTarget extends UnknownTypedTarget,
   TExpectedInputTargetPath extends UnknownTargetPath,
-  TOutputTypedTarget extends UnknownTypedTarget,
+  TOutputTypedTargetOptions extends readonly UnknownTypedTarget[],
   TOutputTargetPath extends UnknownTargetPath,
 > = {
   typeId: TargetReferenceConfigurationTypeId.DerivedTargetReferenceConfiguration;
   buildReference: KnownDerivedReferenceBuilder<
     TActualInputTypedTarget,
     TActualInputTargetPath,
-    TOutputTypedTarget,
+    TOutputTypedTargetOptions,
     TOutputTargetPath
   >;
   inputTargetTypeId: TExpectedInputTypedTarget['typeId'];
   normalizedInputTargetPath: NormalizedTargetPath<TExpectedInputTargetPath>;
-  outputTargetTypeId: TOutputTypedTarget['typeId'];
+  outputTargetTypeId: {
+    [Index in keyof TOutputTypedTargetOptions]: TOutputTypedTargetOptions[Index]['typeId'];
+  };
   normalizedOutputTargetPath: NormalizedTargetPath<TOutputTargetPath>;
 };
 
 export type KnownDerivedTargetReferenceConfiguration<
   TInputTypedTarget extends UnknownTypedTarget,
   TInputTargetPath extends UnknownTargetPath,
-  TOutputTypedTarget extends UnknownTypedTarget,
+  TOutputTypedTargetOptions extends readonly UnknownTypedTarget[],
   TOutputTargetPath extends UnknownTargetPath,
 > = DerivedTargetReferenceConfiguration<
   TInputTypedTarget,
   TInputTargetPath,
   TInputTypedTarget,
   TInputTargetPath,
-  TOutputTypedTarget,
+  TOutputTypedTargetOptions,
   TOutputTargetPath
 >;
 
 export type PartiallyKnownDerivedTargetReferenceConfiguration<
   TInputTypedTarget extends UnknownTypedTarget,
   TInputTargetPath extends UnknownTargetPath,
-  TOutputTypedTarget extends UnknownTypedTarget,
+  TOutputTypedTargetOptions extends readonly UnknownTypedTarget[],
   TOutputTargetPath extends UnknownTargetPath,
 > = DerivedTargetReferenceConfiguration<
   UnknownTypedTarget,
   UnknownTargetPath,
   TInputTypedTarget,
   TInputTargetPath,
-  TOutputTypedTarget,
+  TOutputTypedTargetOptions,
   TOutputTargetPath
 >;
 
@@ -58,6 +60,6 @@ export type UnknownDerivedTargetReferenceConfiguration =
     UnknownTargetPath,
     UnknownTypedTarget,
     UnknownTargetPath,
-    UnknownTypedTarget,
+    [UnknownTypedTarget],
     UnknownTargetPath
   >;


### PR DESCRIPTION
Derived reference builders can produce one of several output typed targets. This change updates the derived reference builder output target type to be a tuple of target types. That way target reference configurations can provide a list of all potential output target type ids.