### PR TITLE
Separate datum instance configuration aliases from semantics

### DIFF
--- a/packages/open-schema-type-script/src/core/collectionLocator.ts
+++ b/packages/open-schema-type-script/src/core/collectionLocator.ts
@@ -2,4 +2,6 @@ import { UnknownString } from '../utilities/types/unknownHelpers';
 
 export type UnknownCollectionLocator = UnknownString;
 
+export type UnknownCollectionLocatorPart = UnknownString;
+
 export type UnknownCollectionLocatorTuple = readonly UnknownCollectionLocator[];

--- a/packages/open-schema-type-script/src/core/datumInstanceConfiguration.ts
+++ b/packages/open-schema-type-script/src/core/datumInstanceConfiguration.ts
@@ -21,10 +21,12 @@ export type UnknownDatumInstanceConfigurationTuple =
 
 export type NormalizedDatumInstancePredicateLocatorCollection<
   T extends UnknownDatumInstanceConfiguration,
-> = Pick<
-  DatumInstanceConfiguration<T>,
-  'instanceIdentifier' | 'predicateIdentifiers'
->;
+> = {
+  instanceIdentifier:
+    | DatumInstanceConfiguration<T>['instanceIdentifier']
+    | DatumInstanceConfiguration<T>['aliases'][number];
+  predicateIdentifiers: DatumInstanceConfiguration<T>['predicateIdentifiers'];
+};
 
 export type UnknownNormalizedDatumInstancePredicateLocatorCollection =
   NormalizedDatumInstancePredicateLocatorCollection<UnknownDatumInstanceConfiguration>;

--- a/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/file/file.ts
+++ b/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/file/file.ts
@@ -1,28 +1,22 @@
-export enum FileSemanticsIdentifier {
-  A = 'File:A',
-  TypeScript = 'File:TypeScript',
-  Json = 'File:Json',
-  Unknown = 'File:Unknown',
-}
+import { FileExtensionSemanticsIdentifier } from './fileExtensionSemanticsIdentifier';
 
-export type FileExtensionSemanticsIdentifier = Exclude<
-  FileSemanticsIdentifier,
-  FileSemanticsIdentifier.A
->;
-
-const extensionsByFileSemantics = {
-  [FileSemanticsIdentifier.Json]: '.json',
-  [FileSemanticsIdentifier.TypeScript]: '.ts',
-  [FileSemanticsIdentifier.Unknown]: '.:shrug:',
+const extensionsByFileExtensionSemanticsIdentifer = {
+  [FileExtensionSemanticsIdentifier.Json]: '.json',
+  [FileExtensionSemanticsIdentifier.TypeScript]: '.ts',
+  [FileExtensionSemanticsIdentifier.Unknown]: '.:shrug:',
 } satisfies Record<FileExtensionSemanticsIdentifier, string>;
 
 // TODO: make a util for swapping keys and values
-export const fileSemanticsByExtension = Object.fromEntries(
-  Object.entries(extensionsByFileSemantics).map(([k, v]) => [v, k]),
+export const fileExtensionSemanticsIdentifiersByExtension = Object.fromEntries(
+  Object.entries(extensionsByFileExtensionSemanticsIdentifer).map(([k, v]) => [
+    v,
+    k,
+  ]),
 ) as Record<string, FileExtensionSemanticsIdentifier>;
 
-export type File<T extends FileSemanticsIdentifier = FileSemanticsIdentifier> =
-  {
-    filePath: string;
-    fileSemanticsIdentifier: T;
-  };
+export type File<
+  TFileExtensionSemanticsIdentifier extends FileExtensionSemanticsIdentifier = FileExtensionSemanticsIdentifier,
+> = {
+  filePath: string;
+  fileExtensionSemanticsIdentifier: TFileExtensionSemanticsIdentifier;
+};

--- a/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/file/fileA.ts
+++ b/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/file/fileA.ts
@@ -1,30 +1,30 @@
 import fs from 'fs';
 import { posix } from 'path';
-import { UnknownCollectionLocator } from '../../../../core/collectionLocator';
+import { UnknownCollectionLocatorPart } from '../../../../core/collectionLocator';
 import {
   DatumInstanceTypeScriptConfiguration,
   DatumInstanceTypeScriptConfigurationToDatumInstanceConfiguration,
 } from '../../../../type-script/datumInstanceTypeScriptConfiguration';
 import { DatumInstanceTypeScriptConfigurationCollectionBuilder } from '../../../../type-script/datumInstanceTypeScriptConfigurationCollectionBuilder';
-import {
-  File,
-  FileSemanticsIdentifier,
-  fileSemanticsByExtension,
-  FileExtensionSemanticsIdentifier,
-} from './file';
+import { File, fileExtensionSemanticsIdentifiersByExtension } from './file';
+import { FileExtensionSemanticsIdentifier } from './fileExtensionSemanticsIdentifier';
+import { FileTypeScriptSemanticsIdentifier } from './fileTypeScriptSemanticsIdentifier';
 
 export type FileA = File;
 
+export type FileADatumInstanceIdentifier =
+  `${FileTypeScriptSemanticsIdentifier.FileA}:${UnknownCollectionLocatorPart}`;
+
+export type FileADatumInstanceAlias =
+  `${FileExtensionSemanticsIdentifier}:${FileTypeScriptSemanticsIdentifier.FileA}`;
+
 export type FileATypeScriptConfiguration =
   DatumInstanceTypeScriptConfiguration<{
-    typeSemanticsIdentifiers: [
-      FileSemanticsIdentifier.A,
-      FileExtensionSemanticsIdentifier,
-    ];
-    datumInstanceIdentifier: UnknownCollectionLocator;
+    typeSemanticsIdentifiers: [FileTypeScriptSemanticsIdentifier.FileA];
+    datumInstanceIdentifier: FileADatumInstanceIdentifier;
     datumInstance: FileA;
     // TODO: consider not using the semantics identifier since that could be confusing; and we don't want people to look up the semantics from an alias; they are indirectly related
-    datumInstanceAliases: [FileSemanticsIdentifier];
+    datumInstanceAliases: [FileADatumInstanceAlias];
   }>;
 
 const accumulateFilePaths = (
@@ -82,20 +82,20 @@ export const buildFileATuple: DatumInstanceTypeScriptConfigurationCollectionBuil
       const extension = posix.extname(filePath);
 
       // TODO: encapsulate this default behavior in a function
-      const fileSemanticsIdentifier =
-        fileSemanticsByExtension[extension] ?? FileSemanticsIdentifier.Unknown;
+      const fileExtensionSemanticsIdentifier =
+        fileExtensionSemanticsIdentifiersByExtension[extension] ??
+        FileExtensionSemanticsIdentifier.Unknown;
+
+      const alias: FileADatumInstanceAlias = `${fileExtensionSemanticsIdentifier}:${FileTypeScriptSemanticsIdentifier.FileA}`;
 
       return {
-        instanceIdentifier: filePath,
+        instanceIdentifier: `${FileTypeScriptSemanticsIdentifier.FileA}:${filePath}`,
         datumInstance: {
           filePath,
-          fileSemanticsIdentifier,
+          fileExtensionSemanticsIdentifier,
         },
-        predicateIdentifiers: [
-          FileSemanticsIdentifier.A,
-          fileSemanticsIdentifier,
-        ],
-        aliases: [fileSemanticsIdentifier],
+        predicateIdentifiers: [FileTypeScriptSemanticsIdentifier.FileA],
+        aliases: [alias],
       };
     },
   );

--- a/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/file/fileExtensionSemanticsIdentifier.ts
+++ b/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/file/fileExtensionSemanticsIdentifier.ts
@@ -1,0 +1,5 @@
+export enum FileExtensionSemanticsIdentifier {
+  TypeScript = 'FileExtension=TypeScript',
+  Json = 'FileExtension=Json',
+  Unknown = 'FileExtension=Unknown',
+}

--- a/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/file/fileTypeScriptSemanticsIdentifier.ts
+++ b/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/file/fileTypeScriptSemanticsIdentifier.ts
@@ -1,0 +1,4 @@
+export enum FileTypeScriptSemanticsIdentifier {
+  FileA = 'TypeScriptType=FileA',
+  TypeScriptFileA = 'TypeScriptType=TypeScriptFileA',
+}

--- a/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/file/typeScriptFile.ts
+++ b/packages/open-schema-type-script/src/example/datum-instance-type-script-configuration-definitions/testingPlatform/file/typeScriptFile.ts
@@ -2,18 +2,23 @@ import * as parser from '@typescript-eslint/typescript-estree';
 import type { TSESTree } from '@typescript-eslint/types';
 import fs from 'fs';
 import { posix } from 'path';
-import { UnknownCollectionLocator } from '../../../../core/collectionLocator';
+import {
+  UnknownCollectionLocator,
+  UnknownCollectionLocatorPart,
+} from '../../../../core/collectionLocator';
 import {
   DatumInstanceTypeScriptConfiguration,
   DatumInstanceTypeScriptConfigurationToDatumInstanceConfiguration,
 } from '../../../../type-script/datumInstanceTypeScriptConfiguration';
 import { DatumInstanceTypeScriptConfigurationCollectionBuilder } from '../../../../type-script/datumInstanceTypeScriptConfigurationCollectionBuilder';
 import { Merge } from '../../../../utilities/types/merge/merge';
-import { File, FileSemanticsIdentifier } from './file';
+import { File } from './file';
 import { FileATypeScriptConfiguration } from './fileA';
+import { FileTypeScriptSemanticsIdentifier } from './fileTypeScriptSemanticsIdentifier';
+import { FileExtensionSemanticsIdentifier } from './fileExtensionSemanticsIdentifier';
 
 export type TypeScriptFile = Merge<
-  File<FileSemanticsIdentifier.TypeScript>,
+  File<FileExtensionSemanticsIdentifier.TypeScript>,
   {
     ast: TSESTree.Program | Error;
     configFilePath: string;
@@ -21,15 +26,20 @@ export type TypeScriptFile = Merge<
   }
 >;
 
+export type TypeScriptFileADatumInstanceIdentifier =
+  `${FileTypeScriptSemanticsIdentifier.TypeScriptFileA}:${UnknownCollectionLocatorPart}`;
+
+export type TypeScriptFileADatumInstancAlias =
+  `${FileExtensionSemanticsIdentifier.TypeScript}:${FileTypeScriptSemanticsIdentifier.TypeScriptFileA}`;
+
 export type TypeScriptFileTypeScriptConfiguration =
   DatumInstanceTypeScriptConfiguration<{
     typeSemanticsIdentifiers: [
-      FileSemanticsIdentifier.TypeScript,
-      FileSemanticsIdentifier.A,
+      FileTypeScriptSemanticsIdentifier.TypeScriptFileA,
     ];
     datumInstanceIdentifier: UnknownCollectionLocator;
     datumInstance: TypeScriptFile;
-    datumInstanceAliases: [FileSemanticsIdentifier.TypeScript];
+    datumInstanceAliases: [TypeScriptFileADatumInstancAlias];
   }>;
 
 const getConfigFilePath = (filePath: string): string => {
@@ -74,22 +84,21 @@ export const buildTypeScriptFile: DatumInstanceTypeScriptConfigurationCollection
     throw error;
   }
 
+  const alias: TypeScriptFileADatumInstancAlias = `${FileExtensionSemanticsIdentifier.TypeScript}:${FileTypeScriptSemanticsIdentifier.TypeScriptFileA}`;
+
   const outputConfiguration: DatumInstanceTypeScriptConfigurationToDatumInstanceConfiguration<TypeScriptFileTypeScriptConfiguration> =
     {
-      instanceIdentifier: `TS:${filePath}`,
+      instanceIdentifier: `${FileTypeScriptSemanticsIdentifier.TypeScriptFileA}:${filePath}`,
       datumInstance: {
-        fileSemanticsIdentifier: FileSemanticsIdentifier.TypeScript,
+        fileExtensionSemanticsIdentifier:
+          FileExtensionSemanticsIdentifier.TypeScript,
         filePath,
         configFilePath,
         ast,
         tsconfigRootDir,
       },
-      predicateIdentifiers: [
-        FileSemanticsIdentifier.TypeScript,
-        FileSemanticsIdentifier.A,
-      ],
-      // TODO: figure out how to tie this alias to the one from FileA, so you can just do inputFileConfiguration.aliases
-      aliases: [FileSemanticsIdentifier.TypeScript],
+      predicateIdentifiers: [FileTypeScriptSemanticsIdentifier.TypeScriptFileA],
+      aliases: [alias],
     };
 
   return [outputConfiguration];

--- a/packages/open-schema-type-script/src/example/index.ts
+++ b/packages/open-schema-type-script/src/example/index.ts
@@ -38,7 +38,8 @@ import {
   TypeScriptFile,
   TypeScriptFileTypeScriptConfiguration,
 } from './datum-instance-type-script-configuration-definitions/testingPlatform/file/typeScriptFile';
-import { FileSemanticsIdentifier } from './datum-instance-type-script-configuration-definitions/testingPlatform/file/file';
+import { FileTypeScriptSemanticsIdentifier } from './datum-instance-type-script-configuration-definitions/testingPlatform/file/fileTypeScriptSemanticsIdentifier';
+import { FileExtensionSemanticsIdentifier } from './datum-instance-type-script-configuration-definitions/testingPlatform/file/fileExtensionSemanticsIdentifier';
 
 const builderConfigurationCollection = [
   buildBuilderConfiguration<{
@@ -138,11 +139,8 @@ const builderConfigurationCollection = [
     inputPredicateLocatorTuple: [
       {
         // TODO: rename "instanceIdentifier" to "instanceLocator"
-        instanceIdentifier: FileSemanticsIdentifier.TypeScript,
-        predicateIdentifiers: [
-          FileSemanticsIdentifier.A,
-          FileSemanticsIdentifier.TypeScript,
-        ],
+        instanceIdentifier: `${FileExtensionSemanticsIdentifier.TypeScript}:${FileTypeScriptSemanticsIdentifier.FileA}`,
+        predicateIdentifiers: [FileTypeScriptSemanticsIdentifier.FileA],
       },
     ],
   }),
@@ -185,8 +183,7 @@ if (task === 'v') {
       },
       {
         semanticsIdentifier: 'example-2',
-        // TODO: see? this is confusing because we're using a semantics identifier as a datum instance locator
-        collectionLocator: FileSemanticsIdentifier.TypeScript,
+        collectionLocator: `${FileExtensionSemanticsIdentifier.TypeScript}:${FileTypeScriptSemanticsIdentifier.TypeScriptFileA}`,
         processDatum: (unknownInstance: unknown): true => {
           const instance = unknownInstance as TypeScriptFile;
 


### PR DESCRIPTION
Aliases can point to a collection of datum instance configurations that have the same semantics. Aliases can be easy to understand when they are composed of a series of semantics (ex: corresponds to a file, corresponds to a markdown file, is a TypeScript data structure for a markdown file). However mistaking an alias (a collection locator) for a semantics identifier (also a collection locator) can lead to confusion. That is, we should strive to maintain the semantics of open-schema itself.