### PR TITLE
Add Mentursections to filter and split streams

### DIFF
--- a/packages/open-schema-type-script/src/core/digikikify.ts
+++ b/packages/open-schema-type-script/src/core/digikikify.ts
@@ -87,6 +87,18 @@ export const digikikify = ({
       case TropoignantTypeName.Wortinator:
         platomity.estinant.tropoignant.process(inputHubblepup);
         break;
+      case TropoignantTypeName.Mentursection: {
+        const additionalGepps =
+          platomity.estinant.tropoignant.process(inputHubblepup);
+
+        // TODO: evaluate the repercussions of mutating this state
+        nextQuirm.geppTuple.push(...additionalGepps);
+
+        additionalGepps.forEach((nextGepp) => {
+          tabilly.addQuirmByGepp(nextQuirm, nextGepp);
+        });
+        break;
+      }
     }
 
     if (outputQuirmTuple !== NULL_STRALINE) {

--- a/packages/open-schema-type-script/src/core/estinant.ts
+++ b/packages/open-schema-type-script/src/core/estinant.ts
@@ -1,7 +1,7 @@
 import { Gepp } from './gepp';
 import { Hubblepup } from './hubblepup';
 import { QuirmTuple } from './quirm';
-import { Onama, Tropoignant, Wortinator } from './tropoignant';
+import { Mentursection, Onama, Tropoignant, Wortinator } from './tropoignant';
 
 type BaseEstinant<
   TInputHubblepup extends Hubblepup,
@@ -24,6 +24,10 @@ export type OnamaEstinant<
 export type WortinatorEstinant<TInputHubblepup extends Hubblepup = Hubblepup> =
   BaseEstinant<TInputHubblepup, [], Wortinator<TInputHubblepup>>;
 
+export type MentursectionEstinant<
+  TInputHubblepup extends Hubblepup = Hubblepup,
+> = BaseEstinant<TInputHubblepup, [], Mentursection<TInputHubblepup>>;
+
 /**
  * One of the two programmable units of the Engine (see Quirm).
  * It allows the Progammer to register a Tropoignant to a Voictent via a Gepp.
@@ -33,7 +37,8 @@ export type Estinant<
   TOutputQuirmTuple extends QuirmTuple = QuirmTuple,
 > =
   | OnamaEstinant<TInputHubblepup, TOutputQuirmTuple>
-  | WortinatorEstinant<TInputHubblepup>;
+  | WortinatorEstinant<TInputHubblepup>
+  | MentursectionEstinant<TInputHubblepup>;
 
 export type EstinantTuple<
   TInputHubblepup extends Hubblepup = Hubblepup,

--- a/packages/open-schema-type-script/src/core/tabilly.ts
+++ b/packages/open-schema-type-script/src/core/tabilly.ts
@@ -41,7 +41,7 @@ export class Tabilly extends Map<Gepp, Voictent<Quirm>> {
     });
   }
 
-  private addQuirmByGepp(quirm: Quirm, gepp: Gepp): void {
+  addQuirmByGepp(quirm: Quirm, gepp: Gepp): void {
     const voictent = this.getOrInstantiateAndGetVoictent(gepp);
     voictent.addStraline(quirm);
     this.set(gepp, voictent);

--- a/packages/open-schema-type-script/src/core/tropoignant.ts
+++ b/packages/open-schema-type-script/src/core/tropoignant.ts
@@ -1,9 +1,11 @@
+import { GeppTuple } from './gepp';
 import { Hubblepup } from './hubblepup';
 import { QuirmTuple } from './quirm';
 
 export enum TropoignantTypeName {
   Onama = 'Onama',
   Wortinator = 'Wortinator',
+  Mentursection = 'Mentursection',
 }
 
 type BaseTropoignant<
@@ -38,9 +40,21 @@ export type Wortinator<TInputHubblepup extends Hubblepup = Hubblepup> =
   >;
 
 /**
+ * A Tropoignant that applies zero or more additional Gepps to a Quirm
+ */
+export type Mentursection<TInputHubblepup extends Hubblepup = Hubblepup> =
+  BaseTropoignant<
+    TropoignantTypeName.Mentursection,
+    [input: TInputHubblepup],
+    GeppTuple
+  >;
+/**
  * The thing that a Programmer creates to process a Hubblepup. The engine manages them at runtime.
  */
 export type Tropoignant<
   TInputHubblepup extends Hubblepup = Hubblepup,
   TOutputQuirmTuple extends QuirmTuple = QuirmTuple,
-> = Onama<TInputHubblepup, TOutputQuirmTuple> | Wortinator<TInputHubblepup>;
+> =
+  | Onama<TInputHubblepup, TOutputQuirmTuple>
+  | Wortinator<TInputHubblepup>
+  | Mentursection<TInputHubblepup>;

--- a/packages/open-schema-type-script/src/example/core/odeshin.ts
+++ b/packages/open-schema-type-script/src/example/core/odeshin.ts
@@ -1,8 +1,7 @@
-import { Gepp } from '../../core/gepp';
 import { Hubblepup } from '../../core/hubblepup';
 import { Grition } from './grition';
 
-export const ODESHIN_GEPP = Symbol('odeshin') satisfies Gepp;
+export const ODESHIN_GEPP = Symbol('odeshin');
 
 export type OdeshinGepp = typeof ODESHIN_GEPP;
 

--- a/packages/open-schema-type-script/src/example/file/fileA.ts
+++ b/packages/open-schema-type-script/src/example/file/fileA.ts
@@ -1,4 +1,5 @@
 import { Estinant } from '../../core/estinant';
+import { GeppTuple } from '../../core/gepp';
 import { TropoignantTypeName } from '../../core/tropoignant';
 import { File } from '../../utilities/file/file';
 import {
@@ -15,17 +16,25 @@ import {
   FILE_A_CONFIGURATION_GEPP,
 } from './fileAConfiguration';
 
-export type FileA = Grition<File<FileExtensionSuffixIdentifier, null>>;
+export type FileA<
+  TFileExtensionSuffixIdentifier extends FileExtensionSuffixIdentifier = FileExtensionSuffixIdentifier,
+> = Grition<File<TFileExtensionSuffixIdentifier, null>>;
 
 export type FileAIdentifier = `file-a:${string}`;
 
-export type FileAOdeshin = Odeshin<FileAIdentifier, FileA>;
+export type FileAOdeshin<TFileA extends FileA = FileA> = Odeshin<
+  FileAIdentifier,
+  TFileA
+>;
 
 export const FILE_A_GEPP = 'file-a';
 
 export type FileAGepp = typeof FILE_A_GEPP;
 
-export type FileAPlifal = Plifal<[FileAGepp], FileAOdeshin>;
+export type FileAPlifal<TGeppTuple extends GeppTuple = []> = Plifal<
+  [FileAGepp, ...TGeppTuple],
+  FileAOdeshin
+>;
 
 export type FileAPlifalTuple = readonly FileAPlifal[];
 

--- a/packages/open-schema-type-script/src/example/file/fileAMentursection.ts
+++ b/packages/open-schema-type-script/src/example/file/fileAMentursection.ts
@@ -1,0 +1,22 @@
+import { MentursectionEstinant } from '../../core/estinant';
+import { TropoignantTypeName } from '../../core/tropoignant';
+import { FileExtensionSuffixIdentifier } from '../../utilities/file/fileExtensionSuffixIdentifier';
+import { FileAOdeshin, FILE_A_GEPP } from './fileA';
+import { TYPE_SCRIPT_FILE_A_GEPP } from './typeScriptFileA';
+
+export const fileAMentursection: MentursectionEstinant<FileAOdeshin> = {
+  inputGepp: FILE_A_GEPP,
+  tropoignant: {
+    typeName: TropoignantTypeName.Mentursection,
+    process: function categorizeFileA(inputOdeshin) {
+      switch (inputOdeshin.grition.extension.suffixIdentifier) {
+        case FileExtensionSuffixIdentifier.TypeScript:
+          return [TYPE_SCRIPT_FILE_A_GEPP];
+        case FileExtensionSuffixIdentifier.Json:
+          return [];
+        case FileExtensionSuffixIdentifier.Unknown:
+          return [];
+      }
+    },
+  },
+};

--- a/packages/open-schema-type-script/src/example/file/typeScriptFileA.ts
+++ b/packages/open-schema-type-script/src/example/file/typeScriptFileA.ts
@@ -1,0 +1,14 @@
+import { FileExtensionSuffixIdentifier } from '../../utilities/file/fileExtensionSuffixIdentifier';
+import { FileA, FileAOdeshin, FileAPlifal } from './fileA';
+
+export type TypeScriptFileA = FileA<FileExtensionSuffixIdentifier.TypeScript>;
+
+export type TypeScriptFileAOdeshin = FileAOdeshin<TypeScriptFileA>;
+
+export const TYPE_SCRIPT_FILE_A_GEPP = Symbol('type-script-file-a');
+
+export type TypeScriptFileAGepp = typeof TYPE_SCRIPT_FILE_A_GEPP;
+
+export type TypeScriptFileAPlifal = FileAPlifal<[TypeScriptFileAGepp]>;
+
+export type TypeScriptFileAPlifalTuple = readonly TypeScriptFileAPlifal[];

--- a/packages/open-schema-type-script/src/example/file/typeScriptFileB.ts
+++ b/packages/open-schema-type-script/src/example/file/typeScriptFileB.ts
@@ -1,0 +1,108 @@
+import { TSESTree } from '@typescript-eslint/typescript-estree';
+import * as parser from '@typescript-eslint/typescript-estree';
+import { posix } from 'path';
+import fs from 'fs';
+import { OnamaEstinant } from '../../core/estinant';
+import { TropoignantTypeName } from '../../core/tropoignant';
+import { File } from '../../utilities/file/file';
+import { FileExtensionSuffixIdentifier } from '../../utilities/file/fileExtensionSuffixIdentifier';
+import { Grition } from '../core/grition';
+import { Odeshin, ODESHIN_GEPP } from '../core/odeshin';
+import { Plifal } from '../core/plifal';
+import {
+  TypeScriptFileAOdeshin,
+  TYPE_SCRIPT_FILE_A_GEPP,
+} from './typeScriptFileA';
+
+export type TypeScriptFileB = Grition<
+  File<
+    FileExtensionSuffixIdentifier.TypeScript,
+    {
+      program: TSESTree.Program;
+      configFilePath: string;
+      tsconfigRootDir: string;
+    }
+  >
+>;
+
+export type TypeScriptFileBIdentifier = `type-script-file-b:${string}`;
+
+export type TypeScriptFileBOdeshin = Odeshin<
+  TypeScriptFileBIdentifier,
+  TypeScriptFileB
+>;
+
+export const TYPE_SCRIPT_FILE_B_GEPP = Symbol('type-script-file-b');
+
+export type TypeScriptFileBGepp = typeof TYPE_SCRIPT_FILE_B_GEPP;
+
+export type TypeScriptFileBPlifal = Plifal<
+  [TypeScriptFileBGepp],
+  TypeScriptFileBOdeshin
+>;
+
+export type TypeScriptFileBPlifalTuple = readonly TypeScriptFileBPlifal[];
+
+const getConfigFilePath = (filePath: string): string => {
+  let configFilePath: string | null = null;
+
+  let nextPath = filePath;
+  while (configFilePath === null && nextPath !== '.') {
+    nextPath = posix.dirname(nextPath);
+
+    const files = fs.readdirSync(nextPath);
+    configFilePath = files.find((x) => x === 'tsconfig.json') ?? null;
+    if (configFilePath !== null) {
+      configFilePath = posix.join(nextPath, configFilePath);
+    }
+  }
+
+  if (configFilePath === null) {
+    throw Error('No config found');
+  }
+
+  return configFilePath;
+};
+
+export const typeScriptFileBEstinant: OnamaEstinant<
+  TypeScriptFileAOdeshin,
+  TypeScriptFileBPlifalTuple
+> = {
+  inputGepp: TYPE_SCRIPT_FILE_A_GEPP,
+  tropoignant: {
+    typeName: TropoignantTypeName.Onama,
+    process: function createTypeScriptFileB(input) {
+      const fileContents = fs.readFileSync(input.grition.filePath, 'utf8');
+
+      const typeScriptConfigurationFilePath = getConfigFilePath(
+        input.grition.filePath,
+      );
+      const typeScriptConfigurationRootDirectoryPath = posix.dirname(
+        typeScriptConfigurationFilePath,
+      );
+
+      const program: TSESTree.Program = parser.parse(fileContents, {
+        project: './tsconfig.json',
+        tsconfigRootDir: typeScriptConfigurationRootDirectoryPath,
+        comment: true,
+      });
+
+      const output: TypeScriptFileBPlifal = {
+        geppTuple: [ODESHIN_GEPP, TYPE_SCRIPT_FILE_B_GEPP],
+        hubblepup: {
+          identifier: `type-script-file-b:${input.grition.filePath}`,
+          grition: {
+            ...input.grition,
+            additionalMetadata: {
+              program,
+              tsconfigRootDir: typeScriptConfigurationRootDirectoryPath,
+              configFilePath: typeScriptConfigurationFilePath,
+            },
+          },
+        },
+      };
+
+      return [output];
+    },
+  },
+};

--- a/packages/open-schema-type-script/src/example/file/typeScriptFileC.ts
+++ b/packages/open-schema-type-script/src/example/file/typeScriptFileC.ts
@@ -1,0 +1,81 @@
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/typescript-estree';
+import { OnamaEstinant } from '../../core/estinant';
+import { TropoignantTypeName } from '../../core/tropoignant';
+import { File } from '../../utilities/file/file';
+import { FileExtensionSuffixIdentifier } from '../../utilities/file/fileExtensionSuffixIdentifier';
+import { Grition } from '../core/grition';
+import { Odeshin, ODESHIN_GEPP } from '../core/odeshin';
+import { Plifal } from '../core/plifal';
+import {
+  TypeScriptFileBOdeshin,
+  TYPE_SCRIPT_FILE_B_GEPP,
+} from './typeScriptFileB';
+
+export type TypeScriptFileC = Grition<
+  File<
+    FileExtensionSuffixIdentifier.TypeScript,
+    {
+      declarations: (
+        | TSESTree.ExportNamedDeclaration
+        | TSESTree.ExportAllDeclaration
+      )[];
+    }
+  >
+>;
+
+export type TypeScriptFileCIdentifier = `type-script-file-c:${string}`;
+
+export type TypeScriptFileCOdeshin = Odeshin<
+  TypeScriptFileCIdentifier,
+  TypeScriptFileC
+>;
+
+export const TYPE_SCRIPT_FILE_C_GEPP = Symbol('type-script-file-c');
+
+export type TypeScriptFileCGepp = typeof TYPE_SCRIPT_FILE_C_GEPP;
+
+export type TypeScriptFileCPlifal = Plifal<
+  [TypeScriptFileCGepp],
+  TypeScriptFileCOdeshin
+>;
+
+export type TypeScriptFileCPlifalTuple = readonly TypeScriptFileCPlifal[];
+
+export const typeScriptFileCEstinant: OnamaEstinant<
+  TypeScriptFileBOdeshin,
+  TypeScriptFileCPlifalTuple
+> = {
+  inputGepp: TYPE_SCRIPT_FILE_B_GEPP,
+  tropoignant: {
+    typeName: TropoignantTypeName.Onama,
+    process: function createTypeScriptFileC(input) {
+      const output: TypeScriptFileCPlifal = {
+        geppTuple: [ODESHIN_GEPP, TYPE_SCRIPT_FILE_C_GEPP],
+        hubblepup: {
+          identifier: `type-script-file-c:${input.grition.filePath}`,
+          grition: {
+            ...input.grition,
+            additionalMetadata: {
+              declarations:
+                input.grition.additionalMetadata.program.body.filter(
+                  (
+                    statement,
+                  ): statement is
+                    | TSESTree.ExportNamedDeclaration
+                    | TSESTree.ExportAllDeclaration => {
+                    return (
+                      statement.type ===
+                        AST_NODE_TYPES.ExportNamedDeclaration ||
+                      statement.type === AST_NODE_TYPES.ExportAllDeclaration
+                    );
+                  },
+                ),
+            },
+          },
+        },
+      };
+
+      return [output];
+    },
+  },
+};

--- a/packages/open-schema-type-script/src/example/file/typeScriptFileD.ts
+++ b/packages/open-schema-type-script/src/example/file/typeScriptFileD.ts
@@ -1,0 +1,148 @@
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/typescript-estree';
+import { OnamaEstinant } from '../../core/estinant';
+import { TropoignantTypeName } from '../../core/tropoignant';
+import { File } from '../../utilities/file/file';
+import { FileExtensionSuffixIdentifier } from '../../utilities/file/fileExtensionSuffixIdentifier';
+import { Grition } from '../core/grition';
+import { Odeshin, ODESHIN_GEPP } from '../core/odeshin';
+import { Plifal } from '../core/plifal';
+import {
+  TypeScriptFileCOdeshin,
+  TYPE_SCRIPT_FILE_C_GEPP,
+} from './typeScriptFileC';
+
+export enum DeclarationReferenceTypeName {
+  Code = 'Code',
+  Type = 'Type',
+  Hybrid = 'Hybrid',
+}
+
+export type EnhancedDeclaration = {
+  referenceTypeName: DeclarationReferenceTypeName;
+  identifier: string;
+};
+
+export type TypeScriptFileD = Grition<
+  File<
+    FileExtensionSuffixIdentifier.TypeScript,
+    {
+      declarations: EnhancedDeclaration[];
+    }
+  >
+>;
+
+export type TypeScriptFileDIdentifier = `type-script-file-d:${string}`;
+
+export type TypeScriptFileDOdeshin = Odeshin<
+  TypeScriptFileDIdentifier,
+  TypeScriptFileD
+>;
+
+export const TYPE_SCRIPT_FILE_D_GEPP = Symbol('type-script-file-d');
+
+export type TypeScriptFileDGepp = typeof TYPE_SCRIPT_FILE_D_GEPP;
+
+export type TypeScriptFileDPlifal = Plifal<
+  [TypeScriptFileDGepp],
+  TypeScriptFileDOdeshin
+>;
+
+export type TypeScriptFileDPlifalTuple = readonly TypeScriptFileDPlifal[];
+
+export const typeScriptFileDEstinant: OnamaEstinant<
+  TypeScriptFileCOdeshin,
+  TypeScriptFileDPlifalTuple
+> = {
+  inputGepp: TYPE_SCRIPT_FILE_C_GEPP,
+  tropoignant: {
+    typeName: TropoignantTypeName.Onama,
+    process: function createTypeScriptFileD(input) {
+      const output: TypeScriptFileDPlifal = {
+        geppTuple: [ODESHIN_GEPP, TYPE_SCRIPT_FILE_D_GEPP],
+        hubblepup: {
+          identifier: `type-script-file-d:${input.grition.filePath}`,
+          grition: {
+            ...input.grition,
+            additionalMetadata: {
+              declarations:
+                input.grition.additionalMetadata.declarations.flatMap<EnhancedDeclaration>(
+                  (statement) => {
+                    if (
+                      statement.type === AST_NODE_TYPES.ExportAllDeclaration
+                    ) {
+                      if (statement.exported === null) {
+                        throw Error(
+                          `Unhandled scenario: null exported in ${input.grition.filePath}`,
+                        );
+                      }
+
+                      return {
+                        referenceTypeName: DeclarationReferenceTypeName.Hybrid,
+                        identifier: statement.exported.name,
+                      };
+                    }
+
+                    if (statement.declaration === null) {
+                      return statement.specifiers.map<EnhancedDeclaration>(
+                        (specifier) => {
+                          return {
+                            referenceTypeName:
+                              DeclarationReferenceTypeName.Hybrid,
+                            identifier: specifier.exported.name,
+                          };
+                        },
+                      );
+                    }
+
+                    switch (statement.declaration.type) {
+                      case AST_NODE_TYPES.TSTypeAliasDeclaration:
+                        return {
+                          referenceTypeName: DeclarationReferenceTypeName.Type,
+                          identifier: statement.declaration.id.name,
+                        } satisfies EnhancedDeclaration;
+                      case AST_NODE_TYPES.TSEnumDeclaration:
+                      case AST_NODE_TYPES.ClassDeclaration:
+                        if (statement.declaration.id === null) {
+                          throw Error(
+                            `Null identifier for ${statement.declaration.type} in ${input.grition.filePath}`,
+                          );
+                        }
+
+                        return {
+                          referenceTypeName:
+                            DeclarationReferenceTypeName.Hybrid,
+                          identifier: statement.declaration.id.name,
+                        } satisfies EnhancedDeclaration;
+                      case AST_NODE_TYPES.VariableDeclaration: {
+                        return statement.declaration.declarations
+                          .filter(
+                            (
+                              x,
+                            ): x is typeof x & { id: TSESTree.Identifier } => {
+                              return x.id.type === AST_NODE_TYPES.Identifier;
+                            },
+                          )
+                          .map<EnhancedDeclaration>((declaration) => {
+                            return {
+                              referenceTypeName:
+                                DeclarationReferenceTypeName.Code,
+                              identifier: declaration.id.name,
+                            };
+                          });
+                      }
+                      default:
+                        throw Error(
+                          `Unhandled export named declaration declaration type: ${statement.declaration.type} for file: ${input.grition.filePath}`,
+                        );
+                    }
+                  },
+                ),
+            },
+          },
+        },
+      };
+
+      return [output];
+    },
+  },
+};

--- a/packages/open-schema-type-script/src/example/file/typeScriptFileDHasProperlyNamedExportValidation.ts
+++ b/packages/open-schema-type-script/src/example/file/typeScriptFileDHasProperlyNamedExportValidation.ts
@@ -1,0 +1,62 @@
+import { TropoignantTypeName } from '../../core/tropoignant';
+import { ODESHIN_GEPP } from '../core/odeshin';
+import { ValidationEstinant } from '../validation/validation';
+import {
+  ValidationResultOdeshin,
+  ValidationResultQuirm,
+  VALIDATION_RESULT_GEPP,
+} from '../validation/validationResult';
+import {
+  DeclarationReferenceTypeName,
+  TypeScriptFileDOdeshin,
+  TYPE_SCRIPT_FILE_D_GEPP,
+} from './typeScriptFileD';
+
+export const typeScriptFileDHasProperlyNamedExportValidation: ValidationEstinant<TypeScriptFileDOdeshin> =
+  {
+    inputGepp: TYPE_SCRIPT_FILE_D_GEPP,
+    tropoignant: {
+      typeName: TropoignantTypeName.Onama,
+      process: function typeScriptFileDHasProperlyNamedExport(inputOdeshin) {
+        const hubblepup: ValidationResultOdeshin = {
+          identifier: `validation-result:${typeScriptFileDHasProperlyNamedExport.name}:${inputOdeshin.identifier}`,
+          grition: {
+            identifier: inputOdeshin.identifier,
+            predicate: 'fileAHasKnownExtensionSuffix',
+            isValid: inputOdeshin.grition.additionalMetadata.declarations.some(
+              (declaration): boolean => {
+                switch (declaration.referenceTypeName) {
+                  case DeclarationReferenceTypeName.Code:
+                    return (
+                      declaration.identifier ===
+                      inputOdeshin.grition.inMemoryFileName.camelCase
+                    );
+                  case DeclarationReferenceTypeName.Type:
+                    return (
+                      declaration.identifier ===
+                      inputOdeshin.grition.inMemoryFileName.pascalCase
+                    );
+                  case DeclarationReferenceTypeName.Hybrid:
+                    return (
+                      declaration.identifier ===
+                        inputOdeshin.grition.inMemoryFileName.camelCase ||
+                      declaration.identifier ===
+                        inputOdeshin.grition.inMemoryFileName.pascalCase
+                    );
+                }
+
+                throw Error('Not Implemented');
+              },
+            ),
+          },
+        };
+
+        const outputQuirm: ValidationResultQuirm = {
+          geppTuple: [ODESHIN_GEPP, VALIDATION_RESULT_GEPP],
+          hubblepup,
+        };
+
+        return [outputQuirm];
+      },
+    },
+  };

--- a/packages/open-schema-type-script/src/example/index.ts
+++ b/packages/open-schema-type-script/src/example/index.ts
@@ -6,10 +6,15 @@ import { TropoignantTypeName } from '../core/tropoignant';
 import { blindCastEstinants } from './blindCastEstinants';
 import { eventLogger } from './debugger/eventLogger';
 import { odeshinLogger } from './debugger/odeshinLogger';
+import { fileAMentursection } from './file/fileAMentursection';
 import { fileAEstinant } from './file/fileA';
 import { SIMPLE_FILE_A_CONFIGURATION_QUIRM } from './file/fileAConfiguration';
 import { fileAHasKnownExtensionSuffixEstinant } from './file/fileAHasKnownExtensionSuffix';
+import { typeScriptFileBEstinant } from './file/typeScriptFileB';
 import { validator } from './validation/validator';
+import { typeScriptFileCEstinant } from './file/typeScriptFileC';
+import { typeScriptFileDEstinant } from './file/typeScriptFileD';
+import { typeScriptFileDHasProperlyNamedExportValidation } from './file/typeScriptFileDHasProperlyNamedExportValidation';
 
 const myGeppA: Gepp = 'example-1';
 const myGeppB: Gepp = 'example-2';
@@ -68,5 +73,13 @@ digikikify({
     validator.validatorStreamer,
     eventLogger,
     odeshinLogger,
+    fileAMentursection,
+    typeScriptFileBEstinant,
+    typeScriptFileCEstinant,
+    typeScriptFileDEstinant,
+    typeScriptFileDHasProperlyNamedExportValidation,
   ]),
 });
+
+// TODO: figure out how to not have to do this
+export type Example = symbol;


### PR DESCRIPTION
A Mentursection evaluates a stream element and returns zero or more Gepps for the element. The element is then added to the corresponding stream(s). This effectively allows a stream to be filtered or to be split into multiple streams.