### PR TITLE
Enforce all runTests.sh files to run all package tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -341,6 +341,16 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
+    "node_modules/@types/glob": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.0.0.tgz",
+      "integrity": "sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -353,6 +363,12 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "18.11.17",
@@ -3580,7 +3596,9 @@
     "packages/constraint-engine": {
       "devDependencies": {
         "@tsconfig/node16": "^1.0.3",
+        "@types/glob": "^8.0.0",
         "@types/node": "^18.11.17",
+        "glob": "^8.0.3",
         "mouse-test": "*",
         "rat-test": "*",
         "typescript": "^4.9.4"
@@ -3865,6 +3883,16 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
+    "@types/glob": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.0.0.tgz",
+      "integrity": "sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -3877,6 +3905,12 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "peer": true
+    },
+    "@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true
     },
     "@types/node": {
       "version": "18.11.17",
@@ -4204,7 +4238,9 @@
       "version": "file:packages/constraint-engine",
       "requires": {
         "@tsconfig/node16": "^1.0.3",
+        "@types/glob": "*",
         "@types/node": "^18.11.17",
+        "glob": "^8.0.3",
         "mouse-test": "*",
         "rat-test": "*",
         "typescript": "^4.9.4"

--- a/packages/constraint-engine/package.json
+++ b/packages/constraint-engine/package.json
@@ -2,7 +2,9 @@
   "name": "constraint-engine",
   "devDependencies": {
     "@tsconfig/node16": "^1.0.3",
+    "@types/glob": "^8.0.0",
     "@types/node": "^18.11.17",
+    "glob": "^8.0.3",
     "mouse-test": "*",
     "rat-test": "*",
     "typescript": "^4.9.4"

--- a/packages/constraint-engine/scripts/runTests.sh
+++ b/packages/constraint-engine/scripts/runTests.sh
@@ -1,0 +1,20 @@
+npx ts-node packages/constraint-engine/src/customTargets/file/jsonFile/buildJsonFileInstance.test.ts
+printf "\n"
+
+npx ts-node packages/constraint-engine/src/customTargets/file/utf8File/buildUtf8FileInstance.test.ts
+printf "\n"
+
+npx ts-node packages/constraint-engine/src/customTargets/testingPlatform/packageA/buildPackageAReference.test.ts
+printf "\n"
+
+npx ts-node packages/constraint-engine/src/customTargets/testingPlatform/packageDirectory/buildPackageDirectoryReferenceSet.test.ts
+printf "\n"
+
+npx ts-node packages/constraint-engine/src/customTargets/testingPlatform/packageDirectorySet/buildPackageDirectorySetReference.test.ts
+printf "\n"
+
+npx ts-node packages/constraint-engine/src/engine/referenceBuilders/buildDerivedTargetReferences.test.ts
+printf "\n"
+
+npx ts-node packages/constraint-engine/src/engine/referenceBuilders/buildDerivedTargetReferenceSets.test.ts
+printf "\n"

--- a/packages/constraint-engine/src/customRules/packageAHasKnownTestFileTypes.ts
+++ b/packages/constraint-engine/src/customRules/packageAHasKnownTestFileTypes.ts
@@ -1,0 +1,16 @@
+import { PackageATarget } from '../customTargets/testingPlatform/packageA/packageATarget';
+import { PackageBTarget } from '../customTargets/testingPlatform/packageB/packageBTarget';
+import { GuardRule } from '../types/rule';
+
+type NarrowedPackageATarget = PackageATarget & {
+  testFileMetadataSet: PackageBTarget['testFileMetadataSet'];
+};
+
+export const packageAHasKnownTestFileTypes: GuardRule<
+  PackageATarget,
+  NarrowedPackageATarget
+> = (target): target is NarrowedPackageATarget => {
+  return target.testFileMetadataSet.every(
+    (metadata) => metadata.fileType !== null,
+  );
+};

--- a/packages/constraint-engine/src/customRules/packageBRunsAllTestFiles.ts
+++ b/packages/constraint-engine/src/customRules/packageBRunsAllTestFiles.ts
@@ -1,0 +1,20 @@
+import { runCommandsByFileType } from '../customTargets/testingPlatform/categorizedTestFileMetadata';
+import { PackageBTarget } from '../customTargets/testingPlatform/packageB/packageBTarget';
+import { PackageCTarget } from '../customTargets/testingPlatform/packageC/packageCTarget';
+import { Rule } from '../types/rule';
+
+export const packageBRunsAllTestFiles: Rule<PackageBTarget> = (
+  target,
+): target is PackageCTarget => {
+  const expectedFileContents = target.testFileMetadataSet
+    .flatMap((metadata) => {
+      const runCommand = runCommandsByFileType[metadata.fileType];
+      return [`${runCommand} ${metadata.filePath}`, 'printf "\\n"', ''];
+    })
+    .join('\n');
+
+  const hasAllTestFiles =
+    target.runTestsScript.stringContents === expectedFileContents;
+
+  return hasAllTestFiles;
+};

--- a/packages/constraint-engine/src/customTargets/file/utf8File/buildUtf8FileMetdataInstanceSet.ts
+++ b/packages/constraint-engine/src/customTargets/file/utf8File/buildUtf8FileMetdataInstanceSet.ts
@@ -1,0 +1,15 @@
+import glob from 'glob';
+import { InstanceBuilder } from '../../../types/builders/instanceBuilder';
+import { Utf8FileMetadataTarget } from './utf8FileTarget';
+
+export const buildUtf8FileMetadataInstanceSet: InstanceBuilder<
+  { fileGlob: string },
+  Utf8FileMetadataTarget[]
+> = ({ fileGlob }) => {
+  return glob.sync(fileGlob).map((filePath) => {
+    return {
+      filePath,
+      isOnDisk: true,
+    };
+  });
+};

--- a/packages/constraint-engine/src/customTargets/file/utf8File/utf8FileTarget.ts
+++ b/packages/constraint-engine/src/customTargets/file/utf8File/utf8FileTarget.ts
@@ -1,6 +1,13 @@
-type BaseUtf8FileTarget<T> = {
+type ConfigurableFileProperties = {
+  isOnDisk: boolean;
+  stringContents?: string;
+};
+
+type BaseUtf8FileTarget<TFileProperties extends ConfigurableFileProperties> = {
   filePath: string;
-} & T;
+  isOnDisk: TFileProperties['isOnDisk'];
+  stringContents: TFileProperties['stringContents'];
+};
 
 export type OnDiskUtf8FileTarget = BaseUtf8FileTarget<{
   isOnDisk: true;
@@ -13,3 +20,5 @@ export type NotOnDiskUtf8FileTarget = BaseUtf8FileTarget<{
 }>;
 
 export type Utf8FileTarget = OnDiskUtf8FileTarget | NotOnDiskUtf8FileTarget;
+
+export type Utf8FileMetadataTarget = Omit<Utf8FileTarget, 'stringContents'>;

--- a/packages/constraint-engine/src/customTargets/testingPlatform/basePackage.ts
+++ b/packages/constraint-engine/src/customTargets/testingPlatform/basePackage.ts
@@ -1,5 +1,8 @@
 import { JsonFileTarget } from '../file/jsonFile/jsonFileTarget';
-import { Utf8FileTarget } from '../file/utf8File/utf8FileTarget';
+import {
+  Utf8FileMetadataTarget,
+  Utf8FileTarget,
+} from '../file/utf8File/utf8FileTarget';
 
 type ConfigurablePackageProperties = {
   packageFile: JsonFileTarget;
@@ -14,4 +17,5 @@ export type BasePackage<
   packageFile: TPackageProperties['packageFile'];
   typeScriptConfigFile: TPackageProperties['typeScriptConfigFile'];
   runTestsScript: TPackageProperties['runTestsScript'];
+  testFileMetadataSet: Utf8FileMetadataTarget[];
 };

--- a/packages/constraint-engine/src/customTargets/testingPlatform/basePackage.ts
+++ b/packages/constraint-engine/src/customTargets/testingPlatform/basePackage.ts
@@ -1,13 +1,17 @@
 import { JsonFileTarget } from '../file/jsonFile/jsonFileTarget';
+import { Utf8FileTarget } from '../file/utf8File/utf8FileTarget';
 import {
-  Utf8FileMetadataTarget,
-  Utf8FileTarget,
-} from '../file/utf8File/utf8FileTarget';
+  CategorizedTestFileMetadataTarget,
+  SupportedTestFileType,
+} from './categorizedTestFileMetadata';
 
 type ConfigurablePackageProperties = {
   packageFile: JsonFileTarget;
   runTestsScript: Utf8FileTarget;
   typeScriptConfigFile: JsonFileTarget;
+  testFileMetadataSet: CategorizedTestFileMetadataTarget<{
+    fileType: SupportedTestFileType | null;
+  }>[];
 };
 
 export type BasePackage<
@@ -17,5 +21,5 @@ export type BasePackage<
   packageFile: TPackageProperties['packageFile'];
   typeScriptConfigFile: TPackageProperties['typeScriptConfigFile'];
   runTestsScript: TPackageProperties['runTestsScript'];
-  testFileMetadataSet: Utf8FileMetadataTarget[];
+  testFileMetadataSet: TPackageProperties['testFileMetadataSet'];
 };

--- a/packages/constraint-engine/src/customTargets/testingPlatform/categorizedTestFileMetadata.ts
+++ b/packages/constraint-engine/src/customTargets/testingPlatform/categorizedTestFileMetadata.ts
@@ -14,6 +14,11 @@ export const fileTypesByExtension = Object.fromEntries(
   Object.entries(fileExtensionsByType).map(([k, v]) => [v, k]),
 );
 
+export const runCommandsByFileType = {
+  [SupportedTestFileType.Bash]: 'bash',
+  [SupportedTestFileType.TypeScript]: 'npx ts-node',
+} satisfies Record<SupportedTestFileType, string>;
+
 export type ConfigurableCategorizedTestFileMetadataProperties = {
   fileType: SupportedTestFileType | null;
 };

--- a/packages/constraint-engine/src/customTargets/testingPlatform/categorizedTestFileMetadata.ts
+++ b/packages/constraint-engine/src/customTargets/testingPlatform/categorizedTestFileMetadata.ts
@@ -1,0 +1,25 @@
+import { Utf8FileMetadataTarget } from '../file/utf8File/utf8FileTarget';
+
+export enum SupportedTestFileType {
+  Bash = 'Bash',
+  TypeScript = 'TypeScript',
+}
+
+export const fileExtensionsByType = {
+  [SupportedTestFileType.Bash]: 'sh',
+  [SupportedTestFileType.TypeScript]: 'ts',
+} satisfies Record<SupportedTestFileType, string>;
+
+export const fileTypesByExtension = Object.fromEntries(
+  Object.entries(fileExtensionsByType).map(([k, v]) => [v, k]),
+);
+
+export type ConfigurableCategorizedTestFileMetadataProperties = {
+  fileType: SupportedTestFileType | null;
+};
+
+export type CategorizedTestFileMetadataTarget<
+  TProperties extends ConfigurableCategorizedTestFileMetadataProperties,
+> = Utf8FileMetadataTarget & {
+  fileType: TProperties['fileType'];
+};

--- a/packages/constraint-engine/src/customTargets/testingPlatform/packageA/buildPackageAReference.ts
+++ b/packages/constraint-engine/src/customTargets/testingPlatform/packageA/buildPackageAReference.ts
@@ -11,6 +11,7 @@ import {
 import { PackageDirectoryTypedTarget } from '../packageDirectory/packageDirectoryTarget';
 import { TargetTypeId } from '../targetTypeIds';
 import { PackageATarget, PackageATypedTarget } from './packageATarget';
+import { buildUtf8FileMetadataInstanceSet } from '../../file/utf8File/buildUtf8FileMetdataInstanceSet';
 
 export type TestingPlatformPackageTargetPath<
   TPrefix extends UnknownTargetPath,
@@ -29,6 +30,7 @@ export const buildPackageAReference = (<TPrefix extends UnknownTargetPath>(
   const { directoryPath } = directoryTargetReference.instance;
 
   const directoryName = posix.basename(directoryPath);
+  const testFilePathGlob = `${directoryPath}/**/*.test.{sh,ts}`;
 
   const instance: PackageATarget = {
     directoryName,
@@ -40,6 +42,9 @@ export const buildPackageAReference = (<TPrefix extends UnknownTargetPath>(
     }),
     typeScriptConfigFile: buildJsonFileInstance({
       filePath: `${directoryPath}/tsconfig.json`,
+    }),
+    testFileMetadataSet: buildUtf8FileMetadataInstanceSet({
+      fileGlob: testFilePathGlob,
     }),
   };
 

--- a/packages/constraint-engine/src/customTargets/testingPlatform/packageA/buildPackageAReference.ts
+++ b/packages/constraint-engine/src/customTargets/testingPlatform/packageA/buildPackageAReference.ts
@@ -12,6 +12,11 @@ import { PackageDirectoryTypedTarget } from '../packageDirectory/packageDirector
 import { TargetTypeId } from '../targetTypeIds';
 import { PackageATarget, PackageATypedTarget } from './packageATarget';
 import { buildUtf8FileMetadataInstanceSet } from '../../file/utf8File/buildUtf8FileMetdataInstanceSet';
+import {
+  CategorizedTestFileMetadataTarget,
+  fileTypesByExtension,
+  SupportedTestFileType,
+} from '../categorizedTestFileMetadata';
 
 export type TestingPlatformPackageTargetPath<
   TPrefix extends UnknownTargetPath,
@@ -45,7 +50,19 @@ export const buildPackageAReference = (<TPrefix extends UnknownTargetPath>(
     }),
     testFileMetadataSet: buildUtf8FileMetadataInstanceSet({
       fileGlob: testFilePathGlob,
-    }),
+    }).map(
+      (
+        metadata,
+      ): CategorizedTestFileMetadataTarget<{
+        fileType: SupportedTestFileType | null;
+      }> => ({
+        ...metadata,
+        fileType:
+          (fileTypesByExtension[
+            posix.extname(metadata.filePath).replace(/\./, '')
+          ] as SupportedTestFileType) ?? null,
+      }),
+    ),
   };
 
   return [

--- a/packages/constraint-engine/src/customTargets/testingPlatform/packageA/packageATarget.ts
+++ b/packages/constraint-engine/src/customTargets/testingPlatform/packageA/packageATarget.ts
@@ -2,12 +2,19 @@ import { TypedTarget } from '../../../types/typedTarget';
 import { JsonFileTarget } from '../../file/jsonFile/jsonFileTarget';
 import { Utf8FileTarget } from '../../file/utf8File/utf8FileTarget';
 import { BasePackage } from '../basePackage';
+import {
+  CategorizedTestFileMetadataTarget,
+  SupportedTestFileType,
+} from '../categorizedTestFileMetadata';
 import { TargetTypeId } from '../targetTypeIds';
 
 export type PackageATarget = BasePackage<{
   packageFile: JsonFileTarget;
   typeScriptConfigFile: JsonFileTarget;
   runTestsScript: Utf8FileTarget;
+  testFileMetadataSet: CategorizedTestFileMetadataTarget<{
+    fileType: SupportedTestFileType | null;
+  }>[];
 }>;
 
 export type PackageATypedTarget = TypedTarget<

--- a/packages/constraint-engine/src/customTargets/testingPlatform/packageB/packageBTarget.ts
+++ b/packages/constraint-engine/src/customTargets/testingPlatform/packageB/packageBTarget.ts
@@ -3,12 +3,19 @@ import { ParseableOnDiskJsonFileTarget } from '../../file/jsonFile/jsonFileTarge
 import { OnDiskUtf8FileTarget } from '../../file/utf8File/utf8FileTarget';
 import { ObjectTarget } from '../../type-script/objectTarget';
 import { BasePackage } from '../basePackage';
+import {
+  CategorizedTestFileMetadataTarget,
+  SupportedTestFileType,
+} from '../categorizedTestFileMetadata';
 import { TargetTypeId } from '../targetTypeIds';
 
 export type PackageBTarget = BasePackage<{
   packageFile: ParseableOnDiskJsonFileTarget<ObjectTarget>;
   typeScriptConfigFile: ParseableOnDiskJsonFileTarget<ObjectTarget>;
   runTestsScript: OnDiskUtf8FileTarget;
+  testFileMetadataSet: CategorizedTestFileMetadataTarget<{
+    fileType: SupportedTestFileType;
+  }>[];
 }>;
 
 export type PackageBTypedTarget = TypedTarget<

--- a/packages/constraint-engine/src/customTargets/testingPlatform/packageC/packageCTarget.ts
+++ b/packages/constraint-engine/src/customTargets/testingPlatform/packageC/packageCTarget.ts
@@ -3,6 +3,10 @@ import { ParseableOnDiskJsonFileTarget } from '../../file/jsonFile/jsonFileTarge
 import { OnDiskUtf8FileTarget } from '../../file/utf8File/utf8FileTarget';
 import { ObjectTarget } from '../../type-script/objectTarget';
 import { BasePackage } from '../basePackage';
+import {
+  CategorizedTestFileMetadataTarget,
+  SupportedTestFileType,
+} from '../categorizedTestFileMetadata';
 import { TargetTypeId } from '../targetTypeIds';
 import { PackageConfigurationTarget } from './packageConfigurationTarget';
 
@@ -18,6 +22,9 @@ export type PackageCTarget = BasePackage<{
   packageFile: PackageCPackageFileTarget;
   typeScriptConfigFile: ParseableOnDiskJsonFileTarget<ObjectTarget>;
   runTestsScript: OnDiskUtf8FileTarget;
+  testFileMetadataSet: CategorizedTestFileMetadataTarget<{
+    fileType: SupportedTestFileType;
+  }>[];
 }>;
 
 export type PackageCTypedTarget = TypedTarget<

--- a/packages/constraint-engine/src/example/ruleConfigurations.ts
+++ b/packages/constraint-engine/src/example/ruleConfigurations.ts
@@ -9,6 +9,7 @@ import { targetReferenceConfigurations } from './targetReferenceConfigurations';
 import { packageAHasRunTestsScript } from '../customRules/packageAHasRunTestsScript';
 import { TargetTypeId } from '../customTargets/testingPlatform/targetTypeIds';
 import { packageAHasKnownTestFileTypes } from '../customRules/packageAHasKnownTestFileTypes';
+import { packageBRunsAllTestFiles } from '../customRules/packageBRunsAllTestFiles';
 
 type CustomTargetReferenceConfigurations = typeof targetReferenceConfigurations;
 
@@ -42,6 +43,11 @@ export const ruleConfigurations = [
     targetTypeId: TargetTypeId.PackageB,
     targetPath: 'testingPlatformPackageDirectorySet/:directoryName',
     rule: packageBHasTestingPlatformConfiguration,
+  }),
+  buildRuleConfiguration<CustomTargetReferenceConfigurations>({
+    targetTypeId: TargetTypeId.PackageB,
+    targetPath: 'testingPlatformPackageDirectorySet/:directoryName',
+    rule: packageBRunsAllTestFiles,
   }),
   buildRuleConfiguration<CustomTargetReferenceConfigurations>({
     targetTypeId: TargetTypeId.PackageC,

--- a/packages/constraint-engine/src/example/ruleConfigurations.ts
+++ b/packages/constraint-engine/src/example/ruleConfigurations.ts
@@ -8,6 +8,7 @@ import { UnknownRuleConfiguration } from '../types/ruleConfiguration';
 import { targetReferenceConfigurations } from './targetReferenceConfigurations';
 import { packageAHasRunTestsScript } from '../customRules/packageAHasRunTestsScript';
 import { TargetTypeId } from '../customTargets/testingPlatform/targetTypeIds';
+import { packageAHasKnownTestFileTypes } from '../customRules/packageAHasKnownTestFileTypes';
 
 type CustomTargetReferenceConfigurations = typeof targetReferenceConfigurations;
 
@@ -31,6 +32,11 @@ export const ruleConfigurations = [
     targetTypeId: TargetTypeId.PackageA,
     targetPath: 'testingPlatformPackageDirectorySet/:directoryName',
     rule: packageAHasRunTestsScript,
+  }),
+  buildRuleConfiguration<CustomTargetReferenceConfigurations>({
+    targetTypeId: TargetTypeId.PackageA,
+    targetPath: 'testingPlatformPackageDirectorySet/:directoryName',
+    rule: packageAHasKnownTestFileTypes,
   }),
   buildRuleConfiguration<CustomTargetReferenceConfigurations>({
     targetTypeId: TargetTypeId.PackageB,

--- a/packages/constraint-engine/src/example/targetReferenceConfigurations.ts
+++ b/packages/constraint-engine/src/example/targetReferenceConfigurations.ts
@@ -31,6 +31,7 @@ import { PackageCTarget } from '../customTargets/testingPlatform/packageC/packag
 import { buildStaticTargetReferenceConfiguration } from '../configurationHelpers/buildStaticTargetReferenceConfiguration';
 import { PackageDirectorySetConfigurationTypedTarget } from '../customTargets/testingPlatform/packageDirectorySet/packageDirectorySetConfigurationTarget';
 import { RootTargetPath } from '../types/targetPath';
+import { packageAHasKnownTestFileTypes } from '../customRules/packageAHasKnownTestFileTypes';
 
 export const targetReferenceConfigurations = [
   buildStaticTargetReferenceConfiguration<
@@ -88,6 +89,7 @@ export const targetReferenceConfigurations = [
       typeof packageAHasPackageFile,
       typeof packageAHasTypeScriptConfigFile,
       typeof packageAHasRunTestsScript,
+      typeof packageAHasKnownTestFileTypes,
     ],
     TargetTypeId.PackageB,
     PackageBTarget
@@ -98,6 +100,7 @@ export const targetReferenceConfigurations = [
       packageAHasPackageFile,
       packageAHasTypeScriptConfigFile,
       packageAHasRunTestsScript,
+      packageAHasKnownTestFileTypes,
     ],
     outputTargetTypeId: TargetTypeId.PackageB,
   }),

--- a/packages/mouse-test/scripts/runTests.sh
+++ b/packages/mouse-test/scripts/runTests.sh
@@ -1,0 +1,11 @@
+npx ts-node packages/mouse-test/type-script/agnostic/errorUtils/tryThrowable.test.ts
+printf "\n"
+
+npx ts-node packages/mouse-test/type-script/shell/fileSystemUtils/createDirectory.test.ts
+printf "\n"
+
+npx ts-node packages/mouse-test/type-script/shell/fileSystemUtils/createFile.test.ts
+printf "\n"
+
+npx ts-node packages/mouse-test/type-script/shell/fileSystemUtils/removeFileSystemObject.test.ts
+printf "\n"

--- a/packages/rat-test/scripts/runTests.sh
+++ b/packages/rat-test/scripts/runTests.sh
@@ -1,0 +1,5 @@
+bash packages/rat-test/shell/assertEqual.test.sh
+printf "\n"
+
+bash packages/rat-test/shell/runCommandForEachFile.test.sh
+printf "\n"


### PR DESCRIPTION
The convention for now is to run the tests in alphabetical order. In the future we will want two scripts:

    - one that runs tests in order of dependencies (all tests run after their dependencies are tests)
    - one that attempts to run as many tests in parallel at once
    
We will enforce that the CI runs the runTests.sh files for each package 😁 