### PR TITLE
Update the representation engine to trigger builders found from aliases

### DIFF
--- a/packages/open-schema-type-script/src/core/datumInstanceConfiguration.ts
+++ b/packages/open-schema-type-script/src/core/datumInstanceConfiguration.ts
@@ -5,9 +5,8 @@ import { ConstrainObject } from '../utilities/types/constrainObject';
 export type UnknownDatumInstanceConfiguration = {
   instanceIdentifier: UnknownCollectionLocator;
   datumInstance: UnknownDatumInstance;
-  // TOOD: we aren't do anything with these, so disabling them for now
-  // aliases: UnknownCollectionLocator[];
   predicateIdentifiers: UnknownCollectionLocator[];
+  aliases: UnknownCollectionLocator[];
 };
 
 export type DatumInstanceConfiguration<

--- a/packages/open-schema-type-script/src/core/representation-engine/mutableBuilderConfiguration.ts
+++ b/packages/open-schema-type-script/src/core/representation-engine/mutableBuilderConfiguration.ts
@@ -1,4 +1,5 @@
 import { CustomMap } from '../../utilities/customMap';
+import { CustomSet } from '../../utilities/customSet';
 import { UnknownBuilderConfiguration } from '../builderConfiguration';
 import {
   UnknownCollectionLocator,
@@ -16,6 +17,10 @@ type MutableInputStatus = {
 };
 
 export class MutableBuilderConfiguration {
+  public readonly isRetriggerable: boolean;
+
+  public triggeredIdentifierSet = new CustomSet<UnknownCollectionLocator>();
+
   public mutableInputStatusesByLocator: CustomMap<{
     Key: UnknownCollectionLocator;
     InputValue: MutableInputStatus;
@@ -25,6 +30,9 @@ export class MutableBuilderConfiguration {
   constructor(
     public readonly builderConfiguration: UnknownBuilderConfiguration,
   ) {
+    this.isRetriggerable =
+      builderConfiguration.inputPredicateLocatorTuple.length === 1;
+
     // TODO: update Custom map to allow for this pattern
     const tempMap = new Map<
       UnknownCollectionLocator,

--- a/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/ciYamlFile/actualCiYamlFile.ts
+++ b/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/ciYamlFile/actualCiYamlFile.ts
@@ -18,6 +18,7 @@ export type ActualCiYamlFileTypeScriptConfiguration =
     ];
     datumInstanceIdentifier: 'actual-ci-yaml-file';
     datumInstance: ActualCiYamlFile;
+    datumInstanceAliases: [];
   }>;
 
 export const buildActualCiYamlFileContents: DatumInstanceTypeScriptConfigurationCollectionBuilder<{
@@ -37,6 +38,7 @@ export const buildActualCiYamlFileContents: DatumInstanceTypeScriptConfiguration
         filePath,
         stringContents,
       },
+      aliases: [],
     };
 
   return [outputConfiguration];

--- a/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/ciYamlFile/assertableCiYamlFile.ts
+++ b/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/ciYamlFile/assertableCiYamlFile.ts
@@ -21,6 +21,7 @@ export type AssertableCiYamlFileTypeScriptConfiguration =
     ];
     datumInstanceIdentifier: 'assertable-ci-yaml-file';
     datumInstance: AssertableCiYamlFile;
+    datumInstanceAliases: [];
   }>;
 
 export const buildAssertableCiYamlFileContentsConfiguration: DatumInstanceTypeScriptConfigurationCollectionBuilder<{
@@ -53,6 +54,7 @@ export const buildAssertableCiYamlFileContentsConfiguration: DatumInstanceTypeSc
         actualStringContents: actualCiYamlFile.stringContents,
         expectedStringContents: expectedText,
       },
+      aliases: [],
     };
 
   // TODO: move this to the generator-engine when we have one

--- a/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/ciYamlFile/expectedCiYamlFileContents.ts
+++ b/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/ciYamlFile/expectedCiYamlFileContents.ts
@@ -25,6 +25,7 @@ export type ExpectedCiYamlFileContentsTypeScriptConfiguration =
     ];
     datumInstanceIdentifier: 'expected-ci-yaml-file-contents';
     datumInstance: ExpectedCiYamlFileContents;
+    datumInstanceAliases: [];
   }>;
 
 export const buildExpectedCiYamlContents: DatumInstanceTypeScriptConfigurationCollectionBuilder<{
@@ -93,6 +94,7 @@ export const buildExpectedCiYamlContents: DatumInstanceTypeScriptConfigurationCo
           },
         },
       },
+      aliases: [],
     };
 
   return [outputConfiguration];

--- a/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/ciYamlFile/expectedCiYamlFileContentsConfiguration.ts
+++ b/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/ciYamlFile/expectedCiYamlFileContentsConfiguration.ts
@@ -22,6 +22,7 @@ export type ExpectedCiYamlFileContentsConfigurationTypeScriptConfiguration =
     ];
     datumInstanceIdentifier: 'expected-ci-yaml-file-contents-configuration';
     datumInstance: ExpectedCiYamlFileContentsConfiguration;
+    datumInstanceAliases: [];
   }>;
 
 const beforeCommentKey: CommentPlaceHolderKey = `COMMENT_PLACE_HOLDER:${'Pre-Package Steps'}`;
@@ -81,6 +82,7 @@ export const CI_YAML_FILE_CONTENTS_CONFIGURATION_TYPE_SCRIPT_CONFIGURATION: Expe
         },
       },
     },
+    datumInstanceAliases: [],
   };
 
 export const buildExpectedCiYamlFileContentsConfiguration: DatumInstanceTypeScriptConfigurationCollectionBuilder<{

--- a/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/file/fileA.ts
+++ b/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/file/fileA.ts
@@ -23,6 +23,8 @@ export type FileATypeScriptConfiguration =
     ];
     datumInstanceIdentifier: UnknownCollectionLocator;
     datumInstance: FileA;
+    // TODO: consider not using the semantics identifier since that could be confusing; and we don't want people to look up the semantics from an alias; they are indirectly related
+    datumInstanceAliases: [FileSemanticsIdentifier];
   }>;
 
 const accumulateFilePaths = (
@@ -93,6 +95,7 @@ export const buildFileATuple: DatumInstanceTypeScriptConfigurationCollectionBuil
           FileSemanticsIdentifier.A,
           fileSemanticsIdentifier,
         ],
+        aliases: [fileSemanticsIdentifier],
       };
     },
   );

--- a/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/file/typeScriptFile.ts
+++ b/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/file/typeScriptFile.ts
@@ -23,6 +23,7 @@ export type TypeScriptFileTypeScriptConfiguration =
     ];
     datumInstanceIdentifier: UnknownCollectionLocator;
     datumInstance: TypeScriptFile;
+    datumInstanceAliases: [FileSemanticsIdentifier.TypeScript];
   }>;
 
 export const buildTypeScriptFile: DatumInstanceTypeScriptConfigurationCollectionBuilder<{
@@ -41,6 +42,8 @@ export const buildTypeScriptFile: DatumInstanceTypeScriptConfigurationCollection
         FileSemanticsIdentifier.A,
         FileSemanticsIdentifier.TypeScript,
       ],
+      // TODO: figure out how to tie this alias to the one from FileA, so you can just do inputFileConfiguration.aliases
+      aliases: [FileSemanticsIdentifier.TypeScript],
     };
 
   return [outputConfiguration];

--- a/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/file/typeScriptFile.ts
+++ b/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/file/typeScriptFile.ts
@@ -18,8 +18,8 @@ export type TypeScriptFile = Merge<
 export type TypeScriptFileTypeScriptConfiguration =
   DatumInstanceTypeScriptConfiguration<{
     typeSemanticsIdentifiers: [
-      FileSemanticsIdentifier.A,
       FileSemanticsIdentifier.TypeScript,
+      FileSemanticsIdentifier.A,
     ];
     datumInstanceIdentifier: UnknownCollectionLocator;
     datumInstance: TypeScriptFile;
@@ -32,15 +32,15 @@ export const buildTypeScriptFile: DatumInstanceTypeScriptConfigurationCollection
 }> = (inputFileConfiguration) => {
   const outputConfiguration: DatumInstanceTypeScriptConfigurationToDatumInstanceConfiguration<TypeScriptFileTypeScriptConfiguration> =
     {
-      instanceIdentifier: `${Math.random()}`,
+      instanceIdentifier: `TS:${inputFileConfiguration.datumInstance.filePath}`,
       datumInstance: {
         fileSemanticsIdentifier: FileSemanticsIdentifier.TypeScript,
         filePath: inputFileConfiguration.datumInstance.filePath,
         ast: null,
       },
       predicateIdentifiers: [
-        FileSemanticsIdentifier.A,
         FileSemanticsIdentifier.TypeScript,
+        FileSemanticsIdentifier.A,
       ],
       // TODO: figure out how to tie this alias to the one from FileA, so you can just do inputFileConfiguration.aliases
       aliases: [FileSemanticsIdentifier.TypeScript],

--- a/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/packageDirectory/packageDirectoryASet.ts
+++ b/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/packageDirectory/packageDirectoryASet.ts
@@ -18,6 +18,7 @@ export type PackageDirectoryNameSetTypeScriptConfiguration =
     ];
     datumInstanceIdentifier: 'package-directory-name-set';
     datumInstance: PackageDirectoryNameSet;
+    datumInstanceAliases: [];
   }>;
 
 export const buildPackageDirectoryNameSet: DatumInstanceTypeScriptConfigurationCollectionBuilder<{
@@ -38,6 +39,7 @@ export const buildPackageDirectoryNameSet: DatumInstanceTypeScriptConfigurationC
       ],
       instanceIdentifier: 'package-directory-name-set',
       datumInstance: { directoryPaths },
+      aliases: [],
     };
 
   return [packageDirectoryNameSetConfiguration];

--- a/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/packageDirectory/packageDirectoryASetConfiguration.ts
+++ b/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/packageDirectory/packageDirectoryASetConfiguration.ts
@@ -16,6 +16,7 @@ export type PackageDirectoryNameSetConfigurationTypeScriptConfiguration =
     ];
     datumInstanceIdentifier: 'package-directory-name-set-configuration';
     datumInstance: PackageDirectoryNameSetConfiguration;
+    datumInstanceAliases: [];
   }>;
 
 export const PACKAGE_DIRECTORY_NAME_SET_CONFIGURATION_TYPE_SCRIPT_CONFIGURATION: PackageDirectoryNameSetConfigurationTypeScriptConfiguration =
@@ -27,6 +28,7 @@ export const PACKAGE_DIRECTORY_NAME_SET_CONFIGURATION_TYPE_SCRIPT_CONFIGURATION:
     datumInstance: {
       rootDirectoryRelativeToCurrentWorkingDirectory: 'packages',
     },
+    datumInstanceAliases: [],
   };
 
 export const buildPackageDirectoryNameSetConfiguration: DatumInstanceTypeScriptConfigurationCollectionBuilder<{

--- a/packages/open-schema-type-script/src/example/index.ts
+++ b/packages/open-schema-type-script/src/example/index.ts
@@ -136,8 +136,8 @@ const builderConfigurationCollection = [
     buildCollection: buildTypeScriptFile,
     inputPredicateLocatorTuple: [
       {
-        // TODO: handle aliases
-        instanceIdentifier: 'some-alias',
+        // TODO: rename "instanceIdentifier" to "instanceLocator"
+        instanceIdentifier: FileSemanticsIdentifier.TypeScript,
         predicateIdentifiers: [
           FileSemanticsIdentifier.A,
           FileSemanticsIdentifier.TypeScript,

--- a/packages/open-schema-type-script/src/type-script/datumInstanceTypeScriptConfiguration.ts
+++ b/packages/open-schema-type-script/src/type-script/datumInstanceTypeScriptConfiguration.ts
@@ -7,6 +7,7 @@ export type UnknownDatumInstanceTypeScriptConfiguration = {
   datumInstanceIdentifier: UnknownCollectionLocator;
   typeSemanticsIdentifiers: UnknownCollectionLocator[];
   datumInstance: UnknownDatumInstance;
+  datumInstanceAliases: UnknownCollectionLocator[];
 };
 
 export type UnknownDatumInstanceTypeScriptConfigurationTuple =
@@ -25,6 +26,7 @@ export type DatumInstanceTypeScriptConfigurationToDatumInstanceConfiguration<
   instanceIdentifier: T['datumInstanceIdentifier'];
   datumInstance: T['datumInstance'];
   predicateIdentifiers: T['typeSemanticsIdentifiers'];
+  aliases: T['datumInstanceAliases'];
 }>;
 
 export type DatumInstanceTypeScriptConfigurationTupleToDatumInstanceConfigurationTuple<
@@ -43,8 +45,10 @@ export const getDatumInstanceConfiguration = <
   typeSemanticsIdentifiers,
   datumInstanceIdentifier,
   datumInstance,
+  datumInstanceAliases,
 }: T): DatumInstanceTypeScriptConfigurationToDatumInstanceConfiguration<T> => ({
   predicateIdentifiers: typeSemanticsIdentifiers,
   instanceIdentifier: datumInstanceIdentifier,
   datumInstance,
+  aliases: datumInstanceAliases,
 });


### PR DESCRIPTION
Datum instance configuration builders can have zero, one, or more inputs. A builder with zero inputs is triggered at the beginning of the engine's lifecycle. Builders with one input can be triggered multiple times per input instance. Builders with multiple inputs can only be triggered once (this behavior is not finalized, but this constraint simplifies the implementation). 

A builder that expects one input can be configured with an alias locator which can locate a collection with more than one datum instance. In this scenario, we want to queue up the builder to trigger once per datum instance.