### PR TITLE
Implement a Cortmum

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  "configurations": [
+    {
+      "name": "Open Schema Example 1",
+      "request": "launch",
+      "runtimeArgs": [
+        "ts-node",
+        "${workspaceFolder}/packages/open-schema-type-script/src/example/example1.ts"
+      ],
+      "runtimeExecutable": "npx",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "type": "node"
+    }
+  ]
+}

--- a/packages/open-schema-type-script/README.md
+++ b/packages/open-schema-type-script/README.md
@@ -13,8 +13,9 @@ An Open Schema implementation that is used to iterate on the Open Schema specifi
 # One time install
 npm ci
 
-# Run the Open Schema example: It will output files that contain engine event information
-npx ts-node packages/open-schema-type-script/src/example/index.ts
+# Run the Open Schema example(s): They will output files that contain engine event information
+npx ts-node packages/open-schema-type-script/src/example/example1.ts
+npx ts-node packages/open-schema-type-script/src/example/example2.ts
 ```
 
 ## Terminology

--- a/packages/open-schema-type-script/src/core/cology.ts
+++ b/packages/open-schema-type-script/src/core/cology.ts
@@ -1,0 +1,15 @@
+import { Gepp, GeppTuple } from './gepp';
+import { Quirm } from './quirm';
+
+/**
+ * A cache of Quirms, where each Quirm is keyed by one of its Gepps. This is used by a Procody.
+ */
+export class Cology extends Map<Gepp, Quirm> {
+  constructor(public readonly geppTuple: GeppTuple) {
+    super();
+  }
+
+  isReady(): boolean {
+    return this.geppTuple.every((gepp) => this.has(gepp));
+  }
+}

--- a/packages/open-schema-type-script/src/core/croarder.ts
+++ b/packages/open-schema-type-script/src/core/croarder.ts
@@ -1,0 +1,10 @@
+import { Hubblepup } from './hubblepup';
+import { Zorn } from './zorn';
+
+/**
+ * A function that converts a Hubblepup to an identifying Zorn.
+ * This is use by the Engine to associate Hubblepups from different Voictents when processing Estinants with multiple inputs.
+ */
+export type Croarder<TInputHubblepup extends Hubblepup, TZorn extends Zorn> = (
+  hubblepup: TInputHubblepup,
+) => TZorn;

--- a/packages/open-schema-type-script/src/core/digikikify.ts
+++ b/packages/open-schema-type-script/src/core/digikikify.ts
@@ -1,5 +1,8 @@
-import { EstinantTuple } from './estinant';
-import { Platomity } from './platomity';
+import { Cology } from './cology';
+import { Dreanor } from './dreanor';
+import { Estinant, Estinant2 } from './estinant';
+import { Platomity, Platomity2 } from './platomity';
+import { Procody } from './procody';
 import { Quirm, QuirmTuple } from './quirm';
 import { NullStraline, NULL_STRALINE } from './straline';
 import { Tabilly } from './tabilly';
@@ -7,6 +10,7 @@ import { TropoignantTypeName } from './tropoignant';
 import {
   digikikifierGeppsByIdentifer,
   EngineEventName,
+  OnEstinant2ResultEvent,
   OnEstinantResultEvent,
   OnEstinantsRegisteredEvent,
   OnFinishEvent,
@@ -15,9 +19,21 @@ import {
   yek,
 } from './yek';
 
+type DigikikifierEstinantTuple = readonly (Estinant | Estinant2)[];
+
+const isEstinant2 = (
+  estinant: DigikikifierEstinantTuple[number],
+): estinant is Estinant2 => 'inputGeppTuple' in estinant;
+
+type DigikikifierPlatomity = Platomity | Platomity2;
+
+const isPlatomity2 = (
+  platomity: DigikikifierPlatomity,
+): platomity is Platomity2 => 'procody' in platomity;
+
 export type DigikikifierInput = {
   initialQuirmTuple: QuirmTuple;
-  estinantTuple: EstinantTuple;
+  estinantTuple: DigikikifierEstinantTuple;
 };
 
 /**
@@ -41,7 +57,28 @@ export const digikikify = ({
     }),
   ]);
 
-  const platomities = estinantTuple.map<Platomity>((estinant) => {
+  const platomities = estinantTuple.map<DigikikifierPlatomity>((estinant) => {
+    if (isEstinant2(estinant)) {
+      const dreanorTuple = estinant.inputGeppTuple.map<Dreanor>((inputGepp) => {
+        const voictent = tabilly.getOrInstantiateAndGetVoictent(inputGepp);
+        const lanbe = voictent.createPointer(estinant.tropoig.name);
+        const dreanor: Dreanor = {
+          gepp: inputGepp,
+          lanbe,
+        };
+
+        return dreanor;
+      });
+
+      const platomity: Platomity2 = {
+        estinant,
+        dreanorTuple,
+        procody: new Procody(),
+      };
+
+      return platomity;
+    }
+
     const voictent = tabilly.getOrInstantiateAndGetVoictent(estinant.inputGepp);
 
     // TODO: consider using an estinant identifier instead of the tropoignant name
@@ -71,7 +108,71 @@ export const digikikify = ({
     }),
   ]);
 
-  const executePlatomity = (platomity: Platomity): void => {
+  const canPlatomityAdvance = (platomity: DigikikifierPlatomity): boolean => {
+    if (isPlatomity2(platomity)) {
+      return platomity.dreanorTuple.some((dreanor) =>
+        dreanor.lanbe.canAdvance(),
+      );
+    }
+
+    return platomity.lanbe.canAdvance();
+  };
+
+  const executePlatomity = (platomity: DigikikifierPlatomity): void => {
+    if (isPlatomity2(platomity)) {
+      const readyCologies: Cology[] = [];
+
+      platomity.dreanorTuple
+        .filter((dreanor) => dreanor.lanbe.canAdvance())
+        .forEach((dreanor) => {
+          dreanor.lanbe.advance();
+
+          const nextQuirm = dreanor.lanbe.dereference() as Quirm;
+          const zorn = platomity.estinant.croard(nextQuirm.hubblepup);
+          const cology =
+            platomity.procody.get(zorn) ??
+            new Cology(platomity.estinant.inputGeppTuple);
+
+          cology.set(dreanor.gepp, nextQuirm);
+          platomity.procody.set(zorn, cology);
+
+          if (cology.isReady()) {
+            readyCologies.push(cology);
+          }
+        });
+
+      readyCologies.forEach((cology) => {
+        const inputHubblepupTuple = platomity.estinant.inputGeppTuple.map(
+          (gepp) => {
+            const quirm = cology.get(gepp) as Quirm;
+            const { hubblepup } = quirm;
+            return hubblepup;
+          },
+        );
+
+        const outputQuirmTuple = platomity.estinant.tropoig(
+          ...inputHubblepupTuple,
+        );
+
+        tabilly.addQuirmsToVoictents(outputQuirmTuple);
+
+        tabilly.addQuirmsToVoictents([
+          yek.createEventQuirm<OnEstinant2ResultEvent>({
+            name: EngineEventName.OnEstinant2Result,
+            data: {
+              tropoignant: platomity.estinant.tropoig,
+              inputGeppTuple: platomity.estinant.inputGeppTuple,
+              inputTuple: inputHubblepupTuple,
+              outputTuple: outputQuirmTuple,
+            },
+            tabilly,
+          }),
+        ]);
+      });
+
+      return;
+    }
+
     platomity.lanbe.advance();
 
     const nextQuirm = platomity.lanbe.dereference() as Quirm;
@@ -121,12 +222,10 @@ export const digikikify = ({
     }
   };
 
-  while (platomities.some((platomity) => platomity.lanbe.canAdvance())) {
-    platomities
-      .filter((platomity) => platomity.lanbe.canAdvance())
-      .forEach((platomity) => {
-        executePlatomity(platomity);
-      });
+  while (platomities.some(canPlatomityAdvance)) {
+    platomities.filter(canPlatomityAdvance).forEach((platomity) => {
+      executePlatomity(platomity);
+    });
   }
 
   tabilly.addQuirmsToVoictents([
@@ -144,6 +243,7 @@ export const digikikify = ({
   platomities
     .filter(
       (platomity) =>
+        !isPlatomity2(platomity) &&
         platomity.estinant.inputGepp === digikikifierGeppsByIdentifer.OnEvent,
     )
     .forEach((platomity) => {
@@ -153,6 +253,7 @@ export const digikikify = ({
   platomities
     .filter(
       (platomity) =>
+        !isPlatomity2(platomity) &&
         platomity.estinant.inputGepp === digikikifierGeppsByIdentifer.OnFinish,
     )
     .forEach((platomity) => {

--- a/packages/open-schema-type-script/src/core/dreanor.ts
+++ b/packages/open-schema-type-script/src/core/dreanor.ts
@@ -1,0 +1,10 @@
+import { Gepp } from './gepp';
+import { Lanbe } from './lanbe';
+import { Quirm } from './quirm';
+
+export type Dreanor = {
+  gepp: Gepp;
+  lanbe: Lanbe<Quirm>;
+};
+
+export type DreanorTuple = readonly Dreanor[];

--- a/packages/open-schema-type-script/src/core/estinant.ts
+++ b/packages/open-schema-type-script/src/core/estinant.ts
@@ -1,7 +1,20 @@
+import { Croarder } from './croarder';
 import { Gepp } from './gepp';
 import { Hubblepup } from './hubblepup';
-import { QuirmTuple } from './quirm';
-import { Mentursection, Onama, Tropoignant, Wortinator } from './tropoignant';
+import {
+  QuirmTuple,
+  QuirmTupleToGeppTuple,
+  QuirmTupleToHubblepupTuple,
+  QuirmTupleToHubblepupTupleElement,
+} from './quirm';
+import { Straline } from './straline';
+import {
+  Mentursection,
+  Onama,
+  Tropoignant,
+  Tropoignant2,
+  Wortinator,
+} from './tropoignant';
 
 type BaseEstinant<
   TInputHubblepup extends Hubblepup,
@@ -44,3 +57,24 @@ export type EstinantTuple<
   TInputHubblepup extends Hubblepup = Hubblepup,
   TOutputQuirmTuple extends QuirmTuple = QuirmTuple,
 > = readonly Estinant<TInputHubblepup, TOutputQuirmTuple>[];
+
+/**
+ * One of the two programmable units of the Engine (see Quirm).
+ * It allows the Progammer to register a Tropoignant to one or more Voictents via a tuple of Gepps.
+ */
+export type Estinant2<
+  TInputQuirmTuple extends QuirmTuple = QuirmTuple,
+  TIntersectionIdentity extends Straline = Straline,
+> = {
+  inputGeppTuple: QuirmTupleToGeppTuple<TInputQuirmTuple>;
+  tropoig: Tropoignant2<QuirmTupleToHubblepupTuple<TInputQuirmTuple>>;
+  croard: Croarder<
+    QuirmTupleToHubblepupTupleElement<TInputQuirmTuple>,
+    TIntersectionIdentity
+  >;
+};
+
+export type Estinant2Tuple<
+  TInputQuirmTuple extends QuirmTuple = QuirmTuple,
+  TIntersectionIdentity extends Straline = Straline,
+> = readonly Estinant2<TInputQuirmTuple, TIntersectionIdentity>[];

--- a/packages/open-schema-type-script/src/core/hubblepup.ts
+++ b/packages/open-schema-type-script/src/core/hubblepup.ts
@@ -3,3 +3,5 @@
  * I'm aware that this does not need to be a generic type, but it helps with semantics.
  */
 export type Hubblepup<THubblepup = unknown> = THubblepup;
+
+export type HubblepupTuple = readonly Hubblepup[];

--- a/packages/open-schema-type-script/src/core/platomity.ts
+++ b/packages/open-schema-type-script/src/core/platomity.ts
@@ -1,5 +1,7 @@
-import { Estinant } from './estinant';
+import { DreanorTuple } from './dreanor';
+import { Estinant, Estinant2 } from './estinant';
 import { Lanbe } from './lanbe';
+import { Procody } from './procody';
 import { Quirm } from './quirm';
 
 /**
@@ -9,4 +11,14 @@ import { Quirm } from './quirm';
 export type Platomity = {
   estinant: Estinant;
   lanbe: Lanbe<Quirm>;
+};
+
+/**
+ * The primary thing that the engine operates on in the main loop.
+ * The Lanbe allows the Engine to resolve Quirms, and subsequently Hubblepups, to be sent to the Tropoignant that is saved to the Estinant.
+ */
+export type Platomity2 = {
+  estinant: Estinant2;
+  dreanorTuple: DreanorTuple;
+  procody: Procody;
 };

--- a/packages/open-schema-type-script/src/core/procody.ts
+++ b/packages/open-schema-type-script/src/core/procody.ts
@@ -1,0 +1,8 @@
+import { Cology } from './cology';
+import { Zorn } from './zorn';
+
+/**
+ * Cologies cached by Zorns. This is stored in a Platomity.
+ * The Engine finds a Cology where every item cached in the Cology resolves to the same Zorn
+ */
+export class Procody extends Map<Zorn, Cology> {}

--- a/packages/open-schema-type-script/src/core/quirm.ts
+++ b/packages/open-schema-type-script/src/core/quirm.ts
@@ -17,3 +17,14 @@ export type Quirm<
 
 export type QuirmTuple<THubblepup extends Hubblepup = Hubblepup> =
   readonly Quirm<THubblepup>[];
+
+export type QuirmTupleToGeppTuple<TQuirmTuple extends QuirmTuple> = {
+  [Index in keyof TQuirmTuple]: TQuirmTuple[Index]['geppTuple'][number];
+};
+
+export type QuirmTupleToHubblepupTuple<TQuirmTuple extends QuirmTuple> = {
+  [Index in keyof TQuirmTuple]: TQuirmTuple[Index]['hubblepup'];
+};
+
+export type QuirmTupleToHubblepupTupleElement<TQuirmTuple extends QuirmTuple> =
+  QuirmTupleToHubblepupTuple<TQuirmTuple>[number];

--- a/packages/open-schema-type-script/src/core/tropoignant.ts
+++ b/packages/open-schema-type-script/src/core/tropoignant.ts
@@ -1,5 +1,5 @@
 import { GeppTuple } from './gepp';
-import { Hubblepup } from './hubblepup';
+import { Hubblepup, HubblepupTuple } from './hubblepup';
 import { QuirmTuple } from './quirm';
 
 export enum TropoignantTypeName {
@@ -48,6 +48,7 @@ export type Mentursection<TInputHubblepup extends Hubblepup = Hubblepup> =
     [input: TInputHubblepup],
     GeppTuple
   >;
+
 /**
  * The thing that a Programmer creates to process a Hubblepup. The engine manages them at runtime.
  */
@@ -58,3 +59,12 @@ export type Tropoignant<
   | Onama<TInputHubblepup, TOutputQuirmTuple>
   | Wortinator<TInputHubblepup>
   | Mentursection<TInputHubblepup>;
+
+/**
+ * The thing that a Programmer creates to process one or more Hubblepups. The engine manages them at runtime.
+ * This is also a Cortmum: a many to many Tropoignant
+ */
+export type Tropoignant2<
+  TInputHubblepupTuple extends HubblepupTuple = HubblepupTuple,
+  TOutputQuirmTuple extends QuirmTuple = QuirmTuple,
+> = (...inputs: TInputHubblepupTuple) => TOutputQuirmTuple;

--- a/packages/open-schema-type-script/src/core/yek.ts
+++ b/packages/open-schema-type-script/src/core/yek.ts
@@ -1,8 +1,8 @@
-import { Gepp } from './gepp';
+import { Gepp, GeppTuple } from './gepp';
 import { Hubblepup } from './hubblepup';
 import { Quirm, QuirmTuple } from './quirm';
 import { Tabilly } from './tabilly';
-import { Tropoignant } from './tropoignant';
+import { Tropoignant, Tropoignant2 } from './tropoignant';
 
 export enum DigikikifierGeppIdentifer {
   OnEvent = 'OnEvent',
@@ -26,6 +26,7 @@ export enum EngineEventName {
   OnEstinantsRegistered = 'OnEstinantsRegistered',
   OnInitialQuirmsCached = 'OnInitialQuirmsCached',
   OnEstinantResult = 'OnEstinantResult',
+  OnEstinant2Result = 'OnEstinant2Result',
   OnFinish = 'OnFinish',
 }
 
@@ -55,6 +56,16 @@ export type OnEstinantResultEvent = Event<
   }
 >;
 
+export type OnEstinant2ResultEvent = Event<
+  EngineEventName.OnEstinant2Result,
+  {
+    tropoignant: Tropoignant2;
+    inputGeppTuple: GeppTuple;
+    inputTuple: Hubblepup[];
+    outputTuple: QuirmTuple;
+  }
+>;
+
 export type OnFinishEvent = Event<EngineEventName.OnFinish>;
 
 export type DigikikifierEvent = Hubblepup<
@@ -62,6 +73,7 @@ export type DigikikifierEvent = Hubblepup<
   | OnEstinantsRegisteredEvent
   | OnInitialQuirmsCachedEvent
   | OnEstinantResultEvent
+  | OnEstinant2ResultEvent
   | OnFinishEvent
 >;
 

--- a/packages/open-schema-type-script/src/core/zorn.ts
+++ b/packages/open-schema-type-script/src/core/zorn.ts
@@ -1,0 +1,6 @@
+import { Straline } from './straline';
+
+/**
+ * An arbitrary identifier. This is used by a Procody.
+ */
+export type Zorn = Straline;

--- a/packages/open-schema-type-script/src/example/blindCastEstinants.ts
+++ b/packages/open-schema-type-script/src/example/blindCastEstinants.ts
@@ -1,9 +1,9 @@
-import { EstinantTuple } from '../core/estinant';
+import { Estinant, Estinant2 } from '../core/estinant';
 
 // TODO: add a wrapper layer that takes TypeScript concerns into consideration
 export const blindCastEstinants = <
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  TEstinantTuple extends EstinantTuple<any, any>,
+  TEstinantTuple extends readonly (Estinant<any, any> | Estinant2<any, any>)[],
 >(
   tuple: TEstinantTuple,
-): EstinantTuple => tuple;
+): readonly (Estinant | Estinant2)[] => tuple;

--- a/packages/open-schema-type-script/src/example/example1.ts
+++ b/packages/open-schema-type-script/src/example/example1.ts
@@ -1,0 +1,68 @@
+import { digikikify } from '../core/digikikify';
+import { Estinant } from '../core/estinant';
+import { Gepp } from '../core/gepp';
+import { Quirm, QuirmTuple } from '../core/quirm';
+import { TropoignantTypeName } from '../core/tropoignant';
+import { blindCastEstinants } from './blindCastEstinants';
+import { eventLogger } from './debugger/eventLogger';
+
+const myGeppA: Gepp = 'example-1';
+const myGeppB: Gepp = 'example-2';
+const myGeppC: Gepp = 'example-3';
+const myGeppHello: Gepp = 'example-hello';
+const myGeppGoodbye: Gepp = 'example-goodbye';
+
+const myQuirm1: Quirm<string> = {
+  geppTuple: [myGeppA, myGeppB],
+  hubblepup: 'myself!',
+};
+
+const myQuirm2: Quirm<string> = {
+  geppTuple: [myGeppA, myGeppC],
+  hubblepup: 'someone else',
+};
+
+const myEstinant1: Estinant<string, QuirmTuple<string>> = {
+  inputGepp: myGeppA,
+  tropoignant: {
+    typeName: TropoignantTypeName.Onama,
+    process: function sayHello(input) {
+      return [
+        {
+          geppTuple: [myGeppHello],
+          hubblepup: `Hello ${input}`,
+        },
+      ];
+    },
+  },
+};
+
+const myEstinant2: Estinant<string, QuirmTuple<string>> = {
+  inputGepp: myGeppC,
+  tropoignant: {
+    typeName: TropoignantTypeName.Onama,
+    process: function sayGoodbye(input) {
+      return [
+        {
+          geppTuple: [myGeppGoodbye],
+          hubblepup: `Goodbye ${input}`,
+        },
+      ];
+    },
+  },
+};
+
+digikikify({
+  initialQuirmTuple: [
+    myQuirm1,
+    myQuirm2,
+  ],
+  estinantTuple: blindCastEstinants([
+    myEstinant1,
+    myEstinant2,
+    eventLogger,
+  ]),
+});
+
+// TODO: figure out how to not have to do this
+export type Example1 = symbol;

--- a/packages/open-schema-type-script/src/example/example1.ts
+++ b/packages/open-schema-type-script/src/example/example1.ts
@@ -1,66 +1,87 @@
 import { digikikify } from '../core/digikikify';
-import { Estinant } from '../core/estinant';
+import { MentursectionEstinant, OnamaEstinant } from '../core/estinant';
 import { Gepp } from '../core/gepp';
-import { Quirm, QuirmTuple } from '../core/quirm';
+import { Quirm } from '../core/quirm';
 import { TropoignantTypeName } from '../core/tropoignant';
 import { blindCastEstinants } from './blindCastEstinants';
 import { eventLogger } from './debugger/eventLogger';
 
-const myGeppA: Gepp = 'example-1';
-const myGeppB: Gepp = 'example-2';
-const myGeppC: Gepp = 'example-3';
-const myGeppHello: Gepp = 'example-hello';
-const myGeppGoodbye: Gepp = 'example-goodbye';
+const exampleGeppInitialInput: Gepp = 'gepp-initial-input';
+const exampleGeppA: Gepp = 'gepp-a';
+const exampleGeppB: Gepp = 'gepp-b';
 
-const myQuirm1: Quirm<string> = {
-  geppTuple: [myGeppA, myGeppB],
-  hubblepup: 'myself!',
+const exampleGeppHello: Gepp = 'gepp-hello';
+const exampleGeppDash1: Gepp = 'gepp-dash-1';
+const exampleGeppDash2: Gepp = 'gepp-dash-2';
+
+type ExampleHubblepup = string;
+
+type ExampleQuirm = Quirm<ExampleHubblepup>;
+
+const exampleQuirmA1: ExampleQuirm = {
+  geppTuple: [exampleGeppInitialInput, exampleGeppA],
+  hubblepup: 'a-1',
 };
 
-const myQuirm2: Quirm<string> = {
-  geppTuple: [myGeppA, myGeppC],
-  hubblepup: 'someone else',
+const exampleQuirmA2: ExampleQuirm = {
+  geppTuple: [exampleGeppInitialInput, exampleGeppA],
+  hubblepup: 'a-2',
 };
 
-const myEstinant1: Estinant<string, QuirmTuple<string>> = {
-  inputGepp: myGeppA,
+const exampleQuirmB1: ExampleQuirm = {
+  geppTuple: [exampleGeppInitialInput, exampleGeppB],
+  hubblepup: 'b-1',
+};
+
+const exampleQuirmB2: ExampleQuirm = {
+  geppTuple: [exampleGeppInitialInput, exampleGeppB],
+  hubblepup: 'b-2',
+};
+
+const exampleOnamaEstinant: OnamaEstinant<ExampleHubblepup, [ExampleQuirm]> = {
+  inputGepp: exampleGeppInitialInput,
   tropoignant: {
     typeName: TropoignantTypeName.Onama,
-    process: function sayHello(input) {
-      return [
-        {
-          geppTuple: [myGeppHello],
-          hubblepup: `Hello ${input}`,
-        },
-      ];
+    process: function sayHello(input: ExampleHubblepup) {
+      const output: ExampleQuirm = {
+        geppTuple: [exampleGeppHello],
+        hubblepup: `Hello: ${input}`,
+      };
+
+      return [output];
     },
   },
 };
 
-const myEstinant2: Estinant<string, QuirmTuple<string>> = {
-  inputGepp: myGeppC,
+const exampleMentursectionEstinant: MentursectionEstinant<ExampleHubblepup> = {
+  inputGepp: exampleGeppInitialInput,
   tropoignant: {
-    typeName: TropoignantTypeName.Onama,
-    process: function sayGoodbye(input) {
-      return [
-        {
-          geppTuple: [myGeppGoodbye],
-          hubblepup: `Goodbye ${input}`,
-        },
-      ];
+    typeName: TropoignantTypeName.Mentursection,
+    process: function categorizeByDash(input: ExampleHubblepup) {
+      const [, numberText] = input.split('-') as [string, '1' | '2'];
+
+      if (numberText === '1') {
+        return [exampleGeppDash1];
+      }
+
+      return [exampleGeppDash2];
     },
   },
 };
+
+const exampleWortinatorEstinant = eventLogger;
 
 digikikify({
   initialQuirmTuple: [
-    myQuirm1,
-    myQuirm2,
+    exampleQuirmA1,
+    exampleQuirmA2,
+    exampleQuirmB1,
+    exampleQuirmB2,
   ],
   estinantTuple: blindCastEstinants([
-    myEstinant1,
-    myEstinant2,
-    eventLogger,
+    exampleOnamaEstinant,
+    exampleWortinatorEstinant,
+    exampleMentursectionEstinant,
   ]),
 });
 

--- a/packages/open-schema-type-script/src/example/example1.ts
+++ b/packages/open-schema-type-script/src/example/example1.ts
@@ -1,5 +1,9 @@
 import { digikikify } from '../core/digikikify';
-import { MentursectionEstinant, OnamaEstinant } from '../core/estinant';
+import {
+  Estinant2,
+  MentursectionEstinant,
+  OnamaEstinant,
+} from '../core/estinant';
 import { Gepp } from '../core/gepp';
 import { Quirm } from '../core/quirm';
 import { TropoignantTypeName } from '../core/tropoignant';
@@ -13,6 +17,8 @@ const exampleGeppB: Gepp = 'gepp-b';
 const exampleGeppHello: Gepp = 'gepp-hello';
 const exampleGeppDash1: Gepp = 'gepp-dash-1';
 const exampleGeppDash2: Gepp = 'gepp-dash-2';
+
+const exampleGeppC: Gepp = 'gepp-c';
 
 type ExampleHubblepup = string;
 
@@ -71,6 +77,26 @@ const exampleMentursectionEstinant: MentursectionEstinant<ExampleHubblepup> = {
 
 const exampleWortinatorEstinant = eventLogger;
 
+const exampleCortmumEstinant2: Estinant2<[ExampleQuirm, ExampleQuirm], string> =
+  {
+    inputGeppTuple: [exampleGeppA, exampleGeppB],
+    croard: function getId(input) {
+      const [, numberText] = input.split('-') as [string, '1' | '2'];
+      return numberText;
+    },
+    tropoig: function join(hubblepupA, hubblepupB) {
+      const outputQuirm: Quirm = {
+        geppTuple: [exampleGeppC],
+        hubblepup: {
+          hubblepupA,
+          hubblepupB,
+        },
+      };
+
+      return [outputQuirm];
+    },
+  };
+
 digikikify({
   initialQuirmTuple: [
     exampleQuirmA1,
@@ -82,6 +108,7 @@ digikikify({
     exampleOnamaEstinant,
     exampleWortinatorEstinant,
     exampleMentursectionEstinant,
+    exampleCortmumEstinant2,
   ]),
 });
 

--- a/packages/open-schema-type-script/src/example/example1.ts
+++ b/packages/open-schema-type-script/src/example/example1.ts
@@ -19,6 +19,9 @@ const exampleGeppDash1: Gepp = 'gepp-dash-1';
 const exampleGeppDash2: Gepp = 'gepp-dash-2';
 
 const exampleGeppC: Gepp = 'gepp-c';
+const exampleGeppWhattup: Gepp = 'gepp-whattup';
+const exampleGeppA2: Gepp = 'gepp-aa';
+const exampleGeppB2: Gepp = 'gepp-bb';
 
 type ExampleHubblepup = string;
 
@@ -97,6 +100,51 @@ const exampleCortmumEstinant2: Estinant2<[ExampleQuirm, ExampleQuirm], string> =
     },
   };
 
+const exampleOnamaEstinant2: Estinant2<[ExampleQuirm], symbol> = {
+  inputGeppTuple: [exampleGeppInitialInput],
+  croard: function getId(input) {
+    return Symbol(input);
+  },
+  tropoig: function sayWhattup(input) {
+    const output: ExampleQuirm = {
+      geppTuple: [exampleGeppWhattup],
+      hubblepup: `Whattup: ${input}`,
+    };
+
+    return [output];
+  },
+};
+
+const exampleWortinatorEstinant2: Estinant2<[ExampleQuirm], symbol> = {
+  inputGeppTuple: [exampleGeppInitialInput],
+  croard: function getId(input) {
+    return Symbol(input);
+  },
+  tropoig: function sayWhattup(input) {
+    // eslint-disable-next-line no-console
+    console.log(`Wort Wort Wort: ${input}`);
+
+    return [];
+  },
+};
+
+const exampleMentursectionEstinant2: Estinant2<[ExampleQuirm], symbol> = {
+  inputGeppTuple: [exampleGeppInitialInput],
+  croard: function getId(input) {
+    return Symbol(input);
+  },
+  tropoig: function sayWhattup(input) {
+    const isA = input.startsWith('a');
+
+    const output: ExampleQuirm = {
+      geppTuple: [isA ? exampleGeppA2 : exampleGeppB2],
+      hubblepup: input,
+    };
+
+    return [output];
+  },
+};
+
 digikikify({
   initialQuirmTuple: [
     exampleQuirmA1,
@@ -109,6 +157,9 @@ digikikify({
     exampleWortinatorEstinant,
     exampleMentursectionEstinant,
     exampleCortmumEstinant2,
+    exampleOnamaEstinant2,
+    exampleWortinatorEstinant2,
+    exampleMentursectionEstinant2,
   ]),
 });
 

--- a/packages/open-schema-type-script/src/example/example2.ts
+++ b/packages/open-schema-type-script/src/example/example2.ts
@@ -1,8 +1,4 @@
 import { digikikify } from '../core/digikikify';
-import { Estinant } from '../core/estinant';
-import { Gepp } from '../core/gepp';
-import { Quirm, QuirmTuple } from '../core/quirm';
-import { TropoignantTypeName } from '../core/tropoignant';
 import { blindCastEstinants } from './blindCastEstinants';
 import { eventLogger } from './debugger/eventLogger';
 import { odeshinLogger } from './debugger/odeshinLogger';
@@ -23,63 +19,13 @@ import { actualCiYamlFileMentursection } from './ciYamlFile/actualCiYamlFile';
 import { EXPECTED_CI_YAML_FILE_CONTENTS_CONFIGURATION_QUIRM } from './ciYamlFile/expectedCiYamlFileContentsConfiguration';
 import { expectedCiYamlFileContentsOnama } from './ciYamlFile/expectedCiYamlFileContents';
 
-const myGeppA: Gepp = 'example-1';
-const myGeppB: Gepp = 'example-2';
-const myGeppC: Gepp = 'example-3';
-const myGeppHello: Gepp = 'example-hello';
-const myGeppGoodbye: Gepp = 'example-goodbye';
-
-const myQuirm1: Quirm<string> = {
-  geppTuple: [myGeppA, myGeppB],
-  hubblepup: 'myself!',
-};
-
-const myQuirm2: Quirm<string> = {
-  geppTuple: [myGeppA, myGeppC],
-  hubblepup: 'someone else',
-};
-
-const myEstinant1: Estinant<string, QuirmTuple<string>> = {
-  inputGepp: myGeppA,
-  tropoignant: {
-    typeName: TropoignantTypeName.Onama,
-    process: function sayHello(input) {
-      return [
-        {
-          geppTuple: [myGeppHello],
-          hubblepup: `Hello ${input}`,
-        },
-      ];
-    },
-  },
-};
-
-const myEstinant2: Estinant<string, QuirmTuple<string>> = {
-  inputGepp: myGeppC,
-  tropoignant: {
-    typeName: TropoignantTypeName.Onama,
-    process: function sayGoodbye(input) {
-      return [
-        {
-          geppTuple: [myGeppGoodbye],
-          hubblepup: `Goodbye ${input}`,
-        },
-      ];
-    },
-  },
-};
-
 digikikify({
   initialQuirmTuple: [
-    myQuirm1,
-    myQuirm2,
     SIMPLE_FILE_A_CONFIGURATION_QUIRM,
     CI_FILE_A_CONFIGURATION_QUIRM,
     EXPECTED_CI_YAML_FILE_CONTENTS_CONFIGURATION_QUIRM,
   ],
   estinantTuple: blindCastEstinants([
-    myEstinant1,
-    myEstinant2,
     fileAEstinant,
     fileAHasKnownExtensionSuffixEstinant,
     validator.validatorExecutor,
@@ -98,4 +44,4 @@ digikikify({
 });
 
 // TODO: figure out how to not have to do this
-export type Example = symbol;
+export type Example2 = symbol;


### PR DESCRIPTION
A Cortmum is a many to many Tropoignant. That is, it allows you to stream entities from multiple collections into a single function to produce zero or more output entities. The Estinant for a Cortmum includes additional logic to determine how to combine entities from different streams similar to how a database has primary keys and foreign keys.

Lastly we demonstrate that a Cortmum is a superset of all other Tropoignants. That is, within the engine, we can just define one Tropoignant that is a many to many function. The specific types, and their semantics (Onama, Wortinator, Mentursection, Cortmum) can all be moved to TypeScript adaptation layer to make it easier to use the core engine without injecting those concerns into the engine itself.