### PR TITLE
Add CiYamlFile datum instance configurations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3282,8 +3282,8 @@
     },
     "node_modules/yaml": {
       "version": "2.2.1",
-      "dev": true,
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
+      "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
       "engines": {
         "node": ">= 14"
       }
@@ -3333,7 +3333,11 @@
         "rat-test": "*"
       }
     },
-    "packages/open-schema-type-script": {},
+    "packages/open-schema-type-script": {
+      "dependencies": {
+        "yaml": "^2.2.1"
+      }
+    },
     "packages/rat-test": {
       "devDependencies": {
         "base-tsconfig": "*",
@@ -4860,7 +4864,10 @@
       }
     },
     "open-schema-type-script": {
-      "version": "file:packages/open-schema-type-script"
+      "version": "file:packages/open-schema-type-script",
+      "requires": {
+        "yaml": "*"
+      }
     },
     "optionator": {
       "version": "0.9.1",
@@ -5385,7 +5392,8 @@
     },
     "yaml": {
       "version": "2.2.1",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
+      "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw=="
     },
     "yn": {
       "version": "3.1.1",

--- a/packages/open-schema-type-script/package.json
+++ b/packages/open-schema-type-script/package.json
@@ -1,5 +1,8 @@
 {
   "testingPlatformConfiguration": {
     "typeId": "NonTestFramework"
+  },
+  "dependencies": {
+    "yaml": "^2.2.1"
   }
 }

--- a/packages/open-schema-type-script/src/example/index.ts
+++ b/packages/open-schema-type-script/src/example/index.ts
@@ -3,6 +3,22 @@ import { UnknownBuilderConfigurationTuple } from '../builderConfiguration';
 import { RootDatumInstanceTypeScriptConfiguration } from '../datumInstanceTypeScriptConfiguration';
 import { run } from '../representation-engine/run';
 import {
+  ActualCiYamlFileTypeScriptConfiguration,
+  buildActualCiYamlFileContents,
+} from './testingPlatform/ciYamlFile/actualCiYamlFile';
+import {
+  AssertableCiYamlFileTypeScriptConfiguration,
+  buildAssertableCiYamlFileContentsConfiguration,
+} from './testingPlatform/ciYamlFile/assertableCiYamlFile';
+import {
+  buildExpectedCiYamlContents,
+  ExpectedCiYamlFileContentsTypeScriptConfiguration,
+} from './testingPlatform/ciYamlFile/expectedCiYamlFileContents';
+import {
+  buildExpectedCiYamlFileContentsConfiguration,
+  ExpectedCiYamlFileContentsConfigurationTypeScriptConfiguration,
+} from './testingPlatform/ciYamlFile/expectedCiYamlFileContentsConfiguration';
+import {
   buildPackageDirectoryNameSet,
   PackageDirectoryNameSetTypeScriptConfiguration,
 } from './testingPlatform/packageDirectoryNameSet/packageDirectoryNameSet';
@@ -30,6 +46,47 @@ const builderConfigurationCollection = [
     buildCollection: buildPackageDirectoryNameSet,
     inputCollectionLocatorCollection: [
       'package-directory-name-set-configuration',
+    ],
+  }),
+
+  buildBuilderConfiguration<{
+    InputCollection: [RootDatumInstanceTypeScriptConfiguration];
+    OutputCollection: [ActualCiYamlFileTypeScriptConfiguration];
+  }>({
+    buildCollection: buildActualCiYamlFileContents,
+    inputCollectionLocatorCollection: [''],
+  }),
+  buildBuilderConfiguration<{
+    InputCollection: [RootDatumInstanceTypeScriptConfiguration];
+    OutputCollection: [
+      ExpectedCiYamlFileContentsConfigurationTypeScriptConfiguration,
+    ];
+  }>({
+    buildCollection: buildExpectedCiYamlFileContentsConfiguration,
+    inputCollectionLocatorCollection: [''],
+  }),
+  buildBuilderConfiguration<{
+    InputCollection: [
+      ExpectedCiYamlFileContentsConfigurationTypeScriptConfiguration,
+    ];
+    OutputCollection: [ExpectedCiYamlFileContentsTypeScriptConfiguration];
+  }>({
+    buildCollection: buildExpectedCiYamlContents,
+    inputCollectionLocatorCollection: [
+      'expected-ci-yaml-file-contents-configuration',
+    ],
+  }),
+  buildBuilderConfiguration<{
+    InputCollection: [
+      ActualCiYamlFileTypeScriptConfiguration,
+      ExpectedCiYamlFileContentsTypeScriptConfiguration,
+    ];
+    OutputCollection: [AssertableCiYamlFileTypeScriptConfiguration];
+  }>({
+    buildCollection: buildAssertableCiYamlFileContentsConfiguration,
+    inputCollectionLocatorCollection: [
+      'actual-ci-yaml-file',
+      'expected-ci-yaml-file-contents',
     ],
   }),
 ] as const satisfies UnknownBuilderConfigurationTuple;

--- a/packages/open-schema-type-script/src/example/testingPlatform/ciYamlFile/actualCiYamlFile.ts
+++ b/packages/open-schema-type-script/src/example/testingPlatform/ciYamlFile/actualCiYamlFile.ts
@@ -1,0 +1,42 @@
+import fs from 'fs';
+import {
+  DatumInstanceTypeScriptConfiguration,
+  DatumInstanceTypeScriptConfigurationToDatumInstanceConfiguration,
+  RootDatumInstanceTypeScriptConfiguration,
+} from '../../../datumInstanceTypeScriptConfiguration';
+import { DatumInstanceTypeScriptConfigurationCollectionBuilder } from '../../../datumInstanceTypeScriptConfigurationCollectionBuilder';
+import { TypeScriptSemanticsIdentifier } from '../typeScriptSemanticsIdentifer';
+
+export type ActualCiYamlFile = {
+  filePath: '.github/workflows/continuous-integration.yml';
+  stringContents: string;
+};
+
+export type ActualCiYamlFileTypeScriptConfiguration =
+  DatumInstanceTypeScriptConfiguration<{
+    typeSemanticsIdentifier: TypeScriptSemanticsIdentifier.ActualCiYamlFileType;
+    datumInstanceIdentifier: 'actual-ci-yaml-file';
+    datumInstance: ActualCiYamlFile;
+  }>;
+
+export const buildActualCiYamlFileContents: DatumInstanceTypeScriptConfigurationCollectionBuilder<{
+  InputCollection: [RootDatumInstanceTypeScriptConfiguration];
+  OutputCollection: [ActualCiYamlFileTypeScriptConfiguration];
+}> = () => {
+  const filePath = '.github/workflows/continuous-integration.yml';
+  const stringContents = fs.readFileSync(filePath, 'utf8');
+
+  const outputConfiguration: DatumInstanceTypeScriptConfigurationToDatumInstanceConfiguration<ActualCiYamlFileTypeScriptConfiguration> =
+    {
+      predicateIdentifiers: [
+        TypeScriptSemanticsIdentifier.ActualCiYamlFileType,
+      ],
+      instanceIdentifier: 'actual-ci-yaml-file',
+      datumInstance: {
+        filePath,
+        stringContents,
+      },
+    };
+
+  return [outputConfiguration];
+};

--- a/packages/open-schema-type-script/src/example/testingPlatform/ciYamlFile/assertableCiYamlFile.ts
+++ b/packages/open-schema-type-script/src/example/testingPlatform/ciYamlFile/assertableCiYamlFile.ts
@@ -1,0 +1,46 @@
+import yaml from 'yaml';
+import {
+  DatumInstanceTypeScriptConfiguration,
+  DatumInstanceTypeScriptConfigurationToDatumInstanceConfiguration,
+} from '../../../datumInstanceTypeScriptConfiguration';
+import { DatumInstanceTypeScriptConfigurationCollectionBuilder } from '../../../datumInstanceTypeScriptConfigurationCollectionBuilder';
+import { TypeScriptSemanticsIdentifier } from '../typeScriptSemanticsIdentifer';
+import { ActualCiYamlFileTypeScriptConfiguration } from './actualCiYamlFile';
+import { ExpectedCiYamlFileContentsTypeScriptConfiguration } from './expectedCiYamlFileContents';
+
+export type AssertableCiYamlFile = {
+  actualStringContents: string;
+  expectedStringContents: string;
+};
+
+export type AssertableCiYamlFileTypeScriptConfiguration =
+  DatumInstanceTypeScriptConfiguration<{
+    typeSemanticsIdentifier: TypeScriptSemanticsIdentifier.AssertableCiYamlFile;
+    datumInstanceIdentifier: 'assertable-ci-yaml-file';
+    datumInstance: AssertableCiYamlFile;
+  }>;
+
+export const buildAssertableCiYamlFileContentsConfiguration: DatumInstanceTypeScriptConfigurationCollectionBuilder<{
+  InputCollection: [
+    ActualCiYamlFileTypeScriptConfiguration,
+    ExpectedCiYamlFileContentsTypeScriptConfiguration,
+  ];
+  OutputCollection: [AssertableCiYamlFileTypeScriptConfiguration];
+}> = (
+  { datumInstance: actualCiYamlFile },
+  { datumInstance: expectedCiYamlFileContents },
+) => {
+  const outputConfiguration: DatumInstanceTypeScriptConfigurationToDatumInstanceConfiguration<AssertableCiYamlFileTypeScriptConfiguration> =
+    {
+      predicateIdentifiers: [
+        TypeScriptSemanticsIdentifier.AssertableCiYamlFile,
+      ],
+      instanceIdentifier: 'assertable-ci-yaml-file',
+      datumInstance: {
+        actualStringContents: actualCiYamlFile.stringContents,
+        expectedStringContents: yaml.stringify(expectedCiYamlFileContents),
+      },
+    };
+
+  return [outputConfiguration];
+};

--- a/packages/open-schema-type-script/src/example/testingPlatform/ciYamlFile/expectedCiYamlFileContents.ts
+++ b/packages/open-schema-type-script/src/example/testingPlatform/ciYamlFile/expectedCiYamlFileContents.ts
@@ -1,0 +1,80 @@
+import fs from 'fs';
+import { posix } from 'path';
+import {
+  DatumInstanceTypeScriptConfiguration,
+  DatumInstanceTypeScriptConfigurationToDatumInstanceConfiguration,
+} from '../../../datumInstanceTypeScriptConfiguration';
+import { DatumInstanceTypeScriptConfigurationCollectionBuilder } from '../../../datumInstanceTypeScriptConfigurationCollectionBuilder';
+import { TypeScriptSemanticsIdentifier } from '../typeScriptSemanticsIdentifer';
+import {
+  CiYamlFileContents,
+  CiYamlFileContentsRunStep,
+  CiYamlFileContentsStep,
+  ExpectedCiYamlFileContentsConfigurationTypeScriptConfiguration,
+} from './expectedCiYamlFileContentsConfiguration';
+
+export type ExpectedCiYamlFileContents = CiYamlFileContents<
+  CiYamlFileContentsStep[]
+>;
+
+export type ExpectedCiYamlFileContentsTypeScriptConfiguration =
+  DatumInstanceTypeScriptConfiguration<{
+    typeSemanticsIdentifier: TypeScriptSemanticsIdentifier.ExpectedCiYamlFileContents;
+    datumInstanceIdentifier: 'expected-ci-yaml-file-contents';
+    datumInstance: ExpectedCiYamlFileContents;
+  }>;
+
+export const buildExpectedCiYamlContents: DatumInstanceTypeScriptConfigurationCollectionBuilder<{
+  InputCollection: [
+    ExpectedCiYamlFileContentsConfigurationTypeScriptConfiguration,
+  ];
+  OutputCollection: [ExpectedCiYamlFileContentsTypeScriptConfiguration];
+}> = (inputConfiguration) => {
+  const outputConfiguration: DatumInstanceTypeScriptConfigurationToDatumInstanceConfiguration<ExpectedCiYamlFileContentsTypeScriptConfiguration> =
+    {
+      predicateIdentifiers: [
+        TypeScriptSemanticsIdentifier.ExpectedCiYamlFileContents,
+      ],
+      instanceIdentifier: 'expected-ci-yaml-file-contents',
+      datumInstance: {
+        ...inputConfiguration.datumInstance,
+        jobs: {
+          'Continuous-Integration': {
+            'runs-on': 'ubuntu-latest',
+            steps: [
+              ...inputConfiguration.datumInstance.jobs['Continuous-Integration']
+                .steps.beforePackageRunSteps,
+              // TODO: separate concerns for this logic once we can aggregate multiple targets into one
+              ...fs
+                .readdirSync('packages')
+                .map((directoryName) => ({
+                  directoryName,
+                  directoryPath: posix.join('packages', directoryName),
+                }))
+                .map(
+                  ({
+                    directoryName,
+                    directoryPath,
+                  }): CiYamlFileContentsRunStep => {
+                    const runTestsScriptPath = posix.join(
+                      directoryPath,
+                      'scripts',
+                      'runTests.sh',
+                    );
+
+                    return {
+                      name: `Run ${directoryName} Tests`,
+                      run: `bash ${runTestsScriptPath}`,
+                    };
+                  },
+                ),
+              ...inputConfiguration.datumInstance.jobs['Continuous-Integration']
+                .steps.afterPackageRunSteps,
+            ],
+          },
+        },
+      },
+    };
+
+  return [outputConfiguration];
+};

--- a/packages/open-schema-type-script/src/example/testingPlatform/ciYamlFile/expectedCiYamlFileContentsConfiguration.ts
+++ b/packages/open-schema-type-script/src/example/testingPlatform/ciYamlFile/expectedCiYamlFileContentsConfiguration.ts
@@ -1,0 +1,99 @@
+import {
+  DatumInstanceTypeScriptConfiguration,
+  getDatumInstanceConfiguration,
+  RootDatumInstanceTypeScriptConfiguration,
+} from '../../../datumInstanceTypeScriptConfiguration';
+import { DatumInstanceTypeScriptConfigurationCollectionBuilder } from '../../../datumInstanceTypeScriptConfigurationCollectionBuilder';
+import { TypeScriptSemanticsIdentifier } from '../typeScriptSemanticsIdentifer';
+
+export type CiYamlFileContentsStep = Record<string, unknown>;
+
+export type CiYamlFileContentsRunStep = {
+  name: string;
+  run: string;
+};
+
+export type CiYamlFileContents<TSteps> = {
+  name: 'Continuous Integration';
+  on: ['push'];
+  jobs: {
+    'Continuous-Integration': {
+      'runs-on': 'ubuntu-latest';
+      steps: TSteps;
+    };
+  };
+};
+
+export type ExpectedCiYamlFileContentsConfiguration = CiYamlFileContents<{
+  beforePackageRunSteps: CiYamlFileContentsStep[];
+  afterPackageRunSteps: CiYamlFileContentsStep[];
+}>;
+
+export type ExpectedCiYamlFileContentsConfigurationTypeScriptConfiguration =
+  DatumInstanceTypeScriptConfiguration<{
+    typeSemanticsIdentifier: TypeScriptSemanticsIdentifier.ExpectedCiYamlFileContentsConfiguration;
+    datumInstanceIdentifier: 'expected-ci-yaml-file-contents-configuration';
+    datumInstance: ExpectedCiYamlFileContentsConfiguration;
+  }>;
+
+export const CI_YAML_FILE_CONTENTS_CONFIGURATION_TYPE_SCRIPT_CONFIGURATION: ExpectedCiYamlFileContentsConfigurationTypeScriptConfiguration =
+  {
+    typeSemanticsIdentifier:
+      TypeScriptSemanticsIdentifier.ExpectedCiYamlFileContentsConfiguration,
+    datumInstanceIdentifier: 'expected-ci-yaml-file-contents-configuration',
+    datumInstance: {
+      name: 'Continuous Integration',
+      on: ['push'],
+      jobs: {
+        'Continuous-Integration': {
+          'runs-on': 'ubuntu-latest',
+          steps: {
+            beforePackageRunSteps: [
+              {
+                name: 'Check Out Code',
+                uses: 'actions/checkout@v3',
+              },
+              {
+                name: 'Install Node',
+                uses: 'actions/setup-node@v3',
+                with: {
+                  'node-version-file': '.nvmrc',
+                },
+              },
+              {
+                name: 'Install Dependencies',
+                run: 'npm clean-install',
+              },
+              {
+                name: 'Lint Markdown',
+                run: 'npm run lint:md',
+              },
+              {
+                name: 'Lint TypeScript',
+                run: 'npm run lint:ts:all',
+              },
+            ],
+            afterPackageRunSteps: [
+              {
+                name: 'Lint Constraints',
+                run: 'npm run lint:constraints',
+              },
+            ],
+          },
+        },
+      },
+    },
+  };
+
+export const buildExpectedCiYamlFileContentsConfiguration: DatumInstanceTypeScriptConfigurationCollectionBuilder<{
+  InputCollection: [RootDatumInstanceTypeScriptConfiguration];
+  OutputCollection: [
+    ExpectedCiYamlFileContentsConfigurationTypeScriptConfiguration,
+  ];
+}> = () => {
+  return [
+    getDatumInstanceConfiguration(
+      CI_YAML_FILE_CONTENTS_CONFIGURATION_TYPE_SCRIPT_CONFIGURATION,
+    ),
+  ];
+};

--- a/packages/open-schema-type-script/src/example/testingPlatform/typeScriptSemanticsIdentifer.ts
+++ b/packages/open-schema-type-script/src/example/testingPlatform/typeScriptSemanticsIdentifer.ts
@@ -1,4 +1,9 @@
 export enum TypeScriptSemanticsIdentifier {
   PackageDirectoryNameSetConfiguration = 'TestingPlatform:PackageDirectoryNameSetConfiguration',
   PackageDirectoryNameSet = 'TestingPlatform:PackageDirectoryNameSet',
+
+  ExpectedCiYamlFileContentsConfiguration = 'TestingPlatform:CiYamlFileContentsConfiguration',
+  ExpectedCiYamlFileContents = 'TestingPlatform:ExpectedCiYamlFileContents',
+  ActualCiYamlFileType = 'TestingPlatform:ActualCiYamlFileType',
+  AssertableCiYamlFile = 'TestingPlatform:AssertableCiYamlFile',
 }


### PR DESCRIPTION
These will let us check if the CI yaml file up to date. The configuration that takes two inputs won't work in the current representation engine. We need to remodel how we check which configurations need to be built. 