### PR TITLE
Remove the root datum instance configuration

### DIFF
--- a/packages/open-schema-type-script/src/core/collectionLocator.ts
+++ b/packages/open-schema-type-script/src/core/collectionLocator.ts
@@ -3,7 +3,3 @@ import { UnknownString } from '../utilities/types/unknownHelpers';
 export type UnknownCollectionLocator = UnknownString;
 
 export type UnknownCollectionLocatorTuple = readonly UnknownCollectionLocator[];
-
-export const ROOT_DATUM_INSTANCE_LOCATOR = '' as const;
-
-export type RootDatumInstanceLocator = typeof ROOT_DATUM_INSTANCE_LOCATOR;

--- a/packages/open-schema-type-script/src/core/datumInstance.ts
+++ b/packages/open-schema-type-script/src/core/datumInstance.ts
@@ -1,5 +1,1 @@
 export type UnknownDatumInstance = unknown;
-
-export const ROOT_DATUM_INSTANCE = null;
-
-export type RootDatumInstance = typeof ROOT_DATUM_INSTANCE;

--- a/packages/open-schema-type-script/src/core/representation-engine/mutableBuilderConfiguration.ts
+++ b/packages/open-schema-type-script/src/core/representation-engine/mutableBuilderConfiguration.ts
@@ -1,11 +1,58 @@
+import { CustomMap } from '../../utilities/customMap';
 import { UnknownBuilderConfiguration } from '../builderConfiguration';
+import { UnknownCollectionLocator } from '../collectionLocator';
+import { UnknownDatumInstanceConfiguration } from '../datumInstanceConfiguration';
+
+type MutableInputStatus = {
+  locator: UnknownCollectionLocator;
+  isReady: boolean;
+};
 
 export class MutableBuilderConfiguration {
-  public builtInputCount = 0;
+  public mutableInputStatusesByLocator: CustomMap<{
+    Key: UnknownCollectionLocator;
+    InputValue: MutableInputStatus;
+    StoredValue: MutableInputStatus;
+  }>;
 
   constructor(
     public readonly builderConfiguration: UnknownBuilderConfiguration,
-  ) {}
+  ) {
+    this.mutableInputStatusesByLocator = new CustomMap<{
+      Key: UnknownCollectionLocator;
+      InputValue: MutableInputStatus;
+      StoredValue: MutableInputStatus;
+    }>({
+      mutateStoredValue: (): void => {},
+      createDefaultStoredValue: (inputLocator): MutableInputStatus => {
+        return {
+          locator: inputLocator,
+          isReady: false,
+        };
+      },
+      initialKeys: builderConfiguration.inputCollectionLocatorCollection,
+    });
+  }
+
+  updateInputStatus(
+    inputConfiguration: UnknownDatumInstanceConfiguration,
+  ): void {
+    const mutableInputStatus = this.mutableInputStatusesByLocator.get(
+      inputConfiguration.instanceIdentifier,
+    );
+
+    if (mutableInputStatus === undefined) {
+      return;
+    }
+
+    mutableInputStatus.isReady = true;
+  }
+
+  isReady(): boolean {
+    return this.mutableInputStatusesByLocator
+      .asEntries()
+      .every(([, mutableStatus]) => mutableStatus.isReady);
+  }
 }
 
 export type MutableBuilderConfigurationTuple =

--- a/packages/open-schema-type-script/src/core/representation-engine/mutableBuilderConfigurationCollection.ts
+++ b/packages/open-schema-type-script/src/core/representation-engine/mutableBuilderConfigurationCollection.ts
@@ -1,20 +1,4 @@
-import { UnknownBuilderConfiguration } from '../builderConfiguration';
 import { CustomSet } from '../../utilities/customSet';
 import { MutableBuilderConfiguration } from './mutableBuilderConfiguration';
 
-export type MutableBuilderCollectionConstructorParameter = {
-  builderConfiguration: UnknownBuilderConfiguration;
-};
-
-export class MutableBuilderConfigurationCollection extends CustomSet<MutableBuilderConfiguration> {
-  addBuilderConfiguration(
-    builderConfiguration: UnknownBuilderConfiguration,
-  ): void {
-    const mutableBuilderConfiguration: MutableBuilderConfiguration = {
-      builderConfiguration,
-      builtInputCount: 0,
-    };
-
-    super.add(mutableBuilderConfiguration);
-  }
-}
+export class MutableBuilderConfigurationCollection extends CustomSet<MutableBuilderConfiguration> {}

--- a/packages/open-schema-type-script/src/core/representation-engine/run.ts
+++ b/packages/open-schema-type-script/src/core/representation-engine/run.ts
@@ -1,6 +1,9 @@
 import fs from 'fs';
 import posix from 'path';
-import { UnknownBuilderConfigurationTuple } from '../builderConfiguration';
+import {
+  UnknownBuilderConfiguration,
+  UnknownBuilderConfigurationTuple,
+} from '../builderConfiguration';
 import { UnknownCollectionLocator } from '../collectionLocator';
 import { UnknownDatumInstance } from '../datumInstance';
 import { UnknownDatumInstanceConfiguration } from '../datumInstanceConfiguration';
@@ -54,67 +57,50 @@ export const run: RepresentationEngine = ({
   const datumInstanceConfigurationEmitter =
     new DatumInstanceConfigurationEmitter(onDatumInstanceConfiguration);
 
-  let loopCount = 0;
-  let currentDatumInstanceLocatorCollection: CustomSet<UnknownCollectionLocator> =
-    new CustomSet();
-  let nextDatumInstanceLocatorCollection: CustomSet<UnknownCollectionLocator> =
-    new CustomSet();
+  const initialBuilderConfigurations = builderConfigurationCollection.filter(
+    (builderConfiguration) =>
+      builderConfiguration.inputCollectionLocatorCollection.length === 0,
+  );
 
-  const instanceMap: DatumInstancesByIdentifier = new Map();
+  const derivedBuilderConfigurations = builderConfigurationCollection.filter(
+    (builderConfiguration) =>
+      builderConfiguration.inputCollectionLocatorCollection.length > 0,
+  );
+
+  const derivedMutableBuilderConfigurationCollection =
+    derivedBuilderConfigurations.map((builderConfiguration) => {
+      return new MutableBuilderConfiguration(builderConfiguration);
+    });
 
   const mutableBuilderConfigurationCollectionsByInputLocator =
     new MutableBuilderConfigurationCollectionsByInputLocator();
 
-  const mutableBuilderConfigurationColection =
-    builderConfigurationCollection.map((builderConfiguration) => {
-      return new MutableBuilderConfiguration(builderConfiguration);
-    });
-
   mutableBuilderConfigurationCollectionsByInputLocator.indexMutableBuilderConfigurationCollection(
-    mutableBuilderConfigurationColection,
+    derivedMutableBuilderConfigurationCollection,
   );
 
-  // TODO: instead of tracking recently created instances, track builders that are ready to build. A builder with 0 inputs is ready immediately
-  while (nextDatumInstanceLocatorCollection.size > 0) {
-    currentDatumInstanceLocatorCollection = nextDatumInstanceLocatorCollection;
-    nextDatumInstanceLocatorCollection = new CustomSet();
+  const createdInstancesMap: DatumInstancesByIdentifier = new Map();
 
-    const configurationsToBuild = currentDatumInstanceLocatorCollection
+  let loopCount = 0;
+  let currentBuildersToRun: CustomSet<UnknownBuilderConfiguration> =
+    new CustomSet();
+  let nextBuildersToRun: CustomSet<UnknownBuilderConfiguration> = new CustomSet(
+    initialBuilderConfigurations,
+  );
+
+  while (nextBuildersToRun.size > 0) {
+    currentBuildersToRun = nextBuildersToRun;
+    nextBuildersToRun = new CustomSet();
+
+    const outputDatumConfigurationTupleCollection = currentBuildersToRun
       .asArray()
-      .flatMap((currentLocator) => {
-        const mutableBuilderConfigurationCollection =
-          mutableBuilderConfigurationCollectionsByInputLocator.get(
-            currentLocator,
-          );
-
-        mutableBuilderConfigurationCollection.forEach(
-          (mutableBuilderConfiguration) => {
-            // eslint-disable-next-line no-param-reassign
-            mutableBuilderConfiguration.builtInputCount += 1;
-          },
-        );
-
-        const readyConfigurations = mutableBuilderConfigurationCollection
-          .asArray()
-          .filter((mutableBuilderConfiguration) => {
-            return (
-              mutableBuilderConfiguration.builtInputCount ===
-              mutableBuilderConfiguration.builderConfiguration
-                .inputCollectionLocatorCollection.length
-            );
-          });
-
-        return readyConfigurations;
-      });
-
-    const outputDatumConfigurationTupleCollection = configurationsToBuild.map(
-      ({ builderConfiguration }) => {
+      .map((builderConfiguration) => {
         const inputCollection =
           builderConfiguration.inputCollectionLocatorCollection.map(
             (inputLocator): UnknownDatumInstanceConfiguration => {
               return {
                 instanceIdentifier: inputLocator,
-                datumInstance: instanceMap.get(inputLocator),
+                datumInstance: createdInstancesMap.get(inputLocator),
                 // TODO: figure out what to do with these predicate identifiers
                 predicateIdentifiers: [],
               };
@@ -122,8 +108,7 @@ export const run: RepresentationEngine = ({
           );
 
         return builderConfiguration.buildCollection(...inputCollection);
-      },
-    );
+      });
 
     const outputDatumConfigurationTuple =
       outputDatumConfigurationTupleCollection.flat();
@@ -131,11 +116,11 @@ export const run: RepresentationEngine = ({
     outputDatumConfigurationTuple.forEach(
       // eslint-disable-next-line @typescript-eslint/no-loop-func
       (datumInstanceConfiguration) => {
+        // debug
         // eslint-disable-next-line no-console
         console.log(
           `  Built: ${datumInstanceConfiguration.instanceIdentifier}`,
         );
-
         const filePath = getCacheFilePath(datumInstanceConfiguration);
         fs.mkdirSync(posix.dirname(filePath), { recursive: true });
         fs.writeFileSync(
@@ -143,29 +128,66 @@ export const run: RepresentationEngine = ({
           JSON.stringify(datumInstanceConfiguration, null, 2),
         );
 
-        nextDatumInstanceLocatorCollection.add(
-          datumInstanceConfiguration.instanceIdentifier,
-        );
-
-        instanceMap.set(
+        // cache
+        createdInstancesMap.set(
           datumInstanceConfiguration.instanceIdentifier,
           datumInstanceConfiguration.datumInstance,
         );
 
+        // emit
         datumInstanceConfigurationEmitter.emitDatum(datumInstanceConfiguration);
       },
     );
+
+    const pairedThings = outputDatumConfigurationTuple.flatMap(
+      (datumInstanceConfiguration) => {
+        const mutableBuilderConfigurationCollection =
+          mutableBuilderConfigurationCollectionsByInputLocator.get(
+            datumInstanceConfiguration.instanceIdentifier,
+          );
+
+        return mutableBuilderConfigurationCollection
+          .asArray()
+          .map((mutableBuilderConfiguration) => ({
+            datumInstanceConfiguration,
+            mutableBuilderConfiguration,
+          }));
+      },
+    );
+
+    const uniqueMutableBuilderConfigurations =
+      new CustomSet<MutableBuilderConfiguration>();
+    pairedThings.forEach(({ mutableBuilderConfiguration }) => {
+      // eslint-disable-next-line no-param-reassign
+      mutableBuilderConfiguration.builtInputCount += 1;
+
+      uniqueMutableBuilderConfigurations.add(mutableBuilderConfiguration);
+    });
+
+    const readyMutableBuilderConfigurations = uniqueMutableBuilderConfigurations
+      .asArray()
+      .filter((mutableBuilderConfiguration) => {
+        return (
+          mutableBuilderConfiguration.builtInputCount ===
+          mutableBuilderConfiguration.builderConfiguration
+            .inputCollectionLocatorCollection.length
+        );
+      });
+
+    const readyBuilderConfigurations =
+      new CustomSet<UnknownBuilderConfiguration>();
+    readyMutableBuilderConfigurations.forEach((mutableBuilderConfiguration) => {
+      readyBuilderConfigurations.add(
+        mutableBuilderConfiguration.builderConfiguration,
+      );
+    });
+
+    nextBuildersToRun = readyBuilderConfigurations;
 
     fs.writeFileSync(
       posix.join(LOOP_PATH, `loop-${loopCount}.txt`),
       [
         `Loop: ${loopCount}`,
-        '',
-        'Current Collection:',
-        ...currentDatumInstanceLocatorCollection
-          .asArray()
-          .map((x) => (x === '' ? '""' : x))
-          .map((x) => `    ${x}`),
         '',
         'Output Data:',
         ...outputDatumConfigurationTuple.flatMap((outputDatumConfiguration) => {
@@ -175,16 +197,12 @@ export const run: RepresentationEngine = ({
           ];
         }),
         '',
-        'Next Collection:',
-        ...nextDatumInstanceLocatorCollection.asArray().map((x) => `    ${x}`),
       ].join('\n'),
     );
 
     loopCount += 1;
   }
 
-  const numberOfDataBuilt = [...instanceMap].reduce((sum) => sum + 1, 0) - 1;
-
   // eslint-disable-next-line no-console
-  console.log(`Built ${numberOfDataBuilt} instances`);
+  console.log(`Built ${createdInstancesMap.size} instances`);
 };

--- a/packages/open-schema-type-script/src/core/representation-engine/run.ts
+++ b/packages/open-schema-type-script/src/core/representation-engine/run.ts
@@ -4,7 +4,6 @@ import { UnknownBuilderConfigurationTuple } from '../builderConfiguration';
 import { UnknownCollectionLocator } from '../collectionLocator';
 import { UnknownDatumInstance } from '../datumInstance';
 import { UnknownDatumInstanceConfiguration } from '../datumInstanceConfiguration';
-import { ROOT_DATUM_INSTANCE_TYPE_SCRIPT_CONFIGURATION } from '../../type-script/datumInstanceTypeScriptConfiguration';
 import { CustomSet } from '../../utilities/customSet';
 import { DatumHandler } from '../../utilities/datumEmitter';
 import { DatumInstanceConfigurationEmitter } from './datumInstanceConfigurationEmitter';
@@ -59,16 +58,9 @@ export const run: RepresentationEngine = ({
   let currentDatumInstanceLocatorCollection: CustomSet<UnknownCollectionLocator> =
     new CustomSet();
   let nextDatumInstanceLocatorCollection: CustomSet<UnknownCollectionLocator> =
-    new CustomSet([
-      ROOT_DATUM_INSTANCE_TYPE_SCRIPT_CONFIGURATION.datumInstanceIdentifier,
-    ]);
+    new CustomSet();
 
-  const instanceMap: DatumInstancesByIdentifier = new Map([
-    [
-      ROOT_DATUM_INSTANCE_TYPE_SCRIPT_CONFIGURATION.datumInstanceIdentifier,
-      ROOT_DATUM_INSTANCE_TYPE_SCRIPT_CONFIGURATION.datumInstance,
-    ],
-  ]);
+  const instanceMap: DatumInstancesByIdentifier = new Map();
 
   const mutableBuilderConfigurationCollectionsByInputLocator =
     new MutableBuilderConfigurationCollectionsByInputLocator();
@@ -82,6 +74,7 @@ export const run: RepresentationEngine = ({
     mutableBuilderConfigurationColection,
   );
 
+  // TODO: instead of tracking recently created instances, track builders that are ready to build. A builder with 0 inputs is ready immediately
   while (nextDatumInstanceLocatorCollection.size > 0) {
     currentDatumInstanceLocatorCollection = nextDatumInstanceLocatorCollection;
     nextDatumInstanceLocatorCollection = new CustomSet();

--- a/packages/open-schema-type-script/src/core/representation-engine/run.ts
+++ b/packages/open-schema-type-script/src/core/representation-engine/run.ts
@@ -157,21 +157,21 @@ export const run: RepresentationEngine = ({
 
     const uniqueMutableBuilderConfigurations =
       new CustomSet<MutableBuilderConfiguration>();
-    pairedThings.forEach(({ mutableBuilderConfiguration }) => {
-      // eslint-disable-next-line no-param-reassign
-      mutableBuilderConfiguration.builtInputCount += 1;
+    pairedThings.forEach(
+      ({ datumInstanceConfiguration, mutableBuilderConfiguration }) => {
+        // eslint-disable-next-line no-param-reassign
+        mutableBuilderConfiguration.updateInputStatus(
+          datumInstanceConfiguration,
+        );
 
-      uniqueMutableBuilderConfigurations.add(mutableBuilderConfiguration);
-    });
+        uniqueMutableBuilderConfigurations.add(mutableBuilderConfiguration);
+      },
+    );
 
     const readyMutableBuilderConfigurations = uniqueMutableBuilderConfigurations
       .asArray()
       .filter((mutableBuilderConfiguration) => {
-        return (
-          mutableBuilderConfiguration.builtInputCount ===
-          mutableBuilderConfiguration.builderConfiguration
-            .inputCollectionLocatorCollection.length
-        );
+        return mutableBuilderConfiguration.isReady();
       });
 
     const readyBuilderConfigurations =

--- a/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/ciYamlFile/actualCiYamlFile.ts
+++ b/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/ciYamlFile/actualCiYamlFile.ts
@@ -2,7 +2,6 @@ import fs from 'fs';
 import {
   DatumInstanceTypeScriptConfiguration,
   DatumInstanceTypeScriptConfigurationToDatumInstanceConfiguration,
-  RootDatumInstanceTypeScriptConfiguration,
 } from '../../../../type-script/datumInstanceTypeScriptConfiguration';
 import { DatumInstanceTypeScriptConfigurationCollectionBuilder } from '../../../../type-script/datumInstanceTypeScriptConfigurationCollectionBuilder';
 import { TypeScriptSemanticsIdentifier } from '../typeScriptSemanticsIdentifier';
@@ -20,7 +19,7 @@ export type ActualCiYamlFileTypeScriptConfiguration =
   }>;
 
 export const buildActualCiYamlFileContents: DatumInstanceTypeScriptConfigurationCollectionBuilder<{
-  InputCollection: [RootDatumInstanceTypeScriptConfiguration];
+  InputCollection: [];
   OutputCollection: [ActualCiYamlFileTypeScriptConfiguration];
 }> = () => {
   const filePath = '.github/workflows/continuous-integration.yml';

--- a/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/ciYamlFile/expectedCiYamlFileContentsConfiguration.ts
+++ b/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/ciYamlFile/expectedCiYamlFileContentsConfiguration.ts
@@ -1,7 +1,6 @@
 import {
   DatumInstanceTypeScriptConfiguration,
   getDatumInstanceConfiguration,
-  RootDatumInstanceTypeScriptConfiguration,
 } from '../../../../type-script/datumInstanceTypeScriptConfiguration';
 import { DatumInstanceTypeScriptConfigurationCollectionBuilder } from '../../../../type-script/datumInstanceTypeScriptConfigurationCollectionBuilder';
 import { TypeScriptSemanticsIdentifier } from '../typeScriptSemanticsIdentifier';
@@ -82,7 +81,7 @@ export const CI_YAML_FILE_CONTENTS_CONFIGURATION_TYPE_SCRIPT_CONFIGURATION: Expe
   };
 
 export const buildExpectedCiYamlFileContentsConfiguration: DatumInstanceTypeScriptConfigurationCollectionBuilder<{
-  InputCollection: [RootDatumInstanceTypeScriptConfiguration];
+  InputCollection: [];
   OutputCollection: [
     ExpectedCiYamlFileContentsConfigurationTypeScriptConfiguration,
   ];

--- a/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/file/fileA.ts
+++ b/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/file/fileA.ts
@@ -4,7 +4,6 @@ import { UnknownCollectionLocator } from '../../../../core/collectionLocator';
 import {
   DatumInstanceTypeScriptConfiguration,
   DatumInstanceTypeScriptConfigurationToDatumInstanceConfiguration,
-  RootDatumInstanceTypeScriptConfiguration,
 } from '../../../../type-script/datumInstanceTypeScriptConfiguration';
 import { DatumInstanceTypeScriptConfigurationCollectionBuilder } from '../../../../type-script/datumInstanceTypeScriptConfigurationCollectionBuilder';
 import { TypeScriptSemanticsIdentifier } from '../typeScriptSemanticsIdentifier';
@@ -56,7 +55,7 @@ const accumulateFilePaths = (
 };
 
 export const buildFileATuple: DatumInstanceTypeScriptConfigurationCollectionBuilder<{
-  InputCollection: [RootDatumInstanceTypeScriptConfiguration];
+  InputCollection: [];
   OutputCollection: FileATypeScriptConfiguration[];
 }> = () => {
   const mutableFilePathList: string[] = [];

--- a/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/packageDirectory/packageDirectoryASetConfiguration.ts
+++ b/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/packageDirectory/packageDirectoryASetConfiguration.ts
@@ -1,7 +1,6 @@
 import {
   DatumInstanceTypeScriptConfiguration,
   getDatumInstanceConfiguration,
-  RootDatumInstanceTypeScriptConfiguration,
 } from '../../../../type-script/datumInstanceTypeScriptConfiguration';
 import { DatumInstanceTypeScriptConfigurationCollectionBuilder } from '../../../../type-script/datumInstanceTypeScriptConfigurationCollectionBuilder';
 import { TypeScriptSemanticsIdentifier } from '../typeScriptSemanticsIdentifier';
@@ -28,7 +27,7 @@ export const PACKAGE_DIRECTORY_NAME_SET_CONFIGURATION_TYPE_SCRIPT_CONFIGURATION:
   };
 
 export const buildPackageDirectoryNameSetConfiguration: DatumInstanceTypeScriptConfigurationCollectionBuilder<{
-  InputCollection: [RootDatumInstanceTypeScriptConfiguration];
+  InputCollection: [];
   OutputCollection: [
     PackageDirectoryNameSetConfigurationTypeScriptConfiguration,
   ];

--- a/packages/open-schema-type-script/src/example/index.ts
+++ b/packages/open-schema-type-script/src/example/index.ts
@@ -1,7 +1,6 @@
 import assert from 'assert';
 import { buildBuilderConfiguration } from '../type-script/buildBuilderConfiguration';
 import { UnknownBuilderConfigurationTuple } from '../core/builderConfiguration';
-import { RootDatumInstanceTypeScriptConfiguration } from '../type-script/datumInstanceTypeScriptConfiguration';
 import { representationEngine } from '../core/representation-engine';
 import { validationEngine } from '../core/validation-engine';
 import {
@@ -40,13 +39,13 @@ import {
 
 const builderConfigurationCollection = [
   buildBuilderConfiguration<{
-    InputCollection: [RootDatumInstanceTypeScriptConfiguration];
+    InputCollection: [];
     OutputCollection: [
       PackageDirectoryNameSetConfigurationTypeScriptConfiguration,
     ];
   }>({
     buildCollection: buildPackageDirectoryNameSetConfiguration,
-    inputCollectionLocatorCollection: [''],
+    inputCollectionLocatorCollection: [],
   }),
   buildBuilderConfiguration<{
     InputCollection: [
@@ -61,20 +60,20 @@ const builderConfigurationCollection = [
   }),
 
   buildBuilderConfiguration<{
-    InputCollection: [RootDatumInstanceTypeScriptConfiguration];
+    InputCollection: [];
     OutputCollection: [ActualCiYamlFileTypeScriptConfiguration];
   }>({
     buildCollection: buildActualCiYamlFileContents,
-    inputCollectionLocatorCollection: [''],
+    inputCollectionLocatorCollection: [],
   }),
   buildBuilderConfiguration<{
-    InputCollection: [RootDatumInstanceTypeScriptConfiguration];
+    InputCollection: [];
     OutputCollection: [
       ExpectedCiYamlFileContentsConfigurationTypeScriptConfiguration,
     ];
   }>({
     buildCollection: buildExpectedCiYamlFileContentsConfiguration,
-    inputCollectionLocatorCollection: [''],
+    inputCollectionLocatorCollection: [],
   }),
   buildBuilderConfiguration<{
     InputCollection: [
@@ -102,11 +101,11 @@ const builderConfigurationCollection = [
   }),
 
   buildBuilderConfiguration<{
-    InputCollection: [RootDatumInstanceTypeScriptConfiguration];
+    InputCollection: [];
     OutputCollection: FileATypeScriptConfiguration[];
   }>({
     buildCollection: buildFileATuple,
-    inputCollectionLocatorCollection: [''],
+    inputCollectionLocatorCollection: [],
   }),
 
   // TODO: use aliases and semantics to handle this transformation

--- a/packages/open-schema-type-script/src/type-script/datumInstanceTypeScriptConfiguration.ts
+++ b/packages/open-schema-type-script/src/type-script/datumInstanceTypeScriptConfiguration.ts
@@ -1,15 +1,6 @@
-import {
-  RootDatumInstanceLocator,
-  ROOT_DATUM_INSTANCE_LOCATOR,
-  UnknownCollectionLocator,
-} from '../core/collectionLocator';
-import {
-  RootDatumInstance,
-  ROOT_DATUM_INSTANCE,
-  UnknownDatumInstance,
-} from '../core/datumInstance';
+import { UnknownCollectionLocator } from '../core/collectionLocator';
+import { UnknownDatumInstance } from '../core/datumInstance';
 import { DatumInstanceConfiguration } from '../core/datumInstanceConfiguration';
-import { TypeScriptSemanticsIdentifier } from './typeScriptSemanticsIdentifier';
 import { ConstrainObject } from '../utilities/types/constrainObject';
 
 export type UnknownDatumInstanceTypeScriptConfiguration = {
@@ -45,20 +36,6 @@ export type DatumInstanceTypeScriptConfigurationTupleToDatumInstanceConfiguratio
       >;
     }
   : never;
-
-export type RootDatumInstanceTypeScriptConfiguration =
-  DatumInstanceTypeScriptConfiguration<{
-    datumInstanceIdentifier: RootDatumInstanceLocator;
-    typeSemanticsIdentifier: TypeScriptSemanticsIdentifier.null;
-    datumInstance: RootDatumInstance;
-  }>;
-
-export const ROOT_DATUM_INSTANCE_TYPE_SCRIPT_CONFIGURATION: RootDatumInstanceTypeScriptConfiguration =
-  {
-    datumInstanceIdentifier: ROOT_DATUM_INSTANCE_LOCATOR,
-    datumInstance: ROOT_DATUM_INSTANCE,
-    typeSemanticsIdentifier: TypeScriptSemanticsIdentifier.null,
-  };
 
 export const getDatumInstanceConfiguration = <
   T extends UnknownDatumInstanceTypeScriptConfiguration,

--- a/packages/open-schema-type-script/src/utilities/customMap.ts
+++ b/packages/open-schema-type-script/src/utilities/customMap.ts
@@ -6,8 +6,9 @@ export type CustomMapTypeParameter = {
   StoredValue: unknown;
 };
 
-export type DefaultStoredValueInstantiator<T extends CustomMapTypeParameter> =
-  () => T['StoredValue'];
+export type DefaultStoredValueInstantiator<T extends CustomMapTypeParameter> = (
+  key: T['Key'],
+) => T['StoredValue'];
 
 export type StoredValueMutator<T extends CustomMapTypeParameter> = (parameter: {
   [TKey in StringKeys<
@@ -20,6 +21,7 @@ export type CustomMapConstructorParameter<
 > = {
   createDefaultStoredValue: DefaultStoredValueInstantiator<TCustomMapTypeParameter>;
   mutateStoredValue: StoredValueMutator<TCustomMapTypeParameter>;
+  initialKeys?: readonly TCustomMapTypeParameter['Key'][];
 };
 
 export class CustomMap<T extends CustomMapTypeParameter> extends Map<
@@ -33,15 +35,21 @@ export class CustomMap<T extends CustomMapTypeParameter> extends Map<
   constructor({
     createDefaultStoredValue,
     mutateStoredValue,
+    initialKeys = [],
   }: CustomMapConstructorParameter<T>) {
     super();
 
     this.createDefaultStoredValue = createDefaultStoredValue;
     this.mutateStoredValue = mutateStoredValue;
+
+    initialKeys.forEach((key) => {
+      const initialValue = this.get(key);
+      this.setInputValue(key, initialValue);
+    });
   }
 
   get(key: T['Key']): T['StoredValue'] {
-    return super.get(key) ?? this.createDefaultStoredValue();
+    return super.get(key) ?? this.createDefaultStoredValue(key);
   }
 
   setInputValue(key: T['Key'], inputValue: T['InputValue']): void {


### PR DESCRIPTION
- the root datum instance configuration was a hack to kickstart the representation engine
- the representation engine now tracks which builders are ready to trigger instead of which datum configurations were recently built
- a builder configuration with zero inputs is ready to trigger and is queued up to run first
- builders now keep track of their own mutable input statuses to know if they are ready to trigger