### PR TITLE
Update buildNarrowedReferenceBuilder to make a castReferenceBuilder

### DIFF
--- a/packages/constraint-engine/src/configurationHelpers/buildNarrowedTargetReferenceConfiguration.ts
+++ b/packages/constraint-engine/src/configurationHelpers/buildNarrowedTargetReferenceConfiguration.ts
@@ -1,5 +1,6 @@
 import { buildNarrowedReferenceBuilder } from '../referenceBuilders/buildNarrowedReferenceBuilder';
-import { GuardRuleTupleNarrowedTargetIntersection } from '../types/builders/narrowedReferenceBuilder';
+import { PartiallyKnownDerivedReferenceBuilder } from '../types/builders/derivedReferenceBuilder';
+import { EvaluateGuardRuleTuple } from '../types/builders/narrowedReferenceBuilder';
 import { InferableGuardRule } from '../types/rule';
 import { UnknownTargetPath } from '../types/targetPath';
 import {
@@ -17,32 +18,34 @@ export type NarrowedTargetReferenceConfigurationBuilderInput<
   TInputTypedTarget extends UnknownTypedTarget,
   TInputTargetPath extends UnknownTargetPath,
   TGuardRuleTuple extends readonly InferableGuardRule[],
-  TOutputTypedTarget extends TypedTarget<
-    UnknownTargetTypeId,
-    GuardRuleTupleNarrowedTargetIntersection<TGuardRuleTuple>
-  >,
+  TOutputTargetTypeId extends UnknownTargetTypeId,
+  TOutputTargetInstance extends TInputTypedTarget['instance'],
 > = Pick<
   KnownDerivedTargetReferenceConfiguration<
     TInputTypedTarget,
     TInputTargetPath,
-    [TOutputTypedTarget],
+    [TypedTarget<TOutputTargetTypeId, TOutputTargetInstance>],
     [TInputTargetPath]
   >,
   'inputTargetTypeId' | 'conditions'
 > & {
   inputTargetPath: TInputTargetPath;
   conditions: TGuardRuleTuple;
-  outputTargetTypeId: TOutputTypedTarget['typeId'];
+  outputTargetTypeId: EvaluateGuardRuleTuple<
+    TInputTypedTarget,
+    TGuardRuleTuple,
+    TOutputTargetInstance,
+    TOutputTargetTypeId,
+    TInputTypedTarget['typeId']
+  >;
 };
 
 export const buildNarrowedTargetReferenceConfiguration = <
   TInputTypedTarget extends UnknownTypedTarget,
   TInputTargetPath extends UnknownTargetPath,
   TGuardRuleTuple extends readonly InferableGuardRule[],
-  TOutputTypedTarget extends TypedTarget<
-    UnknownTargetTypeId,
-    GuardRuleTupleNarrowedTargetIntersection<TGuardRuleTuple>
-  >,
+  TOutputTargetTypeId extends UnknownTargetTypeId,
+  TOutputTargetInstance extends TInputTypedTarget['instance'],
 >({
   inputTargetTypeId,
   inputTargetPath,
@@ -52,17 +55,34 @@ export const buildNarrowedTargetReferenceConfiguration = <
   TInputTypedTarget,
   TInputTargetPath,
   TGuardRuleTuple,
-  TOutputTypedTarget
+  TOutputTargetTypeId,
+  TOutputTargetInstance
 >): PartiallyKnownDerivedTargetReferenceConfiguration<
   TInputTypedTarget,
   TInputTargetPath,
-  [TOutputTypedTarget],
+  [
+    EvaluateGuardRuleTuple<
+      TInputTypedTarget,
+      TGuardRuleTuple,
+      TOutputTargetInstance,
+      TypedTarget<TOutputTargetTypeId, TOutputTargetInstance>,
+      TInputTypedTarget
+    >,
+  ],
   [TInputTargetPath]
 > =>
   buildDerivedTargetReferenceConfiguration<
     TInputTypedTarget,
     TInputTargetPath,
-    [TOutputTypedTarget],
+    [
+      EvaluateGuardRuleTuple<
+        TInputTypedTarget,
+        TGuardRuleTuple,
+        TOutputTargetInstance,
+        TypedTarget<TOutputTargetTypeId, TOutputTargetInstance>,
+        TInputTypedTarget
+      >,
+    ],
     [TInputTargetPath]
   >({
     inputTargetTypeId,
@@ -73,7 +93,19 @@ export const buildNarrowedTargetReferenceConfiguration = <
       TInputTypedTarget,
       TInputTargetPath,
       TGuardRuleTuple,
-      TOutputTypedTarget
-    >(outputTargetTypeId),
+      TOutputTargetTypeId,
+      TOutputTargetInstance
+    >(conditions, outputTargetTypeId) as PartiallyKnownDerivedReferenceBuilder<
+      [
+        EvaluateGuardRuleTuple<
+          TInputTypedTarget,
+          TGuardRuleTuple,
+          TOutputTargetInstance,
+          TypedTarget<TOutputTargetTypeId, TOutputTargetInstance>,
+          TInputTypedTarget
+        >,
+      ],
+      [TInputTargetPath]
+    >,
     conditions,
   });

--- a/packages/constraint-engine/src/customRules/packageAHasRunTestsScript.ts
+++ b/packages/constraint-engine/src/customRules/packageAHasRunTestsScript.ts
@@ -1,0 +1,14 @@
+import { OnDiskUtf8FileTarget } from '../customTargets/file/utf8FileTarget';
+import { TestingPlatformPackageATarget } from '../customTargets/testingPlatformPackage/targets';
+import { GuardRule } from '../types/rule';
+
+type NarrowedPackageATarget = TestingPlatformPackageATarget & {
+  runTestsScript: OnDiskUtf8FileTarget;
+};
+
+export const packageAHasRunTestsScript: GuardRule<
+  TestingPlatformPackageATarget,
+  NarrowedPackageATarget
+> = (target): target is NarrowedPackageATarget => {
+  return target.runTestsScript.isOnDisk;
+};

--- a/packages/constraint-engine/src/customTargets/testingPlatformPackage/buildTestingPlatformPackageAReference.ts
+++ b/packages/constraint-engine/src/customTargets/testingPlatformPackage/buildTestingPlatformPackageAReference.ts
@@ -3,6 +3,7 @@ import { KnownDerivedReferenceBuilder } from '../../types/builders/derivedRefere
 import { UnknownTargetPath } from '../../types/targetPath';
 import { TargetReferenceTuple } from '../../types/targetReference';
 import { buildJsonFileInstance } from '../file/buildJsonFileInstance';
+import { buildUtf8FileInstance } from '../file/buildUtf8FileInstance';
 import {
   TestingPlatformPackageDirectoryTargetPath,
   TestingPlatformPackageDirectoryTargetReference,
@@ -36,6 +37,9 @@ export const buildTestingPlatformPackageAReference = (<
 
   const instance: TestingPlatformPackageATarget = {
     directoryName,
+    runTestsScript: buildUtf8FileInstance({
+      filePath: `${directoryPath}/scripts/runTests.sh`,
+    }),
     packageFile: buildJsonFileInstance({
       filePath: `${directoryPath}/package.json`,
     }),

--- a/packages/constraint-engine/src/customTargets/testingPlatformPackage/targets.ts
+++ b/packages/constraint-engine/src/customTargets/testingPlatformPackage/targets.ts
@@ -3,6 +3,7 @@ import {
   JsonFileTarget,
   ParseableOnDiskJsonFileTarget,
 } from '../file/jsonFileTarget';
+import { OnDiskUtf8FileTarget, Utf8FileTarget } from '../file/utf8FileTarget';
 
 export enum TestingPlatformTargetTypeId {
   PackageDirectorySet = 'PackageDirectorySet',
@@ -31,6 +32,7 @@ export type TestingPlatformPackageDirectoryTypedTarget = TypedTarget<
 
 export type TestingPlatformPackageATarget = {
   directoryName: string;
+  runTestsScript: Utf8FileTarget;
   packageFile: JsonFileTarget;
   typeScriptConfigFile: JsonFileTarget;
 };
@@ -44,6 +46,7 @@ export type ObjectTarget = Record<string, unknown>;
 
 export type TestingPlatformPackageBTarget = {
   directoryName: string;
+  runTestsScript: OnDiskUtf8FileTarget;
   packageFile: ParseableOnDiskJsonFileTarget<ObjectTarget>;
   typeScriptConfigFile: ParseableOnDiskJsonFileTarget<ObjectTarget>;
 };
@@ -72,6 +75,7 @@ export type PackageCPackageFileTarget =
 
 export type TestingPlatformPackageCTarget = {
   directoryName: string;
+  runTestsScript: OnDiskUtf8FileTarget;
   packageFile: PackageCPackageFileTarget;
   typeScriptConfigFile: ParseableOnDiskJsonFileTarget<ObjectTarget>;
 };

--- a/packages/constraint-engine/src/example/targetReferenceConfigurations.ts
+++ b/packages/constraint-engine/src/example/targetReferenceConfigurations.ts
@@ -21,13 +21,15 @@ import {
   TestingPlatformPackageATypedTarget,
   TestingPlatformTargetTypeId,
   TestingPlatformPackageBTypedTarget,
-  TestingPlatformPackageCTypedTarget,
+  TestingPlatformPackageBTarget,
+  TestingPlatformPackageCTarget,
 } from '../customTargets/testingPlatformPackage/targets';
 import { UnknownTargetReferenceConfiguration } from '../types/targetReferenceConfiguration/unknownTargetReferenceConfiguration';
 import { packageAHasPackageFile } from '../customRules/packageAHasPackagefile';
 import { packageAHasTypeScriptConfigFile } from '../customRules/packageAHasTypeScriptConfigFile';
 import { packageBHasTestingPlatformConfiguration } from '../customRules/packageBHasTestingPlatformConfiguration';
 import { buildNarrowedTargetReferenceConfiguration } from '../configurationHelpers/buildNarrowedTargetReferenceConfiguration';
+import { packageAHasRunTestsScript } from '../customRules/packageAHasRunTestsScript';
 
 export const targetReferenceConfigurations = [
   buildRootTargetReferenceConfiguration<
@@ -68,19 +70,29 @@ export const targetReferenceConfigurations = [
   buildNarrowedTargetReferenceConfiguration<
     TestingPlatformPackageATypedTarget,
     TestingPlatformPackageTargetPath<TestingPlatformPackageDirectorySetTargetPath>,
-    [typeof packageAHasPackageFile, typeof packageAHasTypeScriptConfigFile],
-    TestingPlatformPackageBTypedTarget
+    [
+      typeof packageAHasPackageFile,
+      typeof packageAHasTypeScriptConfigFile,
+      typeof packageAHasRunTestsScript,
+    ],
+    TestingPlatformTargetTypeId.PackageB,
+    TestingPlatformPackageBTarget
   >({
     inputTargetTypeId: TestingPlatformTargetTypeId.PackageA,
     inputTargetPath: 'testingPlatformPackageDirectorySet/:directoryName',
-    conditions: [packageAHasPackageFile, packageAHasTypeScriptConfigFile],
+    conditions: [
+      packageAHasPackageFile,
+      packageAHasTypeScriptConfigFile,
+      packageAHasRunTestsScript,
+    ],
     outputTargetTypeId: TestingPlatformTargetTypeId.PackageB,
   }),
   buildNarrowedTargetReferenceConfiguration<
     TestingPlatformPackageBTypedTarget,
     TestingPlatformPackageTargetPath<TestingPlatformPackageDirectorySetTargetPath>,
     [typeof packageBHasTestingPlatformConfiguration],
-    TestingPlatformPackageCTypedTarget
+    TestingPlatformTargetTypeId.PackageC,
+    TestingPlatformPackageCTarget
   >({
     inputTargetTypeId: TestingPlatformTargetTypeId.PackageB,
     inputTargetPath: 'testingPlatformPackageDirectorySet/:directoryName',

--- a/packages/constraint-engine/src/referenceBuilders/buildNarrowedReferenceBuilder.ts
+++ b/packages/constraint-engine/src/referenceBuilders/buildNarrowedReferenceBuilder.ts
@@ -1,43 +1,113 @@
 import {
-  GuardRuleTupleNarrowedTargetIntersection,
-  NarrowedReferenceBuilder,
+  CastReferenceBuilder,
+  EvaluateGuardRuleTuple,
 } from '../types/builders/narrowedReferenceBuilder';
 import { InferableGuardRule } from '../types/rule';
 import { UnknownTargetPath } from '../types/targetPath';
+import {
+  TargetReference,
+  TargetReferenceTuple,
+} from '../types/targetReference';
 import {
   TypedTarget,
   UnknownTargetTypeId,
   UnknownTypedTarget,
 } from '../types/typedTarget';
 
+const evaluateInputTargetReference = <
+  TInputTypedTarget extends UnknownTypedTarget,
+  TInputTargetPath extends UnknownTargetPath,
+  TGuardRuleTuple extends readonly InferableGuardRule[],
+  TOutputTargetInstance extends TInputTypedTarget['instance'],
+  TNarrowedOption,
+  TIdentityOption,
+>(
+  inputReference: TargetReference<TInputTypedTarget, TInputTargetPath>,
+  conditions: TGuardRuleTuple,
+  narrowedOutput: TNarrowedOption,
+  identityOutput: TIdentityOption,
+): EvaluateGuardRuleTuple<
+  TInputTypedTarget,
+  TGuardRuleTuple,
+  TOutputTargetInstance,
+  TNarrowedOption,
+  TIdentityOption
+> =>
+  (conditions.every((condition) => condition(inputReference))
+    ? narrowedOutput
+    : identityOutput) as EvaluateGuardRuleTuple<
+    TInputTypedTarget,
+    TGuardRuleTuple,
+    TOutputTargetInstance,
+    TNarrowedOption,
+    TIdentityOption
+  >;
+
 export const buildNarrowedReferenceBuilder = <
   TInputTypedTarget extends UnknownTypedTarget,
   TInputTargetPath extends UnknownTargetPath,
   TGuardRuleTuple extends readonly InferableGuardRule[],
-  TOutputTypedTarget extends TypedTarget<
-    UnknownTargetTypeId,
-    GuardRuleTupleNarrowedTargetIntersection<TGuardRuleTuple>
-  >,
+  TOutputTargetTypeId extends UnknownTargetTypeId,
+  TOutputTargetInstance extends TInputTypedTarget['instance'],
 >(
-  outputTargetTypeId: TOutputTypedTarget['typeId'],
-): NarrowedReferenceBuilder<
+  conditions: TGuardRuleTuple,
+  outputTargetTypeId: EvaluateGuardRuleTuple<
+    TInputTypedTarget,
+    TGuardRuleTuple,
+    TOutputTargetInstance,
+    TOutputTargetTypeId,
+    TInputTypedTarget['typeId']
+  >,
+): CastReferenceBuilder<
   TInputTypedTarget,
   TInputTargetPath,
   TGuardRuleTuple,
-  TOutputTypedTarget
+  TOutputTargetTypeId,
+  TOutputTargetInstance
 > => {
-  const buildNarrowedReference: NarrowedReferenceBuilder<
+  type TOutputTypedTarget = TypedTarget<
+    TOutputTargetTypeId,
+    TOutputTargetInstance
+  >;
+
+  const buildNarrowedReference = (
+    inputReference: TargetReference<TInputTypedTarget, TInputTargetPath>,
+  ): TargetReferenceTuple<
+    TOutputTypedTarget | TInputTypedTarget,
+    [TInputTargetPath]
+  > => {
+    const outputReference: EvaluateGuardRuleTuple<
+      TInputTypedTarget,
+      TGuardRuleTuple,
+      TOutputTargetInstance,
+      TargetReference<TOutputTypedTarget, TInputTargetPath>,
+      TargetReference<TInputTypedTarget, TInputTargetPath>
+    > = evaluateInputTargetReference<
+      TInputTypedTarget,
+      TInputTargetPath,
+      TGuardRuleTuple,
+      TOutputTargetInstance,
+      TargetReference<TOutputTypedTarget, TInputTargetPath>,
+      TargetReference<TInputTypedTarget, TInputTargetPath>
+    >(
+      inputReference,
+      conditions,
+      {
+        typeId: outputTargetTypeId as TOutputTargetTypeId,
+        instance: inputReference.instance as TOutputTargetInstance,
+        path: inputReference.path,
+      },
+      inputReference,
+    );
+
+    return [outputReference];
+  };
+
+  return buildNarrowedReference as CastReferenceBuilder<
     TInputTypedTarget,
     TInputTargetPath,
     TGuardRuleTuple,
-    TOutputTypedTarget
-  > = (inputReference) => [
-    {
-      typeId: outputTargetTypeId,
-      instance: inputReference.instance as TOutputTypedTarget['instance'],
-      path: inputReference.path,
-    },
-  ];
-
-  return buildNarrowedReference;
+    TOutputTargetTypeId,
+    TOutputTargetInstance
+  >;
 };

--- a/packages/constraint-engine/src/types/builders/narrowedReferenceBuilder.ts
+++ b/packages/constraint-engine/src/types/builders/narrowedReferenceBuilder.ts
@@ -31,14 +31,50 @@ export type GuardRuleTupleNarrowedTargetIntersection<
   TGuardRuleTuple extends readonly InferableGuardRule[],
 > = TupleToIntersection<GuardRuleTupleToNarrowedTargetTuple<TGuardRuleTuple>>;
 
+export type EvaluateGuardRuleTuple<
+  TInputTypedTarget extends UnknownTypedTarget,
+  TGuardRuleTuple extends readonly InferableGuardRule[],
+  TOutputTargetInstance extends TInputTypedTarget['instance'],
+  TNarrowOption,
+  TIdentityOption,
+> = GuardRuleTupleNarrowedTargetIntersection<TGuardRuleTuple> extends TOutputTargetInstance
+  ? TNarrowOption
+  : TIdentityOption;
+
 export type NarrowedReferenceBuilder<
   TInputTypedTarget extends UnknownTypedTarget,
   TInputTargetPath extends UnknownTargetPath,
-  TGuardRuleTuple extends readonly InferableGuardRule[],
-  TOutputTypedTarget extends TypedTarget<
-    UnknownTargetTypeId,
-    GuardRuleTupleNarrowedTargetIntersection<TGuardRuleTuple>
-  >,
+  TOutputTargetTypeId extends UnknownTargetTypeId,
+  TOutputTargetInstance extends TInputTypedTarget['instance'],
 > = (
   inputReference: TargetReference<TInputTypedTarget, TInputTargetPath>,
-) => TargetReferenceTuple<TOutputTypedTarget, [TInputTargetPath]>;
+) => TargetReferenceTuple<
+  TypedTarget<TOutputTargetTypeId, TOutputTargetInstance>,
+  [TInputTargetPath]
+>;
+
+export type IdentityReferenceBuilder<
+  TTypedTarget extends UnknownTypedTarget,
+  TTargetPath extends UnknownTargetPath,
+> = (
+  inputReference: TargetReference<TTypedTarget, TTargetPath>,
+) => TargetReferenceTuple<TTypedTarget, [TTargetPath]>;
+
+export type CastReferenceBuilder<
+  TInputTypedTarget extends UnknownTypedTarget,
+  TInputTargetPath extends UnknownTargetPath,
+  TGuardRuleTuple extends readonly InferableGuardRule[],
+  TOutputTargetTypeId extends UnknownTargetTypeId,
+  TOutputTargetInstance extends TInputTypedTarget['instance'],
+> = EvaluateGuardRuleTuple<
+  TInputTypedTarget,
+  TGuardRuleTuple,
+  TOutputTargetInstance,
+  NarrowedReferenceBuilder<
+    TInputTypedTarget,
+    TInputTargetPath,
+    TOutputTargetTypeId,
+    TOutputTargetInstance
+  >,
+  IdentityReferenceBuilder<TInputTypedTarget, TInputTargetPath>
+>;


### PR DESCRIPTION
A cast reference builder allows you to cast an input reference of type A to an output reference of type B if you give it a tuple of guard rules whose intersection of predicates extends type B. If the inputs to the target reference configuration are invalid then a cast reference builder becomes an identity reference builder which returns the input reference A.