### PR TITLE
Rename Gipp to Gepp

### DIFF
--- a/packages/open-schema-type-script/README.md
+++ b/packages/open-schema-type-script/README.md
@@ -98,15 +98,15 @@ S2 --> S3
 #### Voictents and the Tabilly
 
 - A Voictent is an implementation of a "stream"
-- The Engine has a Tabilly which is an index of Voictents by Gipp
+- The Engine has a Tabilly which is an index of Voictents by Gepp
 
-#### Gipps
+#### Gepps
 
-- A Gipp allows the Engine to find a Voictent for various needs
-  - A Quirm contains multiple Gipps and a Hubblepup
-  - An Estinant contains a Gipp and a Tropoignant
-- Quirms allow the Engine to add a Hubblepup to multiple Voictents based on the Quirm's Gipps
-- Estinants allow the Engine to feed a Voictent into a Tropoignant based on the Estinant's Gipp
+- A Gepp allows the Engine to find a Voictent for various needs
+  - A Quirm contains multiple Gepps and a Hubblepup
+  - An Estinant contains a Gepp and a Tropoignant
+- Quirms allow the Engine to add a Hubblepup to multiple Voictents based on the Quirm's Gepps
+- Estinants allow the Engine to feed a Voictent into a Tropoignant based on the Estinant's Gepp
 
 #### Lanbes
 
@@ -163,15 +163,15 @@ state E {
 sequenceDiagram
   participant P as Concrete Programmer
   participant E as Engine
-  participant T as Tabilly <br> (Map<Gipp, Voictent>)
+  participant T as Tabilly <br> (Map<Gepp, Voictent>)
   participant V as Voictent
 
   P ->> E: estinant
-  E ->> T: estinant.inputGipp
-  T ->> T: lookup Voictent by Gipp
+  E ->> T: estinant.inputGepp
+  T ->> T: lookup Voictent by Gepp
 
   alt Voictent does not exist
-    T ->> T: Initialize and cache <br> the Voictent by Gipp
+    T ->> T: Initialize and cache <br> the Voictent by Gepp
   end
 
   T ->> E: Voictent
@@ -186,17 +186,17 @@ sequenceDiagram
 sequenceDiagram
   participant P as Concrete Programmer
   participant E as Engine
-  participant T as Tabilly <br> (Map<Gipp, Voictent>)
+  participant T as Tabilly <br> (Map<Gepp, Voictent>)
   participant V as Voictent
 
   P ->> E: quirm
 
-  loop for each Gipp in quirm.gipps
-    E ->> T: lookup Voictent by Gipp
+  loop for each Gepp in quirm.gepps
+    E ->> T: lookup Voictent by Gepp
   end
 
   alt Voictent does not exist
-    T ->> T: Initialize and cache <br> the Voictent by Gipp
+    T ->> T: Initialize and cache <br> the Voictent by Gepp
   end
 
   T ->> E: Voictent

--- a/packages/open-schema-type-script/src/core/digikikify.ts
+++ b/packages/open-schema-type-script/src/core/digikikify.ts
@@ -38,7 +38,7 @@ export const digikikify = ({
   });
 
   const platomities = estinantTuple.map<Platomity>((estinant) => {
-    const voictent = tabilly.getOrInstantiateAndGetVoictent(estinant.inputGipp);
+    const voictent = tabilly.getOrInstantiateAndGetVoictent(estinant.inputGepp);
 
     // TODO: consider using an estinant identifier instead of the tropoignant name
     const lanbe = voictent.createPointer(estinant.tropoignant.name);
@@ -83,7 +83,7 @@ export const digikikify = ({
           eventName: EngineEventName.OnEstinantResult,
           data: {
             tropoignantName: platomity.estinant.tropoignant.name,
-            inputGipp: platomity.estinant.inputGipp,
+            inputGepp: platomity.estinant.inputGepp,
             inputs: [inputHubblepup],
             outputs: outputQuirmTuple,
           },

--- a/packages/open-schema-type-script/src/core/estinant.ts
+++ b/packages/open-schema-type-script/src/core/estinant.ts
@@ -1,18 +1,18 @@
-import { Gipp } from './gipp';
+import { Gepp } from './gepp';
 import { Hubblepup } from './hubblepup';
 import { QuirmTuple } from './quirm';
 import { Tropoignant } from './tropoignant';
 
 /**
  * One of the two programmable units of the Engine (see Quirm).
- * It allows the Progammer to register a Tropoignant to a Voictent via a Gipp.
+ * It allows the Progammer to register a Tropoignant to a Voictent via a Gepp.
  */
 export type Estinant<
   TInputHubblepup extends Hubblepup = Hubblepup,
   TOutputQuirmTuple extends QuirmTuple = QuirmTuple,
 > = {
   tropoignant: Tropoignant<TInputHubblepup, TOutputQuirmTuple>;
-  inputGipp: Gipp;
+  inputGepp: Gepp;
 };
 
 export type EstinantTuple<

--- a/packages/open-schema-type-script/src/core/gepp.ts
+++ b/packages/open-schema-type-script/src/core/gepp.ts
@@ -1,4 +1,4 @@
 /**
  * The thing that is used to find a Voictent of Quirms
  */
-export type Gipp = string;
+export type Gepp = string;

--- a/packages/open-schema-type-script/src/core/quirm.ts
+++ b/packages/open-schema-type-script/src/core/quirm.ts
@@ -1,17 +1,17 @@
-import { Gipp } from './gipp';
+import { Gepp } from './gepp';
 import { Hubblepup } from './hubblepup';
 
 /**
  * One of the two programmable units of the Engine (see Estinant). It allows the Concrete Programmer to register
- * a Hubblepup to zero or more Voictents via Gipps.
+ * a Hubblepup to zero or more Voictents via Gepps.
  *
- * Note: I currently don't have a use case for defining zero Gipps, but that's irrelevent to the Engine
+ * Note: I currently don't have a use case for defining zero Gepps, but that's irrelevent to the Engine
  */
 export type Quirm<
   THubblepup extends Hubblepup = Hubblepup,
-  TGippTuple extends Gipp[] = Gipp[],
+  TGeppTuple extends Gepp[] = Gepp[],
 > = {
-  gippTuple: TGippTuple;
+  geppTuple: TGeppTuple;
   hubblepup: THubblepup;
 };
 

--- a/packages/open-schema-type-script/src/core/tabilly.ts
+++ b/packages/open-schema-type-script/src/core/tabilly.ts
@@ -1,61 +1,61 @@
-import { Gipp } from './gipp';
+import { Gepp } from './gepp';
 import { Quirm, QuirmTuple } from './quirm';
 import { Voictent, VoictentDebugData } from './voictent';
 
 export type TabillyDebugData = {
-  gipp: Gipp;
+  gepp: Gepp;
   voictent: VoictentDebugData<Quirm>;
 }[];
 
 /**
- * A cache of Voictents by Gipp.
+ * A cache of Voictents by Gepp.
  * The engine uses this to connect Tropoignant's to their input Voictents,
  * and to add Quirms to their corresponding Voictents.
  */
-export class Tabilly extends Map<Gipp, Voictent<Quirm>> {
+export class Tabilly extends Map<Gepp, Voictent<Quirm>> {
   /**
-   * Gets a Voictent cached by a Gipp.
+   * Gets a Voictent cached by a Gepp.
    *
-   * @modifies the cache of Voictents with a new Voictent if one does not already exist for the given gipp
-   * @param gipp the key of the Voictent to get
+   * @modifies the cache of Voictents with a new Voictent if one does not already exist for the given gepp
+   * @param gepp the key of the Voictent to get
    * @returns the cached Voictent or a new Voictent
    */
-  getOrInstantiateAndGetVoictent(gipp: Gipp): Voictent<Quirm> {
-    let voictent = this.get(gipp);
+  getOrInstantiateAndGetVoictent(gepp: Gepp): Voictent<Quirm> {
+    let voictent = this.get(gepp);
 
     if (voictent === undefined) {
       voictent = new Voictent();
-      this.set(gipp, voictent);
+      this.set(gepp, voictent);
     }
 
     return voictent;
   }
 
   addQuirmsToVoictents(quirmTuple: QuirmTuple): void {
-    const quirmAndGippPairs = quirmTuple.flatMap((quirm) => {
-      return quirm.gippTuple.map((gipp) => {
+    const quirmAndGeppPairs = quirmTuple.flatMap((quirm) => {
+      return quirm.geppTuple.map((gepp) => {
         return {
           quirm,
-          gipp,
+          gepp,
         };
       });
     });
 
-    quirmAndGippPairs.forEach(({ quirm, gipp }) => {
-      this.addQuirmByGipp(quirm, gipp);
+    quirmAndGeppPairs.forEach(({ quirm, gepp }) => {
+      this.addQuirmByGepp(quirm, gepp);
     });
   }
 
-  private addQuirmByGipp(quirm: Quirm, gipp: Gipp): void {
-    const voictent = this.getOrInstantiateAndGetVoictent(gipp);
+  private addQuirmByGepp(quirm: Quirm, gepp: Gepp): void {
+    const voictent = this.getOrInstantiateAndGetVoictent(gepp);
     voictent.addStraline(quirm);
-    this.set(gipp, voictent);
+    this.set(gepp, voictent);
   }
 
   get debugData(): TabillyDebugData {
-    return [...this.entries()].map(([gipp, voictent]) => {
+    return [...this.entries()].map(([gepp, voictent]) => {
       return {
-        gipp,
+        gepp,
         voictent: voictent.debugData,
       };
     });

--- a/packages/open-schema-type-script/src/core/yek.ts
+++ b/packages/open-schema-type-script/src/core/yek.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import { posix } from 'path';
 import { JsonObject, JsonString } from '../utilities/json';
 import { logger } from '../utilities/logger';
-import { Gipp } from './gipp';
+import { Gepp } from './gepp';
 import { Hubblepup } from './hubblepup';
 import { QuirmTuple } from './quirm';
 import { TabillyDebugData } from './tabilly';
@@ -37,7 +37,7 @@ export type OnEstinantResultEvent = Event<
   EngineEventName.OnEstinantResult,
   {
     tropoignantName: JsonString;
-    inputGipp: Gipp;
+    inputGepp: Gepp;
     inputs: Hubblepup[];
     outputs: QuirmTuple;
   }

--- a/packages/open-schema-type-script/src/example/file/fileA.ts
+++ b/packages/open-schema-type-script/src/example/file/fileA.ts
@@ -12,7 +12,7 @@ import { Grition } from '../core/grition';
 import { Odeshin } from '../core/odeshin';
 import {
   FileAConfigurationOdeshin,
-  FILE_A_CONFIGURATION_GIPP,
+  FILE_A_CONFIGURATION_GEPP,
 } from './fileAConfiguration';
 
 export type FileA = Grition<File<FileExtensionSuffixIdentifier, JsonNull>>;
@@ -45,13 +45,13 @@ const partsToPascal = (x: string[]): string => {
     .join('');
 };
 
-export const FILE_A_GIPP = 'file-a';
+export const FILE_A_GEPP = 'file-a';
 
 export const fileAEstinant: Estinant<
   FileAConfigurationOdeshin,
   FileAQuirmTuple
 > = {
-  inputGipp: FILE_A_CONFIGURATION_GIPP,
+  inputGepp: FILE_A_CONFIGURATION_GEPP,
   tropoignant: function buildFileA(inputOdeshin) {
     const filePaths = getNestedFilePaths(inputOdeshin.grition);
 
@@ -84,7 +84,7 @@ export const fileAEstinant: Estinant<
       const identifier: FileAIdentifier = `file-a:${filePath}`;
 
       return {
-        gippTuple: [FILE_A_GIPP],
+        geppTuple: [FILE_A_GEPP],
         hubblepup: {
           identifier,
           grition,

--- a/packages/open-schema-type-script/src/example/file/fileAConfiguration.ts
+++ b/packages/open-schema-type-script/src/example/file/fileAConfiguration.ts
@@ -20,10 +20,10 @@ export type FileAConfigurationOdeshin = Odeshin<
 
 export type FileAConfigurationQuirm = Quirm<FileAConfigurationOdeshin>;
 
-export const FILE_A_CONFIGURATION_GIPP = FILE_A_CONFIGURATION_IDENTIFIER;
+export const FILE_A_CONFIGURATION_GEPP = FILE_A_CONFIGURATION_IDENTIFIER;
 
 export const FULL_FILE_A_CONFIGURATION_QUIRM: FileAConfigurationQuirm = {
-  gippTuple: [FILE_A_CONFIGURATION_GIPP],
+  geppTuple: [FILE_A_CONFIGURATION_GEPP],
   hubblepup: {
     identifier: FILE_A_CONFIGURATION_IDENTIFIER,
     grition: {
@@ -47,7 +47,7 @@ export const FULL_FILE_A_CONFIGURATION_QUIRM: FileAConfigurationQuirm = {
 };
 
 export const SIMPLE_FILE_A_CONFIGURATION_QUIRM: FileAConfigurationQuirm = {
-  gippTuple: [FILE_A_CONFIGURATION_GIPP],
+  geppTuple: [FILE_A_CONFIGURATION_GEPP],
   hubblepup: {
     identifier: FILE_A_CONFIGURATION_IDENTIFIER,
     grition: {

--- a/packages/open-schema-type-script/src/example/file/fileAHasKnownExtensionSuffix.ts
+++ b/packages/open-schema-type-script/src/example/file/fileAHasKnownExtensionSuffix.ts
@@ -3,9 +3,9 @@ import { Validation, ValidationEstinant } from '../validation/validation';
 import {
   ValidationResultOdeshin,
   ValidationResultQuirm,
-  VALIDATION_RESULT_GIPP,
+  VALIDATION_RESULT_GEPP,
 } from '../validation/validationResult';
-import { FileAOdeshin, FILE_A_GIPP } from './fileA';
+import { FileAOdeshin, FILE_A_GEPP } from './fileA';
 
 export const fileAHasKnownExtensionSuffix: Validation<FileAOdeshin> = (
   inputOdeshin,
@@ -22,7 +22,7 @@ export const fileAHasKnownExtensionSuffix: Validation<FileAOdeshin> = (
   };
 
   const outputQuirm: ValidationResultQuirm = {
-    gippTuple: [VALIDATION_RESULT_GIPP],
+    geppTuple: [VALIDATION_RESULT_GEPP],
     hubblepup,
   };
 
@@ -31,6 +31,6 @@ export const fileAHasKnownExtensionSuffix: Validation<FileAOdeshin> = (
 
 export const fileAHasKnownExtensionSuffixEstinant: ValidationEstinant<FileAOdeshin> =
   {
-    inputGipp: FILE_A_GIPP,
+    inputGepp: FILE_A_GEPP,
     tropoignant: fileAHasKnownExtensionSuffix,
   };

--- a/packages/open-schema-type-script/src/example/index.ts
+++ b/packages/open-schema-type-script/src/example/index.ts
@@ -1,6 +1,6 @@
 import { digikikify } from '../core/digikikify';
 import { Estinant } from '../core/estinant';
-import { Gipp } from '../core/gipp';
+import { Gepp } from '../core/gepp';
 import { Quirm, QuirmTuple } from '../core/quirm';
 import { JsonString } from '../utilities/json';
 import { blindCastEstinants } from './blindCastEstinants';
@@ -8,28 +8,28 @@ import { fileAEstinant } from './file/fileA';
 import { SIMPLE_FILE_A_CONFIGURATION_QUIRM } from './file/fileAConfiguration';
 import { fileAHasKnownExtensionSuffixEstinant } from './file/fileAHasKnownExtensionSuffix';
 
-const myGippA: Gipp = 'example-1';
-const myGippB: Gipp = 'example-2';
-const myGippC: Gipp = 'example-3';
-const myGippHello: Gipp = 'example-hello';
-const myGippGoodbye: Gipp = 'example-goodbye';
+const myGeppA: Gepp = 'example-1';
+const myGeppB: Gepp = 'example-2';
+const myGeppC: Gepp = 'example-3';
+const myGeppHello: Gepp = 'example-hello';
+const myGeppGoodbye: Gepp = 'example-goodbye';
 
 const myQuirm1: Quirm<JsonString> = {
-  gippTuple: [myGippA, myGippB],
+  geppTuple: [myGeppA, myGeppB],
   hubblepup: 'myself!',
 };
 
 const myQuirm2: Quirm<JsonString> = {
-  gippTuple: [myGippA, myGippC],
+  geppTuple: [myGeppA, myGeppC],
   hubblepup: 'someone else',
 };
 
 const myEstinant1: Estinant<JsonString, QuirmTuple<JsonString>> = {
-  inputGipp: myGippA,
+  inputGepp: myGeppA,
   tropoignant: function sayHello(input) {
     return [
       {
-        gippTuple: [myGippHello],
+        geppTuple: [myGeppHello],
         hubblepup: `Hello ${input}`,
       },
     ];
@@ -37,11 +37,11 @@ const myEstinant1: Estinant<JsonString, QuirmTuple<JsonString>> = {
 };
 
 const myEstinant2: Estinant<JsonString, QuirmTuple<JsonString>> = {
-  inputGipp: myGippC,
+  inputGepp: myGeppC,
   tropoignant: function sayGoodbye(input) {
     return [
       {
-        gippTuple: [myGippGoodbye],
+        geppTuple: [myGeppGoodbye],
         hubblepup: `Goodbye ${input}`,
       },
     ];

--- a/packages/open-schema-type-script/src/example/validation/validationResult.ts
+++ b/packages/open-schema-type-script/src/example/validation/validationResult.ts
@@ -15,11 +15,11 @@ export type ValidationResultOdeshin = Odeshin<
   ValidationResult
 >;
 
-export const VALIDATION_RESULT_GIPP = 'validation-result';
+export const VALIDATION_RESULT_GEPP = 'validation-result';
 
-export type ValidationResultGipp = typeof VALIDATION_RESULT_GIPP;
+export type ValidationResultGepp = typeof VALIDATION_RESULT_GEPP;
 
 export type ValidationResultQuirm = Quirm<
   ValidationResultOdeshin,
-  [ValidationResultGipp]
+  [ValidationResultGepp]
 >;


### PR DESCRIPTION
It has come to my attention that Gipp can be pronounced in multiple ways like "gif" and "gif", and some of those ways mean things that are not very nice.