### PR TITLE
Index builder configurations to help find which ones to run

### DIFF
--- a/packages/open-schema-type-script/src/representation-engine/mutableBuilderConfiguration.ts
+++ b/packages/open-schema-type-script/src/representation-engine/mutableBuilderConfiguration.ts
@@ -1,0 +1,12 @@
+import { UnknownBuilderConfiguration } from '../builderConfiguration';
+
+export class MutableBuilderConfiguration {
+  public builtInputCount = 0;
+
+  constructor(
+    public readonly builderConfiguration: UnknownBuilderConfiguration,
+  ) {}
+}
+
+export type MutableBuilderConfigurationTuple =
+  readonly MutableBuilderConfiguration[];

--- a/packages/open-schema-type-script/src/representation-engine/mutableBuilderConfigurationCollection.ts
+++ b/packages/open-schema-type-script/src/representation-engine/mutableBuilderConfigurationCollection.ts
@@ -1,0 +1,20 @@
+import { UnknownBuilderConfiguration } from '../builderConfiguration';
+import { CustomSet } from '../utilities/customSet';
+import { MutableBuilderConfiguration } from './mutableBuilderConfiguration';
+
+export type MutableBuilderCollectionConstructorParameter = {
+  builderConfiguration: UnknownBuilderConfiguration;
+};
+
+export class MutableBuilderConfigurationCollection extends CustomSet<MutableBuilderConfiguration> {
+  addBuilderConfiguration(
+    builderConfiguration: UnknownBuilderConfiguration,
+  ): void {
+    const mutableBuilderConfiguration: MutableBuilderConfiguration = {
+      builderConfiguration,
+      builtInputCount: 0,
+    };
+
+    super.add(mutableBuilderConfiguration);
+  }
+}

--- a/packages/open-schema-type-script/src/representation-engine/mutableBuilderConfigurationCollectionsByInputLocator.ts
+++ b/packages/open-schema-type-script/src/representation-engine/mutableBuilderConfigurationCollectionsByInputLocator.ts
@@ -1,0 +1,43 @@
+import { UnknownCollectionLocator } from '../collectionLocator';
+import { CustomMap } from '../utilities/customMap';
+import {
+  MutableBuilderConfiguration,
+  MutableBuilderConfigurationTuple,
+} from './mutableBuilderConfiguration';
+import { MutableBuilderConfigurationCollection } from './mutableBuilderConfigurationCollection';
+
+export class MutableBuilderConfigurationCollectionsByInputLocator extends CustomMap<{
+  Key: UnknownCollectionLocator;
+  InputValue: MutableBuilderConfiguration;
+  StoredValue: MutableBuilderConfigurationCollection;
+}> {
+  constructor() {
+    super({
+      createDefaultStoredValue: () =>
+        new MutableBuilderConfigurationCollection(),
+      mutateStoredValue: ({ inputValue, storedValue }) => {
+        storedValue.add(inputValue);
+      },
+    });
+  }
+
+  private indexMutableBuilderConfiguration(
+    mutableBuilderConfiguration: MutableBuilderConfiguration,
+  ): void {
+    mutableBuilderConfiguration.builderConfiguration.inputCollectionLocatorCollection.forEach(
+      (inputCollectionLocator) => {
+        this.setInputValue(inputCollectionLocator, mutableBuilderConfiguration);
+      },
+    );
+  }
+
+  indexMutableBuilderConfigurationCollection(
+    mutableBuilderConfigurationCollection: MutableBuilderConfigurationTuple,
+  ): void {
+    mutableBuilderConfigurationCollection.forEach(
+      (mutableBuilderConfiguration) => {
+        this.indexMutableBuilderConfiguration(mutableBuilderConfiguration);
+      },
+    );
+  }
+}

--- a/packages/open-schema-type-script/src/utilities/customMap.ts
+++ b/packages/open-schema-type-script/src/utilities/customMap.ts
@@ -1,0 +1,56 @@
+import { StringKeys } from '../utilityTypes/stringKeys';
+
+export type CustomMapTypeParameter = {
+  Key: unknown;
+  InputValue: unknown;
+  StoredValue: unknown;
+};
+
+export type DefaultStoredValueInstantiator<T extends CustomMapTypeParameter> =
+  () => T['StoredValue'];
+
+export type StoredValueMutator<T extends CustomMapTypeParameter> = (parameter: {
+  [TKey in StringKeys<
+    Pick<T, 'InputValue' | 'StoredValue'>
+  > as Uncapitalize<TKey>]: T[TKey];
+}) => void;
+
+export type CustomMapConstructorParameter<
+  TCustomMapTypeParameter extends CustomMapTypeParameter,
+> = {
+  createDefaultStoredValue: DefaultStoredValueInstantiator<TCustomMapTypeParameter>;
+  mutateStoredValue: StoredValueMutator<TCustomMapTypeParameter>;
+};
+
+export class CustomMap<T extends CustomMapTypeParameter> extends Map<
+  T['Key'],
+  T['StoredValue']
+> {
+  public readonly createDefaultStoredValue: DefaultStoredValueInstantiator<T>;
+
+  public readonly mutateStoredValue: StoredValueMutator<T>;
+
+  constructor({
+    createDefaultStoredValue,
+    mutateStoredValue,
+  }: CustomMapConstructorParameter<T>) {
+    super();
+
+    this.createDefaultStoredValue = createDefaultStoredValue;
+    this.mutateStoredValue = mutateStoredValue;
+  }
+
+  get(key: T['Key']): T['StoredValue'] {
+    return super.get(key) ?? this.createDefaultStoredValue();
+  }
+
+  setInputValue(key: T['Key'], inputValue: T['InputValue']): void {
+    const storedValue = this.get(key);
+    this.mutateStoredValue({ inputValue, storedValue });
+    this.set(key, storedValue);
+  }
+
+  asEntries(): [T['Key'], T['StoredValue']][] {
+    return [...super.entries()];
+  }
+}

--- a/packages/open-schema-type-script/src/utilities/customSet.ts
+++ b/packages/open-schema-type-script/src/utilities/customSet.ts
@@ -1,0 +1,5 @@
+export class CustomSet<T> extends Set<T> {
+  asArray(): T[] {
+    return [...this];
+  }
+}


### PR DESCRIPTION
This change indexes builder configurations (along with a count) by input datum instance collection locator. This data structure is called a mutable builder configuration because the count is updated every time one of the input datum instances is instantiated. When all of a builder's inputs have been instantiated the builder is run. The current implementation is meant to work with datum instance identifiers, and not aliases. This way a builder is only called once, and we don't have to handle permutations of inputs to multi-input builders.