### PR TITLE
Update Tropoignants to take input Quirm tuples

### DIFF
--- a/packages/open-schema-type-script/src/core/croarder.ts
+++ b/packages/open-schema-type-script/src/core/croarder.ts
@@ -1,10 +1,10 @@
-import { Hubblepup } from './hubblepup';
+import { Quirm } from './quirm';
 import { Zorn } from './zorn';
 
 /**
- * A function that converts a Hubblepup to an identifying Zorn.
- * This is use by the Engine to associate Hubblepups from different Voictents when processing Estinants with multiple inputs.
+ * A function that converts a Quirm to an identifying Zorn.
+ * This is used by the Engine to associate Quirms from different Voictents when processing Estinants with multiple inputs.
  */
-export type Croarder<TInputHubblepup extends Hubblepup, TZorn extends Zorn> = (
-  hubblepup: TInputHubblepup,
+export type Croarder<TInputQuirm extends Quirm, TZorn extends Zorn> = (
+  hubblepup: TInputQuirm,
 ) => TZorn;

--- a/packages/open-schema-type-script/src/core/digikikify.ts
+++ b/packages/open-schema-type-script/src/core/digikikify.ts
@@ -125,7 +125,7 @@ export const digikikify = ({
           dreanor.lanbe.advance();
 
           const nextQuirm = dreanor.lanbe.dereference() as Quirm;
-          const zorn = platomity.estinant.croard(nextQuirm.hubblepup);
+          const zorn = platomity.estinant.croard(nextQuirm);
           const cology =
             platomity.procody.get(zorn) ??
             new Cology(platomity.estinant.inputGeppTuple);
@@ -139,17 +139,14 @@ export const digikikify = ({
         });
 
       readyCologies.forEach((cology) => {
-        const inputHubblepupTuple = platomity.estinant.inputGeppTuple.map(
+        const inputQuirmTuple = platomity.estinant.inputGeppTuple.map(
           (gepp) => {
             const quirm = cology.get(gepp) as Quirm;
-            const { hubblepup } = quirm;
-            return hubblepup;
+            return quirm;
           },
         );
 
-        const outputQuirmTuple = platomity.estinant.tropoig(
-          ...inputHubblepupTuple,
-        );
+        const outputQuirmTuple = platomity.estinant.tropoig(...inputQuirmTuple);
 
         tabilly.addQuirmsToVoictents(outputQuirmTuple);
 
@@ -165,7 +162,7 @@ export const digikikify = ({
               data: {
                 tropoignant: platomity.estinant.tropoig,
                 inputGeppTuple: platomity.estinant.inputGeppTuple,
-                inputTuple: inputHubblepupTuple,
+                inputTuple: inputQuirmTuple,
                 outputTuple: outputQuirmTuple,
               },
             }),
@@ -195,11 +192,13 @@ export const digikikify = ({
         const additionalGepps =
           platomity.estinant.tropoignant.process(inputHubblepup);
 
-        // TODO: evaluate the repercussions of mutating this state
-        nextQuirm.geppTuple.push(...additionalGepps);
+        const outputQuirm: Quirm = {
+          geppTuple: [...nextQuirm.geppTuple, ...additionalGepps],
+          hubblepup: nextQuirm.hubblepup,
+        };
 
         additionalGepps.forEach((nextGepp) => {
-          tabilly.addQuirmByGepp(nextQuirm, nextGepp);
+          tabilly.addQuirmByGepp(outputQuirm, nextGepp);
         });
         break;
       }

--- a/packages/open-schema-type-script/src/core/digikikify.ts
+++ b/packages/open-schema-type-script/src/core/digikikify.ts
@@ -10,13 +10,14 @@ import { TropoignantTypeName } from './tropoignant';
 import {
   digikikifierGeppsByIdentifer,
   DigikikifierEventName,
-  OnEstinant2ResultEvent,
   OnEstinantResultEvent,
   OnEstinantsRegisteredEvent,
   OnFinishEvent,
   OnInitialQuirmsCachedEvent,
   OnTabillyInitializedEvent,
   yek,
+  QuirmTupleQuirm,
+  OnEstinant2ResultEvent,
 } from './yek';
 
 type DigikikifierEstinantTuple = readonly (Estinant | Estinant2)[];
@@ -49,7 +50,22 @@ export const digikikify = ({
 }: DigikikifierInput): void => {
   const tabilly = new Tabilly();
 
-  tabilly.addQuirmsToVoictents([
+  const addToTabilly = (quirmTuple: QuirmTuple): void => {
+    if (quirmTuple.length === 0) {
+      return;
+    }
+
+    const quirmTupleQuirm: QuirmTupleQuirm = {
+      geppTuple: [digikikifierGeppsByIdentifer.OnQuirmTuple],
+      hubblepup: [],
+    };
+    quirmTupleQuirm.hubblepup = [quirmTupleQuirm, ...quirmTuple];
+
+    tabilly.addQuirmsToVoictents([quirmTupleQuirm]);
+    tabilly.addQuirmsToVoictents(quirmTuple);
+  };
+
+  addToTabilly([
     yek.createEventQuirm<OnTabillyInitializedEvent>({
       name: DigikikifierEventName.OnTabillyInitialized,
       data: null,
@@ -89,16 +105,16 @@ export const digikikify = ({
     };
   });
 
-  tabilly.addQuirmsToVoictents([
+  addToTabilly([
     yek.createEventQuirm<OnEstinantsRegisteredEvent>({
       name: DigikikifierEventName.OnEstinantsRegistered,
       data: null,
     }),
   ]);
 
-  tabilly.addQuirmsToVoictents(initialQuirmTuple);
+  addToTabilly(initialQuirmTuple);
 
-  tabilly.addQuirmsToVoictents([
+  addToTabilly([
     yek.createEventQuirm<OnInitialQuirmsCachedEvent>({
       name: DigikikifierEventName.OnInitialQuirmsCached,
       data: null,
@@ -148,15 +164,23 @@ export const digikikify = ({
 
         const outputQuirmTuple = platomity.estinant.tropoig(...inputQuirmTuple);
 
-        tabilly.addQuirmsToVoictents(outputQuirmTuple);
+        if (
+          platomity.estinant.inputGeppTuple.length !== 0 &&
+          platomity.estinant.inputGeppTuple[0] !==
+            digikikifierGeppsByIdentifer.OnEvent
+        ) {
+          addToTabilly(outputQuirmTuple);
+        }
 
         // TODO: Reevaluate this fix. It was kind of half-baked
         if (
           platomity.estinant.inputGeppTuple.length !== 1 ||
-          platomity.estinant.inputGeppTuple[0] !==
-            digikikifierGeppsByIdentifer.OnEvent
+          (platomity.estinant.inputGeppTuple[0] !==
+            digikikifierGeppsByIdentifer.OnQuirmTuple &&
+            platomity.estinant.inputGeppTuple[0] !==
+              digikikifierGeppsByIdentifer.OnEvent)
         ) {
-          tabilly.addQuirmsToVoictents([
+          addToTabilly([
             yek.createEventQuirm<OnEstinant2ResultEvent>({
               name: DigikikifierEventName.OnEstinant2Result,
               data: {
@@ -205,11 +229,11 @@ export const digikikify = ({
     }
 
     if (outputQuirmTuple !== NULL_STRALINE) {
-      tabilly.addQuirmsToVoictents(outputQuirmTuple);
+      addToTabilly(outputQuirmTuple);
     }
 
     if (platomity.estinant.inputGepp !== digikikifierGeppsByIdentifer.OnEvent) {
-      tabilly.addQuirmsToVoictents([
+      addToTabilly([
         yek.createEventQuirm<OnEstinantResultEvent>({
           name: DigikikifierEventName.OnEstinantResult,
           data: {
@@ -229,7 +253,7 @@ export const digikikify = ({
     });
   }
 
-  tabilly.addQuirmsToVoictents([
+  addToTabilly([
     yek.createEventQuirm<OnFinishEvent>({
       name: DigikikifierEventName.OnFinish,
       data: null,

--- a/packages/open-schema-type-script/src/core/digikikify.ts
+++ b/packages/open-schema-type-script/src/core/digikikify.ts
@@ -9,7 +9,7 @@ import { Tabilly } from './tabilly';
 import { TropoignantTypeName } from './tropoignant';
 import {
   digikikifierGeppsByIdentifer,
-  EngineEventName,
+  DigikikifierEventName,
   OnEstinant2ResultEvent,
   OnEstinantResultEvent,
   OnEstinantsRegisteredEvent,
@@ -51,7 +51,7 @@ export const digikikify = ({
 
   tabilly.addQuirmsToVoictents([
     yek.createEventQuirm<OnTabillyInitializedEvent>({
-      name: EngineEventName.OnTabillyInitialized,
+      name: DigikikifierEventName.OnTabillyInitialized,
       data: null,
     }),
   ]);
@@ -91,7 +91,7 @@ export const digikikify = ({
 
   tabilly.addQuirmsToVoictents([
     yek.createEventQuirm<OnEstinantsRegisteredEvent>({
-      name: EngineEventName.OnEstinantsRegistered,
+      name: DigikikifierEventName.OnEstinantsRegistered,
       data: null,
     }),
   ]);
@@ -100,7 +100,7 @@ export const digikikify = ({
 
   tabilly.addQuirmsToVoictents([
     yek.createEventQuirm<OnInitialQuirmsCachedEvent>({
-      name: EngineEventName.OnInitialQuirmsCached,
+      name: DigikikifierEventName.OnInitialQuirmsCached,
       data: null,
     }),
   ]);
@@ -155,7 +155,7 @@ export const digikikify = ({
 
         tabilly.addQuirmsToVoictents([
           yek.createEventQuirm<OnEstinant2ResultEvent>({
-            name: EngineEventName.OnEstinant2Result,
+            name: DigikikifierEventName.OnEstinant2Result,
             data: {
               tropoignant: platomity.estinant.tropoig,
               inputGeppTuple: platomity.estinant.inputGeppTuple,
@@ -205,7 +205,7 @@ export const digikikify = ({
     if (platomity.estinant.inputGepp !== digikikifierGeppsByIdentifer.OnEvent) {
       tabilly.addQuirmsToVoictents([
         yek.createEventQuirm<OnEstinantResultEvent>({
-          name: EngineEventName.OnEstinantResult,
+          name: DigikikifierEventName.OnEstinantResult,
           data: {
             tropoignant: platomity.estinant.tropoignant,
             inputGepp: platomity.estinant.inputGepp.toString(),
@@ -225,7 +225,7 @@ export const digikikify = ({
 
   tabilly.addQuirmsToVoictents([
     yek.createEventQuirm<OnFinishEvent>({
-      name: EngineEventName.OnFinish,
+      name: DigikikifierEventName.OnFinish,
       data: null,
     }),
     {

--- a/packages/open-schema-type-script/src/core/digikikify.ts
+++ b/packages/open-schema-type-script/src/core/digikikify.ts
@@ -153,17 +153,24 @@ export const digikikify = ({
 
         tabilly.addQuirmsToVoictents(outputQuirmTuple);
 
-        tabilly.addQuirmsToVoictents([
-          yek.createEventQuirm<OnEstinant2ResultEvent>({
-            name: DigikikifierEventName.OnEstinant2Result,
-            data: {
-              tropoignant: platomity.estinant.tropoig,
-              inputGeppTuple: platomity.estinant.inputGeppTuple,
-              inputTuple: inputHubblepupTuple,
-              outputTuple: outputQuirmTuple,
-            },
-          }),
-        ]);
+        // TODO: Reevaluate this fix. It was kind of half-baked
+        if (
+          platomity.estinant.inputGeppTuple.length !== 1 ||
+          platomity.estinant.inputGeppTuple[0] !==
+            digikikifierGeppsByIdentifer.OnEvent
+        ) {
+          tabilly.addQuirmsToVoictents([
+            yek.createEventQuirm<OnEstinant2ResultEvent>({
+              name: DigikikifierEventName.OnEstinant2Result,
+              data: {
+                tropoignant: platomity.estinant.tropoig,
+                inputGeppTuple: platomity.estinant.inputGeppTuple,
+                inputTuple: inputHubblepupTuple,
+                outputTuple: outputQuirmTuple,
+              },
+            }),
+          ]);
+        }
       });
 
       return;

--- a/packages/open-schema-type-script/src/core/estinant.ts
+++ b/packages/open-schema-type-script/src/core/estinant.ts
@@ -1,12 +1,7 @@
 import { Croarder } from './croarder';
 import { Gepp } from './gepp';
 import { Hubblepup } from './hubblepup';
-import {
-  QuirmTuple,
-  QuirmTupleToGeppTuple,
-  QuirmTupleToHubblepupTuple,
-  QuirmTupleToHubblepupTupleElement,
-} from './quirm';
+import { QuirmTuple, QuirmTupleToGeppTuple } from './quirm';
 import { Straline } from './straline';
 import {
   Mentursection,
@@ -67,11 +62,8 @@ export type Estinant2<
   TIntersectionIdentity extends Straline = Straline,
 > = {
   inputGeppTuple: QuirmTupleToGeppTuple<TInputQuirmTuple>;
-  tropoig: Tropoignant2<QuirmTupleToHubblepupTuple<TInputQuirmTuple>>;
-  croard: Croarder<
-    QuirmTupleToHubblepupTupleElement<TInputQuirmTuple>,
-    TIntersectionIdentity
-  >;
+  tropoig: Tropoignant2<TInputQuirmTuple>;
+  croard: Croarder<TInputQuirmTuple[number], TIntersectionIdentity>;
 };
 
 export type Estinant2Tuple<

--- a/packages/open-schema-type-script/src/core/hubblepup.ts
+++ b/packages/open-schema-type-script/src/core/hubblepup.ts
@@ -1,7 +1,10 @@
+import { Straline } from './straline';
+
 /**
  * A thing that a Concrete Programmer wants to operate on.
  * I'm aware that this does not need to be a generic type, but it helps with semantics.
  */
-export type Hubblepup<THubblepup = unknown> = THubblepup;
+export type Hubblepup<THubblepup = Straline> = THubblepup;
 
-export type HubblepupTuple = readonly Hubblepup[];
+export type HubblepupTuple<THubblepup = Straline> =
+  readonly Hubblepup<THubblepup>[];

--- a/packages/open-schema-type-script/src/core/quirm.ts
+++ b/packages/open-schema-type-script/src/core/quirm.ts
@@ -1,4 +1,5 @@
-import { Gepp } from './gepp';
+import { Dalph } from '../utilities/dalph';
+import { GeppTuple } from './gepp';
 import { Hubblepup } from './hubblepup';
 
 /**
@@ -9,7 +10,7 @@ import { Hubblepup } from './hubblepup';
  */
 export type Quirm<
   THubblepup extends Hubblepup = Hubblepup,
-  TGeppTuple extends Gepp[] = Gepp[],
+  TGeppTuple extends GeppTuple = GeppTuple,
 > = {
   geppTuple: TGeppTuple;
   hubblepup: THubblepup;
@@ -22,9 +23,7 @@ export type QuirmTupleToGeppTuple<TQuirmTuple extends QuirmTuple> = {
   [Index in keyof TQuirmTuple]: TQuirmTuple[Index]['geppTuple'][number];
 };
 
-export type QuirmTupleToHubblepupTuple<TQuirmTuple extends QuirmTuple> = {
-  [Index in keyof TQuirmTuple]: TQuirmTuple[Index]['hubblepup'];
-};
-
-export type QuirmTupleToHubblepupTupleElement<TQuirmTuple extends QuirmTuple> =
-  QuirmTupleToHubblepupTuple<TQuirmTuple>[number];
+/**
+ * A Quirm that is not meant to be used. This is used in the definition of a Kodataring
+ */
+export type QuirmDalph = Quirm<Dalph, GeppTuple>;

--- a/packages/open-schema-type-script/src/core/tropoignant.ts
+++ b/packages/open-schema-type-script/src/core/tropoignant.ts
@@ -1,5 +1,5 @@
 import { GeppTuple } from './gepp';
-import { Hubblepup, HubblepupTuple } from './hubblepup';
+import { Hubblepup } from './hubblepup';
 import { QuirmTuple } from './quirm';
 
 export enum TropoignantTypeName {
@@ -61,10 +61,10 @@ export type Tropoignant<
   | Mentursection<TInputHubblepup>;
 
 /**
- * The thing that a Programmer creates to process one or more Hubblepups. The engine manages them at runtime.
+ * The thing that a Programmer creates to process one or more Quirms. The engine manages them at runtime.
  * This is also a Cortmum: a many to many Tropoignant
  */
 export type Tropoignant2<
-  TInputHubblepupTuple extends HubblepupTuple = HubblepupTuple,
+  TInputQuirmTuple extends QuirmTuple = QuirmTuple,
   TOutputQuirmTuple extends QuirmTuple = QuirmTuple,
-> = (...inputs: TInputHubblepupTuple) => TOutputQuirmTuple;
+> = (...inputs: TInputQuirmTuple) => TOutputQuirmTuple;

--- a/packages/open-schema-type-script/src/core/yek.ts
+++ b/packages/open-schema-type-script/src/core/yek.ts
@@ -5,6 +5,7 @@ import { Tropoignant, Tropoignant2 } from './tropoignant';
 
 export enum DigikikifierGeppIdentifer {
   OnEvent = 'OnEvent',
+  OnQuirmTuple = 'OnQuirmTuple',
   OnFinish = 'OnFinish',
 }
 
@@ -15,6 +16,9 @@ export const digikikifierGeppsByIdentifer: Record<
   [DigikikifierGeppIdentifer.OnEvent]: Symbol(
     DigikikifierGeppIdentifer.OnEvent,
   ),
+  [DigikikifierGeppIdentifer.OnQuirmTuple]: Symbol(
+    DigikikifierGeppIdentifer.OnQuirmTuple,
+  ),
   [DigikikifierGeppIdentifer.OnFinish]: Symbol(
     DigikikifierGeppIdentifer.OnFinish,
   ),
@@ -24,6 +28,7 @@ export enum DigikikifierEventName {
   OnTabillyInitialized = 'OnTabillyInitialized',
   OnEstinantsRegistered = 'OnEstinantsRegistered',
   OnInitialQuirmsCached = 'OnInitialQuirmsCached',
+  OnQuirmTuple = 'OnQuirmTuple',
   OnEstinantResult = 'OnEstinantResult',
   OnEstinant2Result = 'OnEstinant2Result',
   OnFinish = 'OnFinish',
@@ -34,6 +39,11 @@ type Event<TEventName extends DigikikifierEventName, TEventData = null> = {
   data: TEventData;
   time: string;
 };
+
+export type OnQuirmTupleEvent = Event<
+  DigikikifierEventName.OnQuirmTuple,
+  { quirmTuple: QuirmTuple }
+>;
 
 export type OnTabillyInitializedEvent =
   Event<DigikikifierEventName.OnTabillyInitialized>;
@@ -70,6 +80,7 @@ export type DigikikifierEvent =
   | OnTabillyInitializedEvent
   | OnEstinantsRegisteredEvent
   | OnInitialQuirmsCachedEvent
+  | OnQuirmTupleEvent
   | OnEstinantResultEvent
   | OnEstinant2ResultEvent
   | OnFinishEvent;
@@ -85,6 +96,13 @@ export type DigikikifierEventQuirmTuple =
 
 export type EventTropoignant<TOutputQuirmTuple extends QuirmTuple> =
   Tropoignant2<[input: DigikikifierEventQuirm], TOutputQuirmTuple | []>;
+
+export type QuirmTupleHubblepup = Hubblepup<QuirmTuple>;
+
+export type QuirmTupleQuirm = Quirm<QuirmTupleHubblepup>;
+
+export type QuirmTupleTropoignant<TOutputQuirmTuple extends QuirmTuple> =
+  Tropoignant2<[input: QuirmTupleQuirm], TOutputQuirmTuple | []>;
 
 /**
  * A debugger that writes to the file system for funsies

--- a/packages/open-schema-type-script/src/core/yek.ts
+++ b/packages/open-schema-type-script/src/core/yek.ts
@@ -1,5 +1,5 @@
 import { Gepp, GeppTuple } from './gepp';
-import { Hubblepup } from './hubblepup';
+import { Hubblepup, HubblepupTuple } from './hubblepup';
 import { Quirm, QuirmTuple } from './quirm';
 import { Tropoignant, Tropoignant2 } from './tropoignant';
 
@@ -66,22 +66,35 @@ export type OnEstinant2ResultEvent = Event<
 
 export type OnFinishEvent = Event<DigikikifierEventName.OnFinish>;
 
-export type DigikikifierEvent = Hubblepup<
+export type DigikikifierEvent =
   | OnTabillyInitializedEvent
   | OnEstinantsRegisteredEvent
   | OnInitialQuirmsCachedEvent
   | OnEstinantResultEvent
   | OnEstinant2ResultEvent
-  | OnFinishEvent
->;
+  | OnFinishEvent;
+
+export type DigikikifierEventHubblepup = Hubblepup<DigikikifierEvent>;
+
+export type DigikikifierEventHubblepupTuple = HubblepupTuple<DigikikifierEvent>;
+
+export type DigikikifierEventQuirm = Quirm<DigikikifierEventHubblepup>;
+
+export type DigikikifierEventQuirmTuple =
+  QuirmTuple<DigikikifierEventHubblepup>;
+
+export type EventTropoignant<TOutputQuirmTuple extends QuirmTuple> =
+  Tropoignant2<[input: DigikikifierEventHubblepup], TOutputQuirmTuple | []>;
 
 /**
  * A debugger that writes to the file system for funsies
  */
 export const yek = {
-  createEventQuirm: <TPartialDigikikifierEvent extends DigikikifierEvent>(
+  createEventQuirm: <
+    TPartialDigikikifierEvent extends DigikikifierEventHubblepup,
+  >(
     partialEvent: Pick<TPartialDigikikifierEvent, 'name' | 'data'>,
-  ): Quirm<DigikikifierEvent> => {
+  ): Quirm<DigikikifierEventHubblepup> => {
     const event = {
       ...partialEvent,
       time: process.hrtime.bigint().toString(),

--- a/packages/open-schema-type-script/src/core/yek.ts
+++ b/packages/open-schema-type-script/src/core/yek.ts
@@ -84,7 +84,7 @@ export type DigikikifierEventQuirmTuple =
   QuirmTuple<DigikikifierEventHubblepup>;
 
 export type EventTropoignant<TOutputQuirmTuple extends QuirmTuple> =
-  Tropoignant2<[input: DigikikifierEventHubblepup], TOutputQuirmTuple | []>;
+  Tropoignant2<[input: DigikikifierEventQuirm], TOutputQuirmTuple | []>;
 
 /**
  * A debugger that writes to the file system for funsies

--- a/packages/open-schema-type-script/src/core/yek.ts
+++ b/packages/open-schema-type-script/src/core/yek.ts
@@ -20,7 +20,7 @@ export const digikikifierGeppsByIdentifer: Record<
   ),
 };
 
-export enum EngineEventName {
+export enum DigikikifierEventName {
   OnTabillyInitialized = 'OnTabillyInitialized',
   OnEstinantsRegistered = 'OnEstinantsRegistered',
   OnInitialQuirmsCached = 'OnInitialQuirmsCached',
@@ -29,23 +29,23 @@ export enum EngineEventName {
   OnFinish = 'OnFinish',
 }
 
-type Event<TEventName extends EngineEventName, TEventData = null> = {
+type Event<TEventName extends DigikikifierEventName, TEventData = null> = {
   name: TEventName;
   data: TEventData;
   time: string;
 };
 
 export type OnTabillyInitializedEvent =
-  Event<EngineEventName.OnTabillyInitialized>;
+  Event<DigikikifierEventName.OnTabillyInitialized>;
 
 export type OnEstinantsRegisteredEvent =
-  Event<EngineEventName.OnEstinantsRegistered>;
+  Event<DigikikifierEventName.OnEstinantsRegistered>;
 
 export type OnInitialQuirmsCachedEvent =
-  Event<EngineEventName.OnInitialQuirmsCached>;
+  Event<DigikikifierEventName.OnInitialQuirmsCached>;
 
 export type OnEstinantResultEvent = Event<
-  EngineEventName.OnEstinantResult,
+  DigikikifierEventName.OnEstinantResult,
   {
     tropoignant: Tropoignant;
     inputGepp: Gepp;
@@ -55,7 +55,7 @@ export type OnEstinantResultEvent = Event<
 >;
 
 export type OnEstinant2ResultEvent = Event<
-  EngineEventName.OnEstinant2Result,
+  DigikikifierEventName.OnEstinant2Result,
   {
     tropoignant: Tropoignant2;
     inputGeppTuple: GeppTuple;
@@ -64,7 +64,7 @@ export type OnEstinant2ResultEvent = Event<
   }
 >;
 
-export type OnFinishEvent = Event<EngineEventName.OnFinish>;
+export type OnFinishEvent = Event<DigikikifierEventName.OnFinish>;
 
 export type DigikikifierEvent = Hubblepup<
   | OnTabillyInitializedEvent

--- a/packages/open-schema-type-script/src/example/ciYamlFile/assertableCiYamlFileContents.ts
+++ b/packages/open-schema-type-script/src/example/ciYamlFile/assertableCiYamlFileContents.ts
@@ -59,12 +59,12 @@ export const assertableCiYamlFileCortmumEstinant: Estinant2<
   },
   tropoig: function merge(actual, expected) {
     const actualStringContents: string = fs.readFileSync(
-      actual.grition.filePath,
+      actual.hubblepup.grition.filePath,
       'utf8',
     );
 
     const expectedStringContentsWithPlaceholders = yaml.stringify(
-      expected.grition,
+      expected.hubblepup.grition,
     );
 
     // TODO: learn how to properly manage comments with the yaml library and remove this hack

--- a/packages/open-schema-type-script/src/example/core-debugger/eventDebuggerEstinant.ts
+++ b/packages/open-schema-type-script/src/example/core-debugger/eventDebuggerEstinant.ts
@@ -1,5 +1,6 @@
 import { Estinant2 } from '../../core/estinant';
 import {
+  DigikikifierEvent,
   DigikikifierEventQuirm,
   digikikifierGeppsByIdentifer,
   EventTropoignant,
@@ -10,7 +11,7 @@ import { Struss } from '../../utilities/struss';
 import { fileUtilities } from './fileUtilities';
 
 const debugEvent: EventTropoignant<[]> = (input) => {
-  const event = input;
+  const event: DigikikifierEvent = input.hubblepup;
   const eventId = `${event.time}--${event.name}`;
   const eventFilePath = fileUtilities.getEventFilePath(eventId);
 

--- a/packages/open-schema-type-script/src/example/core-debugger/eventDebuggerEstinant.ts
+++ b/packages/open-schema-type-script/src/example/core-debugger/eventDebuggerEstinant.ts
@@ -1,0 +1,33 @@
+import { Estinant2 } from '../../core/estinant';
+import {
+  DigikikifierEventQuirm,
+  digikikifierGeppsByIdentifer,
+  EventTropoignant,
+} from '../../core/yek';
+import { kodatar } from '../../type-script-adapter/kodataring';
+import { logger } from '../../utilities/logger';
+import { Struss } from '../../utilities/struss';
+import { fileUtilities } from './fileUtilities';
+
+const debugEvent: EventTropoignant<[]> = (input) => {
+  const event = input;
+  const eventId = `${event.time}--${event.name}`;
+  const eventFilePath = fileUtilities.getEventFilePath(eventId);
+
+  fileUtilities.writeFile(
+    eventFilePath,
+    logger.stringifyAsMultipleLines(event),
+  );
+  logger.logText(eventFilePath);
+
+  return [];
+};
+
+export const eventDebuggerEstinant: Estinant2<
+  [DigikikifierEventQuirm],
+  Struss
+> = {
+  inputGeppTuple: [digikikifierGeppsByIdentifer.OnEvent],
+  croard: kodatar,
+  tropoig: debugEvent,
+};

--- a/packages/open-schema-type-script/src/example/core-debugger/fileUtilities.ts
+++ b/packages/open-schema-type-script/src/example/core-debugger/fileUtilities.ts
@@ -13,8 +13,8 @@ export const fileUtilities = {
   getEventFilePath: (fileName: string): string => {
     return posix.join(ENGINE_EVENTS_PATH, `${fileName}.txt`);
   },
-  getCacheFilePath: (): string => {
-    return posix.join(CACHE_PATH, `${uuid.v4()}.txt`);
+  getCacheFilePath: (directoryName: string): string => {
+    return posix.join(CACHE_PATH, directoryName, `${uuid.v4()}.txt`);
   },
   writeFile: (filePath: string, text: string): void => {
     fs.mkdirSync(posix.dirname(filePath), { recursive: true });

--- a/packages/open-schema-type-script/src/example/core-debugger/fileUtilities.ts
+++ b/packages/open-schema-type-script/src/example/core-debugger/fileUtilities.ts
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import { posix } from 'path';
+import * as uuid from 'uuid';
+
+const DEBUG_DIR_PATH = './debug/' as const;
+const ENGINE_EVENTS_PATH = posix.join(DEBUG_DIR_PATH, 'engine-events');
+const CACHE_PATH = posix.join(DEBUG_DIR_PATH, 'cache');
+
+fs.rmSync(DEBUG_DIR_PATH, { recursive: true, force: true });
+fs.mkdirSync(ENGINE_EVENTS_PATH, { recursive: true });
+
+export const fileUtilities = {
+  getEventFilePath: (fileName: string): string => {
+    return posix.join(ENGINE_EVENTS_PATH, `${fileName}.txt`);
+  },
+  getCacheFilePath: (): string => {
+    return posix.join(CACHE_PATH, `${uuid.v4()}.txt`);
+  },
+  writeFile: (filePath: string, text: string): void => {
+    fs.mkdirSync(posix.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, text);
+  },
+};

--- a/packages/open-schema-type-script/src/example/core-debugger/quirmDebuggerEstinant.ts
+++ b/packages/open-schema-type-script/src/example/core-debugger/quirmDebuggerEstinant.ts
@@ -1,0 +1,41 @@
+import { Estinant2 } from '../../core/estinant';
+import { Quirm } from '../../core/quirm';
+import {
+  DigikikifierEventName,
+  DigikikifierEventQuirm,
+  digikikifierGeppsByIdentifer,
+  EventTropoignant,
+} from '../../core/yek';
+import { kodatar } from '../../type-script-adapter/kodataring';
+import { logger } from '../../utilities/logger';
+import { Struss } from '../../utilities/struss';
+import { fileUtilities } from './fileUtilities';
+
+const debugQuirm = (quirm: Quirm): void => {
+  const filePath = fileUtilities.getCacheFilePath();
+  fileUtilities.writeFile(filePath, logger.stringifyAsMultipleLines(quirm));
+};
+
+const debugOutputQuirmTuple: EventTropoignant<[]> = (input) => {
+  const event = input;
+
+  if (event.name !== DigikikifierEventName.OnEstinant2Result) {
+    return [];
+  }
+
+  const outputQuirmTuple = event.data.outputTuple;
+  outputQuirmTuple.forEach((quirm) => {
+    debugQuirm(quirm);
+  });
+
+  return [];
+};
+
+export const quirmDebuggerEstinant: Estinant2<
+  [DigikikifierEventQuirm],
+  Struss
+> = {
+  inputGeppTuple: [digikikifierGeppsByIdentifer.OnEvent],
+  croard: kodatar,
+  tropoig: debugOutputQuirmTuple,
+};

--- a/packages/open-schema-type-script/src/example/core-debugger/quirmDebuggerEstinant.ts
+++ b/packages/open-schema-type-script/src/example/core-debugger/quirmDebuggerEstinant.ts
@@ -1,11 +1,9 @@
 import { Estinant2 } from '../../core/estinant';
 import { Quirm } from '../../core/quirm';
 import {
-  DigikikifierEvent,
-  DigikikifierEventName,
-  DigikikifierEventQuirm,
   digikikifierGeppsByIdentifer,
-  EventTropoignant,
+  QuirmTupleQuirm,
+  QuirmTupleTropoignant,
 } from '../../core/yek';
 import { kodatar } from '../../type-script-adapter/kodataring';
 import { logger } from '../../utilities/logger';
@@ -13,30 +11,25 @@ import { Struss } from '../../utilities/struss';
 import { fileUtilities } from './fileUtilities';
 
 const debugQuirm = (quirm: Quirm): void => {
-  const filePath = fileUtilities.getCacheFilePath();
-  fileUtilities.writeFile(filePath, logger.stringifyAsMultipleLines(quirm));
+  quirm.geppTuple.forEach((gepp) => {
+    const geppDirectoryName = gepp.toString();
+    const filePath = fileUtilities.getCacheFilePath(geppDirectoryName);
+    fileUtilities.writeFile(filePath, logger.stringifyAsMultipleLines(quirm));
+  });
 };
 
-const debugOutputQuirmTuple: EventTropoignant<[]> = (input) => {
-  const event: DigikikifierEvent = input.hubblepup;
+const debugQuirmTuple: QuirmTupleTropoignant<[]> = (quirmTupleQuirm) => {
+  const quirmTuple = quirmTupleQuirm.hubblepup;
 
-  if (event.name !== DigikikifierEventName.OnEstinant2Result) {
-    return [];
-  }
-
-  const outputQuirmTuple = event.data.outputTuple;
-  outputQuirmTuple.forEach((quirm) => {
+  quirmTuple.forEach((quirm) => {
     debugQuirm(quirm);
   });
 
   return [];
 };
 
-export const quirmDebuggerEstinant: Estinant2<
-  [DigikikifierEventQuirm],
-  Struss
-> = {
-  inputGeppTuple: [digikikifierGeppsByIdentifer.OnEvent],
+export const quirmDebuggerEstinant: Estinant2<[QuirmTupleQuirm], Struss> = {
+  inputGeppTuple: [digikikifierGeppsByIdentifer.OnQuirmTuple],
   croard: kodatar,
-  tropoig: debugOutputQuirmTuple,
+  tropoig: debugQuirmTuple,
 };

--- a/packages/open-schema-type-script/src/example/core-debugger/quirmDebuggerEstinant.ts
+++ b/packages/open-schema-type-script/src/example/core-debugger/quirmDebuggerEstinant.ts
@@ -1,6 +1,7 @@
 import { Estinant2 } from '../../core/estinant';
 import { Quirm } from '../../core/quirm';
 import {
+  DigikikifierEvent,
   DigikikifierEventName,
   DigikikifierEventQuirm,
   digikikifierGeppsByIdentifer,
@@ -17,7 +18,7 @@ const debugQuirm = (quirm: Quirm): void => {
 };
 
 const debugOutputQuirmTuple: EventTropoignant<[]> = (input) => {
-  const event = input;
+  const event: DigikikifierEvent = input.hubblepup;
 
   if (event.name !== DigikikifierEventName.OnEstinant2Result) {
     return [];

--- a/packages/open-schema-type-script/src/example/exampleAdapter.ts
+++ b/packages/open-schema-type-script/src/example/exampleAdapter.ts
@@ -52,7 +52,7 @@ const examplePlifalB2 = buildPlifal<'b2', ExampleGrition, BInitialGeppTuple>({
 
 const worWortWort: Haqueler<ExampleAPlifal | ExampleBPlifal> = (input) => {
   // eslint-disable-next-line no-console
-  console.log(`Wort Wort Wort: ${input.grition}`);
+  console.log(`Wort Wort Wort: ${input.hubblepup.grition}`);
 };
 
 const exampleWortinatorHamletive = buildWortinatorHamletive<

--- a/packages/open-schema-type-script/src/example/exampleCore.ts
+++ b/packages/open-schema-type-script/src/example/exampleCore.ts
@@ -9,6 +9,8 @@ import { Quirm } from '../core/quirm';
 import { TropoignantTypeName } from '../core/tropoignant';
 import { blindCastEstinants } from './blindCastEstinants';
 import { eventLogger } from '../type-script-adapter/debugger/eventLogger';
+import { quirmDebuggerEstinant } from './core-debugger/quirmDebuggerEstinant';
+import { eventDebuggerEstinant } from './core-debugger/eventDebuggerEstinant';
 
 const exampleGeppInitialInput: Gepp = 'gepp-initial-input';
 const exampleGeppA: Gepp = 'gepp-a';
@@ -153,6 +155,8 @@ digikikify({
     exampleQuirmB2,
   ],
   estinantTuple: blindCastEstinants([
+    eventDebuggerEstinant,
+    quirmDebuggerEstinant,
     exampleOnamaEstinant,
     exampleWortinatorEstinant,
     exampleMentursectionEstinant,

--- a/packages/open-schema-type-script/src/example/exampleCore.ts
+++ b/packages/open-schema-type-script/src/example/exampleCore.ts
@@ -8,7 +8,6 @@ import { Gepp } from '../core/gepp';
 import { Quirm } from '../core/quirm';
 import { TropoignantTypeName } from '../core/tropoignant';
 import { blindCastEstinants } from './blindCastEstinants';
-import { eventLogger } from '../type-script-adapter/debugger/eventLogger';
 import { quirmDebuggerEstinant } from './core-debugger/quirmDebuggerEstinant';
 import { eventDebuggerEstinant } from './core-debugger/eventDebuggerEstinant';
 
@@ -79,8 +78,6 @@ const exampleMentursectionEstinant: MentursectionEstinant<ExampleHubblepup> = {
     },
   },
 };
-
-const exampleWortinatorEstinant = eventLogger;
 
 const exampleCortmumEstinant2: Estinant2<[ExampleQuirm, ExampleQuirm], string> =
   {
@@ -158,7 +155,6 @@ digikikify({
     eventDebuggerEstinant,
     quirmDebuggerEstinant,
     exampleOnamaEstinant,
-    exampleWortinatorEstinant,
     exampleMentursectionEstinant,
     exampleCortmumEstinant2,
     exampleOnamaEstinant2,

--- a/packages/open-schema-type-script/src/example/exampleCore.ts
+++ b/packages/open-schema-type-script/src/example/exampleCore.ts
@@ -85,8 +85,8 @@ const exampleWortinatorEstinant = eventLogger;
 const exampleCortmumEstinant2: Estinant2<[ExampleQuirm, ExampleQuirm], string> =
   {
     inputGeppTuple: [exampleGeppA, exampleGeppB],
-    croard: function getId(input) {
-      const [, numberText] = input.split('-') as [string, '1' | '2'];
+    croard: function getId(quirm) {
+      const [, numberText] = quirm.hubblepup.split('-') as [string, '1' | '2'];
       return numberText;
     },
     tropoig: function join(hubblepupA, hubblepupB) {
@@ -104,13 +104,13 @@ const exampleCortmumEstinant2: Estinant2<[ExampleQuirm, ExampleQuirm], string> =
 
 const exampleOnamaEstinant2: Estinant2<[ExampleQuirm], symbol> = {
   inputGeppTuple: [exampleGeppInitialInput],
-  croard: function getId(input) {
-    return Symbol(input);
+  croard: function getId(quirm) {
+    return Symbol(quirm.hubblepup);
   },
-  tropoig: function sayWhattup(input) {
+  tropoig: function sayWhattup(quirm) {
     const output: ExampleQuirm = {
       geppTuple: [exampleGeppWhattup],
-      hubblepup: `Whattup: ${input}`,
+      hubblepup: `Whattup: ${quirm.hubblepup}`,
     };
 
     return [output];
@@ -119,12 +119,12 @@ const exampleOnamaEstinant2: Estinant2<[ExampleQuirm], symbol> = {
 
 const exampleWortinatorEstinant2: Estinant2<[ExampleQuirm], symbol> = {
   inputGeppTuple: [exampleGeppInitialInput],
-  croard: function getId(input) {
-    return Symbol(input);
+  croard: function getId(quirm) {
+    return Symbol(quirm.hubblepup);
   },
-  tropoig: function sayWhattup(input) {
+  tropoig: function sayWhattup(quirm) {
     // eslint-disable-next-line no-console
-    console.log(`Wort Wort Wort: ${input}`);
+    console.log(`Wort Wort Wort: ${quirm.hubblepup}`);
 
     return [];
   },
@@ -132,15 +132,15 @@ const exampleWortinatorEstinant2: Estinant2<[ExampleQuirm], symbol> = {
 
 const exampleMentursectionEstinant2: Estinant2<[ExampleQuirm], symbol> = {
   inputGeppTuple: [exampleGeppInitialInput],
-  croard: function getId(input) {
-    return Symbol(input);
+  croard: function getId(quirm) {
+    return Symbol(quirm.hubblepup);
   },
-  tropoig: function sayWhattup(input) {
-    const isA = input.startsWith('a');
+  tropoig: function sayWhattup(quirm) {
+    const isA = quirm.hubblepup.startsWith('a');
 
     const output: ExampleQuirm = {
       geppTuple: [isA ? exampleGeppA2 : exampleGeppB2],
-      hubblepup: input,
+      hubblepup: quirm.hubblepup,
     };
 
     return [output];

--- a/packages/open-schema-type-script/src/type-script-adapter/debugger/eventLogger.ts
+++ b/packages/open-schema-type-script/src/type-script-adapter/debugger/eventLogger.ts
@@ -1,14 +1,14 @@
 import { WortinatorEstinant } from '../../core/estinant';
 import { TropoignantTypeName } from '../../core/tropoignant';
 import {
-  DigikikifierEvent,
+  DigikikifierEventHubblepup,
   digikikifierGeppsByIdentifer,
   DigikikifierEventName,
 } from '../../core/yek';
 import { logger } from '../../utilities/logger';
 import { fileUtilities } from './fileUtilities';
 
-export const eventLogger: WortinatorEstinant<DigikikifierEvent> = {
+export const eventLogger: WortinatorEstinant<DigikikifierEventHubblepup> = {
   inputGepp: digikikifierGeppsByIdentifer.OnEvent,
   tropoignant: {
     typeName: TropoignantTypeName.Wortinator,

--- a/packages/open-schema-type-script/src/type-script-adapter/debugger/eventLogger.ts
+++ b/packages/open-schema-type-script/src/type-script-adapter/debugger/eventLogger.ts
@@ -3,7 +3,7 @@ import { TropoignantTypeName } from '../../core/tropoignant';
 import {
   DigikikifierEvent,
   digikikifierGeppsByIdentifer,
-  EngineEventName,
+  DigikikifierEventName,
 } from '../../core/yek';
 import { logger } from '../../utilities/logger';
 import { fileUtilities } from './fileUtilities';
@@ -17,8 +17,8 @@ export const eventLogger: WortinatorEstinant<DigikikifierEvent> = {
       const eventFilePath = fileUtilities.getEventFilePath(eventId);
 
       if (
-        event.name !== EngineEventName.OnEstinantResult &&
-        event.name !== EngineEventName.OnEstinant2Result
+        event.name !== DigikikifierEventName.OnEstinantResult &&
+        event.name !== DigikikifierEventName.OnEstinant2Result
       ) {
         fileUtilities.writeFile(
           eventFilePath,

--- a/packages/open-schema-type-script/src/type-script-adapter/debugger/odeshinLogger.ts
+++ b/packages/open-schema-type-script/src/type-script-adapter/debugger/odeshinLogger.ts
@@ -4,7 +4,9 @@ import { ODESHIN_GEPP } from '../odeshin';
 import { Plifal } from '../plifal';
 import { fileUtilities } from './fileUtilities';
 
-const cacheOdeshin: Haqueler<Plifal> = (odeshin) => {
+const cacheOdeshin: Haqueler<Plifal> = (plifal) => {
+  const odeshin = plifal.hubblepup;
+
   // TODO: standardize this convention somehow
   const typeName = odeshin.identifier.split(':')[0];
 

--- a/packages/open-schema-type-script/src/type-script-adapter/hamletive/wortinator.ts
+++ b/packages/open-schema-type-script/src/type-script-adapter/hamletive/wortinator.ts
@@ -5,14 +5,14 @@ import { kodatar } from '../kodataring';
 import { Plifal, PlifalToGeppUnion } from '../plifal';
 
 export type Haqueler<TInputPlifal extends Plifal> = (
-  input: TInputPlifal['hubblepup'],
+  input: TInputPlifal,
 ) => void;
 
 /**
  * A one to zero Tropoignant
  */
 export type Wortinator<TInputPlifal extends Plifal> = Tropoignant2<
-  [TInputPlifal['hubblepup']],
+  [TInputPlifal],
   []
 >;
 

--- a/packages/open-schema-type-script/src/type-script-adapter/kodataring.ts
+++ b/packages/open-schema-type-script/src/type-script-adapter/kodataring.ts
@@ -1,12 +1,12 @@
 import * as uuid from 'uuid';
 import { Croarder } from '../core/croarder';
-import { Dalph } from '../utilities/dalph';
+import { QuirmDalph } from '../core/quirm';
 import { Struss } from '../utilities/struss';
 
 /**
  * A Croarder that always returns something unique, regardless of the input
  */
-export type Kodataring = Croarder<Dalph, Struss>;
+export type Kodataring = Croarder<QuirmDalph, Struss>;
 
 /**
  * A Croarder that always returns something unique, regardless of the input


### PR DESCRIPTION
Tropoignants operate on Voictents of Quirms so it makes sense for the inputs to be Quirms instead of Hubblepups. This also makes it easier to debug the state of the engine since we can see the Gepps that a Quirm belongs to, but not for a Hubblepup.