### PR TITLE
Add a base package type

### DIFF
--- a/packages/constraint-engine/src/customTargets/testingPlatform/basePackage.ts
+++ b/packages/constraint-engine/src/customTargets/testingPlatform/basePackage.ts
@@ -1,0 +1,17 @@
+import { JsonFileTarget } from '../file/jsonFile/jsonFileTarget';
+import { Utf8FileTarget } from '../file/utf8File/utf8FileTarget';
+
+type ConfigurablePackageProperties = {
+  packageFile: JsonFileTarget;
+  runTestsScript: Utf8FileTarget;
+  typeScriptConfigFile: JsonFileTarget;
+};
+
+export type BasePackage<
+  TPackageProperties extends ConfigurablePackageProperties,
+> = {
+  directoryName: string;
+  packageFile: TPackageProperties['packageFile'];
+  typeScriptConfigFile: TPackageProperties['typeScriptConfigFile'];
+  runTestsScript: TPackageProperties['runTestsScript'];
+};

--- a/packages/constraint-engine/src/customTargets/testingPlatform/packageA/packageATarget.ts
+++ b/packages/constraint-engine/src/customTargets/testingPlatform/packageA/packageATarget.ts
@@ -1,14 +1,14 @@
 import { TypedTarget } from '../../../types/typedTarget';
 import { JsonFileTarget } from '../../file/jsonFile/jsonFileTarget';
 import { Utf8FileTarget } from '../../file/utf8File/utf8FileTarget';
+import { BasePackage } from '../basePackage';
 import { TargetTypeId } from '../targetTypeIds';
 
-export type PackageATarget = {
-  directoryName: string;
-  runTestsScript: Utf8FileTarget;
+export type PackageATarget = BasePackage<{
   packageFile: JsonFileTarget;
   typeScriptConfigFile: JsonFileTarget;
-};
+  runTestsScript: Utf8FileTarget;
+}>;
 
 export type PackageATypedTarget = TypedTarget<
   TargetTypeId.PackageA,

--- a/packages/constraint-engine/src/customTargets/testingPlatform/packageB/packageBTarget.ts
+++ b/packages/constraint-engine/src/customTargets/testingPlatform/packageB/packageBTarget.ts
@@ -2,14 +2,14 @@ import { TypedTarget } from '../../../types/typedTarget';
 import { ParseableOnDiskJsonFileTarget } from '../../file/jsonFile/jsonFileTarget';
 import { OnDiskUtf8FileTarget } from '../../file/utf8File/utf8FileTarget';
 import { ObjectTarget } from '../../type-script/objectTarget';
+import { BasePackage } from '../basePackage';
 import { TargetTypeId } from '../targetTypeIds';
 
-export type PackageBTarget = {
-  directoryName: string;
-  runTestsScript: OnDiskUtf8FileTarget;
+export type PackageBTarget = BasePackage<{
   packageFile: ParseableOnDiskJsonFileTarget<ObjectTarget>;
   typeScriptConfigFile: ParseableOnDiskJsonFileTarget<ObjectTarget>;
-};
+  runTestsScript: OnDiskUtf8FileTarget;
+}>;
 
 export type PackageBTypedTarget = TypedTarget<
   TargetTypeId.PackageB,

--- a/packages/constraint-engine/src/customTargets/testingPlatform/packageC/packageCTarget.ts
+++ b/packages/constraint-engine/src/customTargets/testingPlatform/packageC/packageCTarget.ts
@@ -2,6 +2,7 @@ import { TypedTarget } from '../../../types/typedTarget';
 import { ParseableOnDiskJsonFileTarget } from '../../file/jsonFile/jsonFileTarget';
 import { OnDiskUtf8FileTarget } from '../../file/utf8File/utf8FileTarget';
 import { ObjectTarget } from '../../type-script/objectTarget';
+import { BasePackage } from '../basePackage';
 import { TargetTypeId } from '../targetTypeIds';
 import { PackageConfigurationTarget } from './packageConfigurationTarget';
 
@@ -13,12 +14,11 @@ export type PackageCPackageFileContentsTarget = {
 export type PackageCPackageFileTarget =
   ParseableOnDiskJsonFileTarget<PackageCPackageFileContentsTarget>;
 
-export type PackageCTarget = {
-  directoryName: string;
-  runTestsScript: OnDiskUtf8FileTarget;
+export type PackageCTarget = BasePackage<{
   packageFile: PackageCPackageFileTarget;
   typeScriptConfigFile: ParseableOnDiskJsonFileTarget<ObjectTarget>;
-};
+  runTestsScript: OnDiskUtf8FileTarget;
+}>;
 
 export type PackageCTypedTarget = TypedTarget<
   TargetTypeId.PackageC,


### PR DESCRIPTION
This enables code reuse since all package types are created using base package, but we can continue to think of a "package" as the union of a package A, B and C.