### PR TITLE
Create custom testing platform datum instance configurations

### DIFF
--- a/packages/open-schema-type-script/src/buildBuilderConfiguration.ts
+++ b/packages/open-schema-type-script/src/buildBuilderConfiguration.ts
@@ -1,4 +1,7 @@
-import { BuilderConfigurationWithNormalizedInput } from './builderConfiguration';
+import {
+  BuilderConfiguration,
+  BuilderConfigurationWithNormalizedInput,
+} from './builderConfiguration';
 import {
   DatumInstanceTypeScriptConfigurationTupleToDatumInstanceConfigurationTuple,
   UnknownDatumInstanceTypeScriptConfigurationTuple,
@@ -24,9 +27,12 @@ export type TypeScriptConfigurationCollectionToConfigurationCollection<
 export const buildBuilderConfiguration = <
   T extends UnknownDatumInstanceTypeScriptConfigurationCollectionBuilderInputAndOutput,
 >(
-  builderConfiguration: BuilderConfigurationWithNormalizedInput<
+  builderConfiguration: BuilderConfiguration<
     TypeScriptConfigurationCollectionToConfigurationCollection<T>
   >,
 ): BuilderConfigurationWithNormalizedInput<
   TypeScriptConfigurationCollectionToConfigurationCollection<T>
-> => builderConfiguration;
+> =>
+  builderConfiguration as BuilderConfigurationWithNormalizedInput<
+    TypeScriptConfigurationCollectionToConfigurationCollection<T>
+  >;

--- a/packages/open-schema-type-script/src/datumInstanceTypeScriptConfiguration.ts
+++ b/packages/open-schema-type-script/src/datumInstanceTypeScriptConfiguration.ts
@@ -59,3 +59,15 @@ export const ROOT_DATUM_INSTANCE_TYPE_SCRIPT_CONFIGURATION: RootDatumInstanceTyp
     datumInstance: ROOT_DATUM_INSTANCE,
     typeSemanticsIdentifier: TypeScriptSemanticsIdentifier.null,
   };
+
+export const getDatumInstanceConfiguration = <
+  T extends UnknownDatumInstanceTypeScriptConfiguration,
+>({
+  typeSemanticsIdentifier,
+  datumInstanceIdentifier,
+  datumInstance,
+}: T): DatumInstanceTypeScriptConfigurationToDatumInstanceConfiguration<T> => ({
+  predicateIdentifiers: [typeSemanticsIdentifier],
+  instanceIdentifier: datumInstanceIdentifier,
+  datumInstance,
+});

--- a/packages/open-schema-type-script/src/datumInstanceTypeScriptConfigurationCollectionBuilder.ts
+++ b/packages/open-schema-type-script/src/datumInstanceTypeScriptConfigurationCollectionBuilder.ts
@@ -1,0 +1,20 @@
+import {
+  DatumInstanceTypeScriptConfigurationTupleToDatumInstanceConfigurationTuple,
+  UnknownDatumInstanceTypeScriptConfigurationTuple,
+} from './datumInstanceTypeScriptConfiguration';
+
+export type UnknownDatumInstanceTypeScriptConfigurationCollectionBuilderInputAndOutput =
+  {
+    InputCollection: UnknownDatumInstanceTypeScriptConfigurationTuple;
+    OutputCollection: UnknownDatumInstanceTypeScriptConfigurationTuple;
+  };
+
+export type DatumInstanceTypeScriptConfigurationCollectionBuilder<
+  T extends UnknownDatumInstanceTypeScriptConfigurationCollectionBuilderInputAndOutput,
+> = (
+  ...inputCollection: DatumInstanceTypeScriptConfigurationTupleToDatumInstanceConfigurationTuple<
+    T['InputCollection']
+  >
+) => DatumInstanceTypeScriptConfigurationTupleToDatumInstanceConfigurationTuple<
+  T['OutputCollection']
+>;

--- a/packages/open-schema-type-script/src/example/index.ts
+++ b/packages/open-schema-type-script/src/example/index.ts
@@ -1,65 +1,36 @@
 import { buildBuilderConfiguration } from '../buildBuilderConfiguration';
 import { UnknownBuilderConfigurationTuple } from '../builderConfiguration';
-import { ROOT_DATUM_INSTANCE_LOCATOR } from '../collectionLocator';
-import {
-  DatumInstanceTypeScriptConfiguration,
-  RootDatumInstanceTypeScriptConfiguration,
-} from '../datumInstanceTypeScriptConfiguration';
+import { RootDatumInstanceTypeScriptConfiguration } from '../datumInstanceTypeScriptConfiguration';
 import { run } from '../representation-engine/run';
-import { TypeScriptSemanticsIdentifier } from '../typeScriptSemanticsIdentifier';
-
-type Instance1TypeScriptConfiguration = DatumInstanceTypeScriptConfiguration<{
-  datumInstanceIdentifier: 'instance-1';
-  datumInstance: string;
-  typeSemanticsIdentifier: TypeScriptSemanticsIdentifier.string;
-}>;
-
-type Instance2TypeScriptConfiguration = DatumInstanceTypeScriptConfiguration<{
-  datumInstanceIdentifier: 'instance-1/instance-2';
-  datumInstance: number;
-  typeSemanticsIdentifier: TypeScriptSemanticsIdentifier.number;
-}>;
-
-type Instance3TypeScriptConfiguration = DatumInstanceTypeScriptConfiguration<{
-  datumInstanceIdentifier: 'instance-1/instance-3';
-  datumInstance: number;
-  typeSemanticsIdentifier: TypeScriptSemanticsIdentifier.number;
-}>;
+import {
+  buildPackageDirectoryNameSet,
+  PackageDirectoryNameSetTypeScriptConfiguration,
+} from './testingPlatform/packageDirectoryNameSet/packageDirectoryNameSet';
+import {
+  buildPackageDirectoryNameSetConfiguration,
+  PackageDirectoryNameSetConfigurationTypeScriptConfiguration,
+} from './testingPlatform/packageDirectoryNameSet/packageDirectoryNameSetConfiguration';
 
 const builderConfigurationCollection = [
   buildBuilderConfiguration<{
     InputCollection: [RootDatumInstanceTypeScriptConfiguration];
-    OutputCollection: [Instance1TypeScriptConfiguration];
-  }>({
-    buildCollection: () => [
-      {
-        instanceIdentifier: 'instance-1',
-        datumInstance: 'hello',
-        predicateIdentifiers: [TypeScriptSemanticsIdentifier.string],
-      },
-    ],
-    inputCollectionLocatorCollection: [ROOT_DATUM_INSTANCE_LOCATOR],
-  }),
-  buildBuilderConfiguration<{
-    InputCollection: [Instance1TypeScriptConfiguration];
     OutputCollection: [
-      Instance2TypeScriptConfiguration,
-      Instance3TypeScriptConfiguration,
+      PackageDirectoryNameSetConfigurationTypeScriptConfiguration,
     ];
   }>({
-    buildCollection: () => [
-      {
-        instanceIdentifier: 'instance-1/instance-2',
-        datumInstance: 2,
-        predicateIdentifiers: [TypeScriptSemanticsIdentifier.number],
-      },
-      {
-        instanceIdentifier: 'instance-1/instance-3',
-        datumInstance: 3,
-        predicateIdentifiers: [TypeScriptSemanticsIdentifier.number],
-      },
+    buildCollection: buildPackageDirectoryNameSetConfiguration,
+    inputCollectionLocatorCollection: [''],
+  }),
+  buildBuilderConfiguration<{
+    InputCollection: [
+      PackageDirectoryNameSetConfigurationTypeScriptConfiguration,
+    ];
+    OutputCollection: [PackageDirectoryNameSetTypeScriptConfiguration];
+  }>({
+    buildCollection: buildPackageDirectoryNameSet,
+    inputCollectionLocatorCollection: [
+      'package-directory-name-set-configuration',
     ],
-    inputCollectionLocatorCollection: ['instance-1'],
   }),
 ] as const satisfies UnknownBuilderConfigurationTuple;
 

--- a/packages/open-schema-type-script/src/example/testingPlatform/packageDirectoryNameSet/packageDirectoryNameSet.ts
+++ b/packages/open-schema-type-script/src/example/testingPlatform/packageDirectoryNameSet/packageDirectoryNameSet.ts
@@ -1,0 +1,42 @@
+import fs from 'fs';
+import {
+  DatumInstanceTypeScriptConfiguration,
+  DatumInstanceTypeScriptConfigurationToDatumInstanceConfiguration,
+} from '../../../datumInstanceTypeScriptConfiguration';
+import { DatumInstanceTypeScriptConfigurationCollectionBuilder } from '../../../datumInstanceTypeScriptConfigurationCollectionBuilder';
+import { TypeScriptSemanticsIdentifier } from '../typeScriptSemanticsIdentifer';
+import { PackageDirectoryNameSetConfigurationTypeScriptConfiguration } from './packageDirectoryNameSetConfiguration';
+
+export type PackageDirectoryNameSet = {
+  directoryPaths: string[];
+};
+
+export type PackageDirectoryNameSetTypeScriptConfiguration =
+  DatumInstanceTypeScriptConfiguration<{
+    typeSemanticsIdentifier: TypeScriptSemanticsIdentifier.PackageDirectoryNameSet;
+    datumInstanceIdentifier: 'package-directory-name-set';
+    datumInstance: PackageDirectoryNameSet;
+  }>;
+
+export const buildPackageDirectoryNameSet: DatumInstanceTypeScriptConfigurationCollectionBuilder<{
+  InputCollection: [
+    PackageDirectoryNameSetConfigurationTypeScriptConfiguration,
+  ];
+  OutputCollection: [PackageDirectoryNameSetTypeScriptConfiguration];
+}> = (packageDirectoryNameSetConfigurationConfiguration) => {
+  const parentDirectoryPath =
+    packageDirectoryNameSetConfigurationConfiguration.datumInstance
+      .rootDirectoryRelativeToCurrentWorkingDirectory;
+  const directoryPaths = fs.readdirSync(parentDirectoryPath);
+
+  const packageDirectoryNameSetConfiguration: DatumInstanceTypeScriptConfigurationToDatumInstanceConfiguration<PackageDirectoryNameSetTypeScriptConfiguration> =
+    {
+      predicateIdentifiers: [
+        TypeScriptSemanticsIdentifier.PackageDirectoryNameSet,
+      ],
+      instanceIdentifier: 'package-directory-name-set',
+      datumInstance: { directoryPaths },
+    };
+
+  return [packageDirectoryNameSetConfiguration];
+};

--- a/packages/open-schema-type-script/src/example/testingPlatform/packageDirectoryNameSet/packageDirectoryNameSetConfiguration.ts
+++ b/packages/open-schema-type-script/src/example/testingPlatform/packageDirectoryNameSet/packageDirectoryNameSetConfiguration.ts
@@ -1,0 +1,41 @@
+import {
+  DatumInstanceTypeScriptConfiguration,
+  getDatumInstanceConfiguration,
+  RootDatumInstanceTypeScriptConfiguration,
+} from '../../../datumInstanceTypeScriptConfiguration';
+import { DatumInstanceTypeScriptConfigurationCollectionBuilder } from '../../../datumInstanceTypeScriptConfigurationCollectionBuilder';
+import { TypeScriptSemanticsIdentifier } from '../typeScriptSemanticsIdentifer';
+
+export type PackageDirectoryNameSetConfiguration = {
+  rootDirectoryRelativeToCurrentWorkingDirectory: string;
+};
+
+export type PackageDirectoryNameSetConfigurationTypeScriptConfiguration =
+  DatumInstanceTypeScriptConfiguration<{
+    typeSemanticsIdentifier: TypeScriptSemanticsIdentifier.PackageDirectoryNameSetConfiguration;
+    datumInstanceIdentifier: 'package-directory-name-set-configuration';
+    datumInstance: PackageDirectoryNameSetConfiguration;
+  }>;
+
+export const PACKAGE_DIRECTORY_NAME_SET_CONFIGURATION_TYPE_SCRIPT_CONFIGURATION: PackageDirectoryNameSetConfigurationTypeScriptConfiguration =
+  {
+    typeSemanticsIdentifier:
+      TypeScriptSemanticsIdentifier.PackageDirectoryNameSetConfiguration,
+    datumInstanceIdentifier: 'package-directory-name-set-configuration',
+    datumInstance: {
+      rootDirectoryRelativeToCurrentWorkingDirectory: 'packages',
+    },
+  };
+
+export const buildPackageDirectoryNameSetConfiguration: DatumInstanceTypeScriptConfigurationCollectionBuilder<{
+  InputCollection: [RootDatumInstanceTypeScriptConfiguration];
+  OutputCollection: [
+    PackageDirectoryNameSetConfigurationTypeScriptConfiguration,
+  ];
+}> = () => {
+  return [
+    getDatumInstanceConfiguration(
+      PACKAGE_DIRECTORY_NAME_SET_CONFIGURATION_TYPE_SCRIPT_CONFIGURATION,
+    ),
+  ];
+};

--- a/packages/open-schema-type-script/src/example/testingPlatform/typeScriptSemanticsIdentifer.ts
+++ b/packages/open-schema-type-script/src/example/testingPlatform/typeScriptSemanticsIdentifer.ts
@@ -1,0 +1,4 @@
+export enum TypeScriptSemanticsIdentifier {
+  PackageDirectoryNameSetConfiguration = 'TestingPlatform:PackageDirectoryNameSetConfiguration',
+  PackageDirectoryNameSet = 'TestingPlatform:PackageDirectoryNameSet',
+}


### PR DESCRIPTION
We want the core open-schema implementation to be TypeScript-agnostic, but we want a TypeScript layer on top of it so that we can create custom datum instances that are coupled to their TypeScript types, and as a result, their runtime TypesScript semantics.