### PR TITLE
Add ASTs to TypeScript files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4866,7 +4866,7 @@
     "open-schema-type-script": {
       "version": "file:packages/open-schema-type-script",
       "requires": {
-        "yaml": "*"
+        "yaml": "^2.2.1"
       }
     },
     "optionator": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -384,13 +384,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.47.1",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.49.0.tgz",
+      "integrity": "sha512-veDlZN9mUhGqU31Qiv2qEp+XrJj5fgZpJ8PW30sHU+j/8/e5ruAhLaVDAeznS7A7i4ucb/s8IozpDtt9NqCkZg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.47.1",
-        "@typescript-eslint/types": "5.47.1",
-        "@typescript-eslint/typescript-estree": "5.47.1",
+        "@typescript-eslint/scope-manager": "5.49.0",
+        "@typescript-eslint/types": "5.49.0",
+        "@typescript-eslint/typescript-estree": "5.49.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -407,6 +408,80 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.49.0.tgz",
+      "integrity": "sha512-clpROBOiMIzpbWNxCe1xDK14uPZh35u4QaZO1GddilEzoCLAEz4szb51rBpdgurs5k2YzPtJeTEN3qVbG+LRUQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.49.0",
+        "@typescript-eslint/visitor-keys": "5.49.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.49.0.tgz",
+      "integrity": "sha512-7If46kusG+sSnEpu0yOz2xFv5nRz158nzEXnJFCGVEHWnuzolXKwrH5Bsf9zsNlOQkyZuk0BZKKoJQI+1JPBBg==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.49.0.tgz",
+      "integrity": "sha512-PBdx+V7deZT/3GjNYPVQv1Nc0U46dAHbIuOG8AZ3on3vuEKiPDwFE/lG1snN2eUB9IhF7EyF7K1hmTcLztNIsA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.49.0",
+        "@typescript-eslint/visitor-keys": "5.49.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.49.0.tgz",
+      "integrity": "sha512-v9jBMjpNWyn8B6k/Mjt6VbUS4J1GvUlR4x3Y+ibnP1z7y7V4n0WRz+50DY6+Myj0UaXVSuUlHohO+eZ8IJEnkg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.49.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -3336,6 +3411,9 @@
     "packages/open-schema-type-script": {
       "dependencies": {
         "yaml": "^2.2.1"
+      },
+      "devDependencies": {
+        "@typescript-eslint/parser": "^5.49.0"
       }
     },
     "packages/rat-test": {
@@ -3593,13 +3671,58 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.47.1",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.49.0.tgz",
+      "integrity": "sha512-veDlZN9mUhGqU31Qiv2qEp+XrJj5fgZpJ8PW30sHU+j/8/e5ruAhLaVDAeznS7A7i4ucb/s8IozpDtt9NqCkZg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.47.1",
-        "@typescript-eslint/types": "5.47.1",
-        "@typescript-eslint/typescript-estree": "5.47.1",
+        "@typescript-eslint/scope-manager": "5.49.0",
+        "@typescript-eslint/types": "5.49.0",
+        "@typescript-eslint/typescript-estree": "5.49.0",
         "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.49.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.49.0.tgz",
+          "integrity": "sha512-clpROBOiMIzpbWNxCe1xDK14uPZh35u4QaZO1GddilEzoCLAEz4szb51rBpdgurs5k2YzPtJeTEN3qVbG+LRUQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.49.0",
+            "@typescript-eslint/visitor-keys": "5.49.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.49.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.49.0.tgz",
+          "integrity": "sha512-7If46kusG+sSnEpu0yOz2xFv5nRz158nzEXnJFCGVEHWnuzolXKwrH5Bsf9zsNlOQkyZuk0BZKKoJQI+1JPBBg==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.49.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.49.0.tgz",
+          "integrity": "sha512-PBdx+V7deZT/3GjNYPVQv1Nc0U46dAHbIuOG8AZ3on3vuEKiPDwFE/lG1snN2eUB9IhF7EyF7K1hmTcLztNIsA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.49.0",
+            "@typescript-eslint/visitor-keys": "5.49.0",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.7",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.49.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.49.0.tgz",
+          "integrity": "sha512-v9jBMjpNWyn8B6k/Mjt6VbUS4J1GvUlR4x3Y+ibnP1z7y7V4n0WRz+50DY6+Myj0UaXVSuUlHohO+eZ8IJEnkg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.49.0",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        }
       }
     },
     "@typescript-eslint/scope-manager": {
@@ -4866,6 +4989,7 @@
     "open-schema-type-script": {
       "version": "file:packages/open-schema-type-script",
       "requires": {
+        "@typescript-eslint/parser": "*",
         "yaml": "^2.2.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Testing frameworks on testing frameworks",
   "private": true,
   "scripts": {
-    "open-schema-example": "npx ts-node packages/open-schema-type-script/src/example/index.ts",
+    "open-schema-example": "ts-node packages/open-schema-type-script/src/example/index.ts",
     "describe:repository": "npm run open-schema-example -- r",
     "lint:repository": "npm run open-schema-example -- v",
     "lint:ts:all": "npm run --silent lint:ts .",

--- a/packages/open-schema-type-script/package.json
+++ b/packages/open-schema-type-script/package.json
@@ -4,5 +4,8 @@
   },
   "dependencies": {
     "yaml": "^2.2.1"
+  },
+  "devDependencies": {
+    "@typescript-eslint/parser": "^5.49.0"
   }
 }

--- a/packages/open-schema-type-script/src/core/validation-engine/run.ts
+++ b/packages/open-schema-type-script/src/core/validation-engine/run.ts
@@ -39,10 +39,19 @@ export const run = ({
   const onDatumInstanceConfiguration: DatumHandler<
     UnknownDatumInstanceConfiguration
   > = (datumInstanceConfiguration) => {
-    const semanticsSet =
-      semanticsByDatumLocator.get(
-        datumInstanceConfiguration.instanceIdentifier,
-      ) ?? new Set();
+    const locators = [
+      datumInstanceConfiguration.instanceIdentifier,
+      ...datumInstanceConfiguration.aliases,
+    ];
+
+    const semanticsSet = new Set<UnknownDatumSemanticsConfiguration>();
+    locators.forEach((locator) => {
+      const nextSet = semanticsByDatumLocator.get(locator) ?? new Set();
+
+      [...nextSet].forEach((nextSemantics) => {
+        semanticsSet.add(nextSemantics);
+      });
+    });
 
     [...semanticsSet].forEach((semanticsConfiguraton) => {
       const result = semanticsConfiguraton.processDatum(

--- a/packages/open-schema-type-script/src/example/index.ts
+++ b/packages/open-schema-type-script/src/example/index.ts
@@ -35,6 +35,7 @@ import {
 import { TypeScriptSemanticsIdentifier as TestingPlatformSemanticsIds } from './datum-instance-type-script-configuration-definitions/testingPlatform/typeScriptSemanticsIdentifier';
 import {
   buildTypeScriptFile,
+  TypeScriptFile,
   TypeScriptFileTypeScriptConfiguration,
 } from './datum-instance-type-script-configuration-definitions/testingPlatform/file/typeScriptFile';
 import { FileSemanticsIdentifier } from './datum-instance-type-script-configuration-definitions/testingPlatform/file/file';
@@ -171,13 +172,33 @@ if (task === 'v') {
     builderConfigurationCollection,
     semanticsConfigurationCollection: [
       {
-        semanticsIdentifier: 'example',
+        semanticsIdentifier: 'example-1',
         collectionLocator: 'assertable-ci-yaml-file',
         processDatum: (instance: unknown): true => {
           const { actualStringContents, expectedStringContents } =
             instance as AssertableCiYamlFile;
 
           assert.strictEqual(actualStringContents, expectedStringContents);
+
+          return true;
+        },
+      },
+      // TODO: Update our datum instance configurations to link each TypeScript file to its tsconfig.json file
+      {
+        semanticsIdentifier: 'example-2',
+        // TODO: see? this is confusing because we're using a semantics identifier as a datum instance locator
+        collectionLocator: FileSemanticsIdentifier.TypeScript,
+        processDatum: (unknownInstance: unknown): boolean => {
+          const instance = unknownInstance as TypeScriptFile;
+
+          if (instance.ast instanceof Error) {
+            /* eslint-disable no-console */
+            console.log(instance.ast.message);
+            console.log(instance.ast.stack);
+            console.log({ ...instance.ast });
+            /* eslint-enable no-console */
+            return false;
+          }
 
           return true;
         },


### PR DESCRIPTION
The TypeScript files outside of the `open-schema-type-script` workspace are failing because we need to link them to your `tsconfig.json` file.