### PR TITLE
More TypeScript adapter types

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "description": "Testing frameworks on testing frameworks",
   "private": true,
   "scripts": {
-    "open-schema-example": "ts-node packages/open-schema-type-script/src/v1/example/index.ts",
+    "example-core": "ts-node packages/open-schema-type-script/src/example/core/exampleCore.ts",
+    "example-adapter": "ts-node packages/open-schema-type-script/src/example/adapter/exampleAdapter.ts",
+    "example-custom": "ts-node packages/open-schema-type-script/src/example/custom/exampleCustom.ts",
     "describe:repository": "npm run open-schema-example -- r",
-    "lint:repository": "ts-node packages/open-schema-type-script/src/example/custom/exampleCustom.ts",
+    "lint:repository": "npm run example-custom",
     "lint:ts:all": "npm run --silent lint:ts .",
     "lint:ts:fix-all": "npm run --silent lint:ts -- --fix .",
     "lint:ts": "eslint --color --max-warnings 0 --ext ts,js",

--- a/packages/open-schema-type-script/README.md
+++ b/packages/open-schema-type-script/README.md
@@ -13,10 +13,10 @@ An Open Schema implementation that is used to iterate on the Open Schema specifi
 # One time install
 npm ci
 
-# Run the Open Schema example(s): They will output files that contain engine event information
-packages/open-schema-type-script/src/example/core/exampleCore.ts
-packages/open-schema-type-script/src/example/adapter/exampleAdapter.ts
-packages/open-schema-type-script/src/example/custom/exampleCustom.ts
+# Run the Open Schema example(s): They will output files that contain engine event information. See the debug/ directory
+npm run example-core
+npm run example-adapter
+npm run example-custom
 ```
 
 ## Terminology

--- a/packages/open-schema-type-script/src/core/quirm.ts
+++ b/packages/open-schema-type-script/src/core/quirm.ts
@@ -16,6 +16,14 @@ export type Quirm<
   hubblepup: THubblepup;
 };
 
+export type Quirm2<
+  TGeppTuple extends GeppTuple = GeppTuple,
+  THubblepup extends Hubblepup = Hubblepup,
+> = {
+  geppTuple: TGeppTuple;
+  hubblepup: THubblepup;
+};
+
 export type QuirmToGeppUnion<TQuirm extends Quirm> =
   TQuirm['geppTuple'][number];
 

--- a/packages/open-schema-type-script/src/core/straline.ts
+++ b/packages/open-schema-type-script/src/core/straline.ts
@@ -3,6 +3,8 @@
  */
 export type Straline = unknown;
 
+export type StralineTuple = readonly Straline[];
+
 /**
  * The engine's specific implementation of "null".
  * This prevents the engine from conflating the purpose of TypeScript's "null" and "undefined" with the engine's need to know if something is "null".

--- a/packages/open-schema-type-script/src/example/adapter/constructs/exampleA.ts
+++ b/packages/open-schema-type-script/src/example/adapter/constructs/exampleA.ts
@@ -1,0 +1,26 @@
+import { Gepp } from '../../../core/gepp';
+import { Hubblepup } from '../../../core/hubblepup';
+import { Quirm2 } from '../../../core/quirm';
+import { InitialInputGeppTuple } from './initialInputGepp';
+
+export type ExampleA = string;
+
+export type ExampleAHubblepup = Hubblepup<ExampleA>;
+
+export type ExampleAGepp = Gepp<'example-a'>;
+
+export type AInitialGeppTuple = InitialInputGeppTuple<[ExampleAGepp]>;
+
+export type ExampleAQuirm = Quirm2<AInitialGeppTuple, ExampleAHubblepup>;
+
+const quirmA1: ExampleAQuirm = {
+  geppTuple: ['initial-input', 'example-a'],
+  hubblepup: 'a-1',
+};
+
+const quirmA2: ExampleAQuirm = {
+  geppTuple: ['initial-input', 'example-a'],
+  hubblepup: 'a-2',
+};
+
+export const exampleAQuirmTuple = [quirmA1, quirmA2] as const;

--- a/packages/open-schema-type-script/src/example/adapter/constructs/exampleB.ts
+++ b/packages/open-schema-type-script/src/example/adapter/constructs/exampleB.ts
@@ -1,0 +1,26 @@
+import { Gepp } from '../../../core/gepp';
+import { Hubblepup } from '../../../core/hubblepup';
+import { Quirm2 } from '../../../core/quirm';
+import { InitialInputGeppTuple } from './initialInputGepp';
+
+export type ExampleB = string;
+
+export type ExampleBHubblepup = Hubblepup<ExampleB>;
+
+export type ExampleBGepp = Gepp<'example-b'>;
+
+export type BInitialGeppTuple = InitialInputGeppTuple<[ExampleBGepp]>;
+
+export type ExampleBQuirm = Quirm2<BInitialGeppTuple, ExampleBHubblepup>;
+
+const quirmB1: ExampleBQuirm = {
+  geppTuple: ['initial-input', 'example-b'],
+  hubblepup: 'b-1',
+};
+
+const quirmB2: ExampleBQuirm = {
+  geppTuple: ['initial-input', 'example-b'],
+  hubblepup: 'b-2',
+};
+
+export const exampleBQuirmTuple = [quirmB1, quirmB2] as const;

--- a/packages/open-schema-type-script/src/example/adapter/constructs/exampleDash1.ts
+++ b/packages/open-schema-type-script/src/example/adapter/constructs/exampleDash1.ts
@@ -1,0 +1,14 @@
+import { Gepp } from '../../../core/gepp';
+import { Hubblepup } from '../../../core/hubblepup';
+import { Quirm2 } from '../../../core/quirm';
+
+export type ExampleDash1Gepp = Gepp<'example-dash-1'>;
+
+export type ExampleDash1 = string;
+
+export type ExampleDash1Hubblepup = Hubblepup<ExampleDash1>;
+
+export type ExampleDash1Quirm = Quirm2<
+  [ExampleDash1Gepp],
+  ExampleDash1Hubblepup
+>;

--- a/packages/open-schema-type-script/src/example/adapter/constructs/exampleDash2.ts
+++ b/packages/open-schema-type-script/src/example/adapter/constructs/exampleDash2.ts
@@ -1,0 +1,14 @@
+import { Gepp } from '../../../core/gepp';
+import { Hubblepup } from '../../../core/hubblepup';
+import { Quirm2 } from '../../../core/quirm';
+
+export type ExampleDash2Gepp = Gepp<'example-dash-2'>;
+
+export type ExampleDash2 = string;
+
+export type ExampleDash2Hubblepup = Hubblepup<ExampleDash2>;
+
+export type ExampleDash2Quirm = Quirm2<
+  [ExampleDash2Gepp],
+  ExampleDash2Hubblepup
+>;

--- a/packages/open-schema-type-script/src/example/adapter/constructs/exampleMentursectionHamletive.ts
+++ b/packages/open-schema-type-script/src/example/adapter/constructs/exampleMentursectionHamletive.ts
@@ -1,0 +1,43 @@
+import {
+  buildMentursectionHamletive,
+  Paraker,
+} from '../../../type-script-adapter/hamletive/mentursection';
+import { QuirmOptionTuple } from '../../../type-script-adapter/quirmOptionTuple';
+import { ExampleAQuirm } from './exampleA';
+import { ExampleBQuirm } from './exampleB';
+import { ExampleDash1, ExampleDash1Quirm } from './exampleDash1';
+import { ExampleDash2Quirm } from './exampleDash2';
+
+type InputOptionTuple = QuirmOptionTuple<[ExampleAQuirm, ExampleBQuirm]>;
+type OutputOptionTuple = QuirmOptionTuple<
+  [ExampleDash1Quirm, ExampleDash2Quirm]
+>;
+
+const isDash1: Paraker<
+  InputOptionTuple,
+  OutputOptionTuple,
+  ExampleDash1Quirm
+> = (input): input is ExampleDash1 => input.endsWith('-1');
+
+const isDash2: Paraker<
+  InputOptionTuple,
+  OutputOptionTuple,
+  ExampleDash2Quirm
+> = (input): input is ExampleDash1 => input.endsWith('-2');
+
+export const exampleMentursectionHamletive = buildMentursectionHamletive<
+  InputOptionTuple,
+  OutputOptionTuple
+>({
+  inputGepp: 'initial-input',
+  kerzTuple: [
+    {
+      outputGeppTuple: ['example-dash-1'],
+      parak: isDash1,
+    },
+    {
+      outputGeppTuple: ['example-dash-2'],
+      parak: isDash2,
+    },
+  ],
+});

--- a/packages/open-schema-type-script/src/example/adapter/constructs/exampleOnamaHamletive.ts
+++ b/packages/open-schema-type-script/src/example/adapter/constructs/exampleOnamaHamletive.ts
@@ -1,0 +1,37 @@
+import { Gepp } from '../../../core/gepp';
+import { Hubblepup } from '../../../core/hubblepup';
+import { Quirm2 } from '../../../core/quirm';
+import {
+  Ankeler,
+  buildOnamaHamletive,
+} from '../../../type-script-adapter/hamletive/onama';
+import { QuirmOptionTuple } from '../../../type-script-adapter/quirmOptionTuple';
+import { ExampleAQuirm } from './exampleA';
+import { ExampleBQuirm } from './exampleB';
+
+type HelloGepp = Gepp<'hello'>;
+
+type HelloHubblepup = Hubblepup<string>;
+
+type HelloQuirm = Quirm2<[HelloGepp], HelloHubblepup>;
+
+type SayHelloQuirmOptionTuple = QuirmOptionTuple<
+  [ExampleAQuirm, ExampleBQuirm]
+>;
+
+const sayHello: Ankeler<SayHelloQuirmOptionTuple, HelloQuirm> = (input) => {
+  const output: HelloQuirm = {
+    geppTuple: ['hello'],
+    hubblepup: `Hello: ${input.hubblepup}`,
+  };
+
+  return output;
+};
+
+export const exampleOnamaHamletive = buildOnamaHamletive<
+  SayHelloQuirmOptionTuple,
+  HelloQuirm
+>({
+  inputGepp: 'initial-input',
+  ankel: sayHello,
+});

--- a/packages/open-schema-type-script/src/example/adapter/constructs/exampleWortinatorHamletive.ts
+++ b/packages/open-schema-type-script/src/example/adapter/constructs/exampleWortinatorHamletive.ts
@@ -1,0 +1,22 @@
+import {
+  Haqueler,
+  buildWortinatorHamletive,
+} from '../../../type-script-adapter/hamletive/wortinator';
+import { QuirmOptionTuple } from '../../../type-script-adapter/quirmOptionTuple';
+import { ExampleAQuirm } from './exampleA';
+import { ExampleBQuirm } from './exampleB';
+
+type WortWortWortQuirmOptionTuple = QuirmOptionTuple<
+  [ExampleAQuirm, ExampleBQuirm]
+>;
+
+const worWortWort: Haqueler<WortWortWortQuirmOptionTuple> = (input) => {
+  // eslint-disable-next-line no-console
+  console.log(`Wort Wort Wort: ${input.hubblepup}`);
+};
+
+export const exampleWortinatorHamletive =
+  buildWortinatorHamletive<WortWortWortQuirmOptionTuple>({
+    inputGepp: 'initial-input',
+    haquel: worWortWort,
+  });

--- a/packages/open-schema-type-script/src/example/adapter/constructs/initialInputGepp.ts
+++ b/packages/open-schema-type-script/src/example/adapter/constructs/initialInputGepp.ts
@@ -1,0 +1,8 @@
+import { Gepp, GeppTuple } from '../../../core/gepp';
+
+export type InitialInputGepp = Gepp<'initial-input'>;
+
+export type InitialInputGeppTuple<TGeppTuple extends GeppTuple> = [
+  InitialInputGepp,
+  ...TGeppTuple,
+];

--- a/packages/open-schema-type-script/src/example/adapter/exampleAdapter.ts
+++ b/packages/open-schema-type-script/src/example/adapter/exampleAdapter.ts
@@ -1,62 +1,13 @@
 import { digikikify } from '../../core/digikikify';
-import { Gepp } from '../../core/gepp';
 import { blindCastEstinants } from './blindCastEstinants';
-import {
-  buildWortinatorHamletive,
-  Haqueler,
-} from '../../type-script-adapter/hamletive/wortinator';
 import { eventDebuggerEstinant } from '../core/debugger/eventDebuggerEstinant';
 import { quirmDebuggerEstinant } from '../core/debugger/quirmDebuggerEstinant';
-import { Hubblepup } from '../../core/hubblepup';
-import { Quirm2 } from '../../core/quirm';
-
-type InitialInputGepp = Gepp<'initial-input'>;
-
-type AGepp = Gepp<'a'>;
-type BGepp = Gepp<'b'>;
-
-type ExampleHubblepup = Hubblepup<string>;
-
-type AInitialGeppTuple = [InitialInputGepp, AGepp];
-type ExampleAQuirm = Quirm2<AInitialGeppTuple, ExampleHubblepup>;
-
-const quirmA1: ExampleAQuirm = {
-  geppTuple: ['initial-input', 'a'],
-  hubblepup: 'a-1',
-};
-
-const quirmA2: ExampleAQuirm = {
-  geppTuple: ['initial-input', 'a'],
-  hubblepup: 'a-2',
-};
-
-type BInitialGeppTuple = [InitialInputGepp, BGepp];
-type ExampleBQuirm = Quirm2<BInitialGeppTuple, ExampleHubblepup>;
-
-const quirmB1: ExampleBQuirm = {
-  geppTuple: ['initial-input', 'b'],
-  hubblepup: 'b-1',
-};
-
-const examplePlifalB2: ExampleBQuirm = {
-  geppTuple: ['initial-input', 'b'],
-  hubblepup: 'b-2',
-};
-
-const worWortWort: Haqueler<ExampleAQuirm | ExampleBQuirm> = (input) => {
-  // eslint-disable-next-line no-console
-  console.log(`Wort Wort Wort: ${input.hubblepup}`);
-};
-
-const exampleWortinatorHamletive = buildWortinatorHamletive<
-  ExampleAQuirm | ExampleBQuirm
->({
-  inputGepp: 'initial-input',
-  haquel: worWortWort,
-});
+import { exampleAQuirmTuple } from './constructs/exampleA';
+import { exampleBQuirmTuple } from './constructs/exampleB';
+import { exampleWortinatorHamletive } from './constructs/exampleWortinatorHamletive';
 
 digikikify({
-  initialQuirmTuple: [quirmA1, quirmA2, quirmB1, examplePlifalB2],
+  initialQuirmTuple: [...exampleAQuirmTuple, ...exampleBQuirmTuple],
   estinantTuple: blindCastEstinants([
     eventDebuggerEstinant,
     quirmDebuggerEstinant,

--- a/packages/open-schema-type-script/src/example/adapter/exampleAdapter.ts
+++ b/packages/open-schema-type-script/src/example/adapter/exampleAdapter.ts
@@ -6,6 +6,7 @@ import { exampleAQuirmTuple } from './constructs/exampleA';
 import { exampleBQuirmTuple } from './constructs/exampleB';
 import { exampleWortinatorHamletive } from './constructs/exampleWortinatorHamletive';
 import { exampleOnamaHamletive } from './constructs/exampleOnamaHamletive';
+import { exampleMentursectionHamletive } from './constructs/exampleMentursectionHamletive';
 
 digikikify({
   initialQuirmTuple: [...exampleAQuirmTuple, ...exampleBQuirmTuple],
@@ -14,6 +15,7 @@ digikikify({
     quirmDebuggerEstinant,
     exampleWortinatorHamletive,
     exampleOnamaHamletive,
+    exampleMentursectionHamletive,
   ]),
 });
 

--- a/packages/open-schema-type-script/src/example/adapter/exampleAdapter.ts
+++ b/packages/open-schema-type-script/src/example/adapter/exampleAdapter.ts
@@ -5,70 +5,58 @@ import {
   buildWortinatorHamletive,
   Haqueler,
 } from '../../type-script-adapter/hamletive/wortinator';
-import { Odeshin } from '../custom/custom-constructs/odeshin';
-import { Grition } from '../custom/custom-constructs/grition';
-import { buildPlifal, Plifal } from '../custom/custom-constructs/plifal';
 import { eventDebuggerEstinant } from '../core/debugger/eventDebuggerEstinant';
 import { quirmDebuggerEstinant } from '../core/debugger/quirmDebuggerEstinant';
+import { Hubblepup } from '../../core/hubblepup';
+import { Quirm2 } from '../../core/quirm';
 
 type InitialInputGepp = Gepp<'initial-input'>;
 
 type AGepp = Gepp<'a'>;
 type BGepp = Gepp<'b'>;
 
-type ExampleGrition = Grition<string>;
-
-type ExampleOdeshin = Odeshin<string, ExampleGrition>;
+type ExampleHubblepup = Hubblepup<string>;
 
 type AInitialGeppTuple = [InitialInputGepp, AGepp];
-type ExampleAPlifal = Plifal<AInitialGeppTuple, ExampleOdeshin>;
+type ExampleAQuirm = Quirm2<AInitialGeppTuple, ExampleHubblepup>;
 
-const examplePlifalA1 = buildPlifal<'a1', ExampleGrition, AInitialGeppTuple>({
+const quirmA1: ExampleAQuirm = {
   geppTuple: ['initial-input', 'a'],
-  identifier: 'a1',
-  grition: 'a-1',
-});
+  hubblepup: 'a-1',
+};
 
-const examplePlifalA2 = buildPlifal<'a2', ExampleGrition, AInitialGeppTuple>({
+const quirmA2: ExampleAQuirm = {
   geppTuple: ['initial-input', 'a'],
-  identifier: 'a2',
-  grition: 'a-2',
-});
+  hubblepup: 'a-2',
+};
 
 type BInitialGeppTuple = [InitialInputGepp, BGepp];
-type ExampleBPlifal = Plifal<BInitialGeppTuple, ExampleOdeshin>;
+type ExampleBQuirm = Quirm2<BInitialGeppTuple, ExampleHubblepup>;
 
-const examplePlifalB1 = buildPlifal<'b1', ExampleGrition, BInitialGeppTuple>({
+const quirmB1: ExampleBQuirm = {
   geppTuple: ['initial-input', 'b'],
-  identifier: 'b1',
-  grition: 'b-1',
-});
+  hubblepup: 'b-1',
+};
 
-const examplePlifalB2 = buildPlifal<'b2', ExampleGrition, BInitialGeppTuple>({
+const examplePlifalB2: ExampleBQuirm = {
   geppTuple: ['initial-input', 'b'],
-  identifier: 'b2',
-  grition: 'b-2',
-});
+  hubblepup: 'b-2',
+};
 
-const worWortWort: Haqueler<ExampleAPlifal | ExampleBPlifal> = (input) => {
+const worWortWort: Haqueler<ExampleAQuirm | ExampleBQuirm> = (input) => {
   // eslint-disable-next-line no-console
-  console.log(`Wort Wort Wort: ${input.hubblepup.grition}`);
+  console.log(`Wort Wort Wort: ${input.hubblepup}`);
 };
 
 const exampleWortinatorHamletive = buildWortinatorHamletive<
-  ExampleAPlifal | ExampleBPlifal
+  ExampleAQuirm | ExampleBQuirm
 >({
   inputGepp: 'initial-input',
   haquel: worWortWort,
 });
 
 digikikify({
-  initialQuirmTuple: [
-    examplePlifalA1,
-    examplePlifalA2,
-    examplePlifalB1,
-    examplePlifalB2,
-  ],
+  initialQuirmTuple: [quirmA1, quirmA2, quirmB1, examplePlifalB2],
   estinantTuple: blindCastEstinants([
     eventDebuggerEstinant,
     quirmDebuggerEstinant,

--- a/packages/open-schema-type-script/src/example/adapter/exampleAdapter.ts
+++ b/packages/open-schema-type-script/src/example/adapter/exampleAdapter.ts
@@ -5,6 +5,7 @@ import { quirmDebuggerEstinant } from '../core/debugger/quirmDebuggerEstinant';
 import { exampleAQuirmTuple } from './constructs/exampleA';
 import { exampleBQuirmTuple } from './constructs/exampleB';
 import { exampleWortinatorHamletive } from './constructs/exampleWortinatorHamletive';
+import { exampleOnamaHamletive } from './constructs/exampleOnamaHamletive';
 
 digikikify({
   initialQuirmTuple: [...exampleAQuirmTuple, ...exampleBQuirmTuple],
@@ -12,6 +13,7 @@ digikikify({
     eventDebuggerEstinant,
     quirmDebuggerEstinant,
     exampleWortinatorHamletive,
+    exampleOnamaHamletive,
   ]),
 });
 

--- a/packages/open-schema-type-script/src/example/custom/debugger/odeshinLogger.ts
+++ b/packages/open-schema-type-script/src/example/custom/debugger/odeshinLogger.ts
@@ -6,8 +6,9 @@ import {
 import { ODESHIN_GEPP } from '../custom-constructs/odeshin';
 import { Plifal } from '../custom-constructs/plifal';
 import { fileUtilities } from './fileUtilities';
+import { QuirmOptionTuple } from '../../../type-script-adapter/quirmOptionTuple';
 
-const cacheOdeshin: Haqueler<Plifal> = (plifal) => {
+const cacheOdeshin: Haqueler<QuirmOptionTuple<[Plifal]>> = (plifal) => {
   const odeshin = plifal.hubblepup;
 
   // TODO: standardize this convention somehow

--- a/packages/open-schema-type-script/src/type-script-adapter/hamletive/hamletive.ts
+++ b/packages/open-schema-type-script/src/type-script-adapter/hamletive/hamletive.ts
@@ -1,7 +1,8 @@
 import { Quirm } from '../../core/quirm';
+import { QuirmOptionTuple } from '../quirmOptionTuple';
 import { WortinatorHamletive } from './wortinator';
 
 /**
  * An Estinant that takes TypeScript concerns into consideration
  */
-export type Hamletive = WortinatorHamletive<Quirm>;
+export type Hamletive = WortinatorHamletive<QuirmOptionTuple<[Quirm]>>;

--- a/packages/open-schema-type-script/src/type-script-adapter/hamletive/mentursection.ts
+++ b/packages/open-schema-type-script/src/type-script-adapter/hamletive/mentursection.ts
@@ -1,1 +1,139 @@
-// one to many
+import { Estinant2 } from '../../core/estinant';
+import { GeppTuple } from '../../core/gepp';
+import { QuirmTupleToGeppTuple } from '../../core/quirm';
+import { Straline } from '../../core/straline';
+import { Tropoignant2 } from '../../core/tropoignant';
+import { Struss } from '../../utilities/struss';
+import { kodatar } from '../kodataring';
+import {
+  QuirmOption,
+  QuirmOptionTuple,
+  QuirmOptionTupleToGeppOptionIntersection,
+} from '../quirmOptionTuple';
+
+type Predicate = (input: Straline) => boolean;
+
+/**
+ * A function to check if a Hubblepup can be recategorized
+ */
+export type Paraker<
+  TInputQuirmOptionTuple extends QuirmOptionTuple,
+  TOutputQuirmOptionTuple extends QuirmOptionTuple,
+  TOutputQuirm extends QuirmOption<TOutputQuirmOptionTuple>,
+> = TOutputQuirm['hubblepup'] extends QuirmOption<TInputQuirmOptionTuple>['hubblepup']
+  ? (
+      input: QuirmOption<TInputQuirmOptionTuple>['hubblepup'],
+    ) => input is TOutputQuirm['hubblepup']
+  : (input: QuirmOption<TInputQuirmOptionTuple>['hubblepup']) => false;
+
+type BaseKerz<TOutputGeppTuple extends GeppTuple, TParak extends Predicate> = {
+  outputGeppTuple: TOutputGeppTuple;
+  parak: TParak;
+};
+
+type NullKerz = BaseKerz<[], () => false>;
+
+const NULL_KERZ: NullKerz = {
+  outputGeppTuple: [],
+  parak: () => false,
+};
+
+/**
+ * A collection of a Paraker, and the Gepp tuple that will recategorize a Quirm, if the Quirm's Hubblepup passes the Paraker
+ */
+export type Kerz<
+  TInputQuirmOptionTuple extends QuirmOptionTuple,
+  TOutputQuirmOptionTuple extends QuirmOptionTuple,
+  TOutputQuirm extends QuirmOption<TOutputQuirmOptionTuple>,
+> = TOutputQuirm['hubblepup'] extends QuirmOption<TInputQuirmOptionTuple>['hubblepup']
+  ? BaseKerz<
+      TOutputQuirm['geppTuple'],
+      Paraker<TInputQuirmOptionTuple, TOutputQuirmOptionTuple, TOutputQuirm>
+    >
+  : NullKerz;
+
+export type KerzTuple<
+  TInputQuirmOptionTuple extends QuirmOptionTuple,
+  TOutputQuirmOptionTuple extends QuirmOptionTuple,
+> = {
+  [Index in keyof TOutputQuirmOptionTuple]: Kerz<
+    TInputQuirmOptionTuple,
+    TOutputQuirmOptionTuple,
+    TOutputQuirmOptionTuple[Index]
+  >;
+};
+
+/**
+ * A one to one Tropoignant that is used to recategorize a Quirm via zero or more Gepps
+ */
+export type Mentursection<
+  TInputQuirmOptionTuple extends QuirmOptionTuple,
+  TOutputQuirmOptionTuple extends QuirmOptionTuple,
+> = Tropoignant2<
+  [QuirmOption<TInputQuirmOptionTuple>],
+  [QuirmOption<TOutputQuirmOptionTuple>]
+>;
+
+/**
+ * A one to one Estinant that is used to recategorize a Quirm via zero or more Gepps
+ */
+export type MentursectionHamletive<
+  TInputQuirmOptionTuple extends QuirmOptionTuple,
+> = Estinant2<[QuirmOption<TInputQuirmOptionTuple>], Struss>;
+
+export type MentursectionHamletiveBuilderInput<
+  TInputQuirmOptionTuple extends QuirmOptionTuple,
+  TOutputQuirmOptionTuple extends QuirmOptionTuple,
+> = {
+  inputGepp: QuirmOptionTupleToGeppOptionIntersection<TInputQuirmOptionTuple>;
+  kerzTuple: KerzTuple<TInputQuirmOptionTuple, TOutputQuirmOptionTuple>;
+};
+
+export const buildMentursectionHamletive = <
+  TInputQuirmOptionTuple extends QuirmOptionTuple,
+  TOutputQuirmOptionTuple extends QuirmOptionTuple,
+>({
+  inputGepp,
+  kerzTuple,
+}: MentursectionHamletiveBuilderInput<
+  TInputQuirmOptionTuple,
+  TOutputQuirmOptionTuple
+>): MentursectionHamletive<TInputQuirmOptionTuple> => {
+  const tropoig: Mentursection<
+    TInputQuirmOptionTuple,
+    TOutputQuirmOptionTuple
+  > = (input) => {
+    const { outputGeppTuple } =
+      kerzTuple.find((kerz) => kerz.parak(input.hubblepup)) ?? NULL_KERZ;
+
+    const outputGeppTupleSet = new Set(outputGeppTuple);
+
+    const sameGepps = input.geppTuple
+      .filter((inputQuirmGepp) => outputGeppTupleSet.has(inputQuirmGepp))
+      .map((inputQuirmGepp) => inputQuirmGepp.toString());
+    if (sameGepps.length > 0) {
+      const serializedSameGepps = sameGepps.join(', ');
+      // TODO: update the Engine to not loop forever when an output Quirm has the same Gepp as its input
+      throw Error(
+        `Unhandled scenario. Output has same gepps as input: [${serializedSameGepps}]`,
+      );
+    }
+
+    const outputQuirm: QuirmOption<TOutputQuirmOptionTuple> = {
+      geppTuple: outputGeppTuple,
+      hubblepup: input.hubblepup,
+    };
+
+    return [outputQuirm];
+  };
+
+  const hamletive: MentursectionHamletive<TInputQuirmOptionTuple> = {
+    inputGeppTuple: [inputGepp] as QuirmTupleToGeppTuple<
+      [QuirmOption<TInputQuirmOptionTuple>]
+    >,
+    tropoig,
+    croard: kodatar,
+  };
+
+  return hamletive;
+};

--- a/packages/open-schema-type-script/src/type-script-adapter/hamletive/onama.ts
+++ b/packages/open-schema-type-script/src/type-script-adapter/hamletive/onama.ts
@@ -1,1 +1,66 @@
-// one to one
+import { Estinant2 } from '../../core/estinant';
+import { Quirm, QuirmTupleToGeppTuple } from '../../core/quirm';
+import { Tropoignant2 } from '../../core/tropoignant';
+import { Struss } from '../../utilities/struss';
+import { kodatar } from '../kodataring';
+import {
+  QuirmOption,
+  QuirmOptionTuple,
+  QuirmOptionTupleToGeppOptionIntersection,
+} from '../quirmOptionTuple';
+
+/**
+ * Like an Onama, but it's return value is abstracted from the Engine's concerns
+ */
+export type Ankeler<
+  TInputQuirmOptionTuple extends QuirmOptionTuple,
+  TOutputQuirm extends Quirm,
+> = (input: QuirmOption<TInputQuirmOptionTuple>) => TOutputQuirm;
+
+/**
+ * A one to one Tropoignant
+ */
+export type Onama<
+  TInputQuirmOptionTuple extends QuirmOptionTuple,
+  TOutputQuirm extends Quirm,
+> = Tropoignant2<[QuirmOption<TInputQuirmOptionTuple>], [TOutputQuirm]>;
+
+/**
+ * A one to one Estinant
+ */
+export type OnamaHamletive<TInputQuirmOptionTuple extends QuirmOptionTuple> =
+  Estinant2<[QuirmOption<TInputQuirmOptionTuple>], Struss>;
+
+export type OnamaHamletiveBuilderInput<
+  TInputQuirmOptionTuple extends QuirmOptionTuple,
+  TOutputQuirm extends Quirm,
+> = {
+  inputGepp: QuirmOptionTupleToGeppOptionIntersection<TInputQuirmOptionTuple>;
+  ankel: Ankeler<TInputQuirmOptionTuple, TOutputQuirm>;
+};
+
+export const buildOnamaHamletive = <
+  TInputQuirmOptionTuple extends QuirmOptionTuple,
+  TOutputQuirm extends Quirm,
+>({
+  inputGepp,
+  ankel,
+}: OnamaHamletiveBuilderInput<
+  TInputQuirmOptionTuple,
+  TOutputQuirm
+>): OnamaHamletive<TInputQuirmOptionTuple> => {
+  const tropoig: Onama<TInputQuirmOptionTuple, TOutputQuirm> = (input) => {
+    const output = ankel(input);
+    return [output];
+  };
+
+  const hamletive: OnamaHamletive<TInputQuirmOptionTuple> = {
+    inputGeppTuple: [inputGepp] as QuirmTupleToGeppTuple<
+      [QuirmOption<TInputQuirmOptionTuple>]
+    >,
+    tropoig,
+    croard: kodatar,
+  };
+
+  return hamletive;
+};

--- a/packages/open-schema-type-script/src/type-script-adapter/hamletive/wortinator.ts
+++ b/packages/open-schema-type-script/src/type-script-adapter/hamletive/wortinator.ts
@@ -1,43 +1,56 @@
 import { Estinant2 } from '../../core/estinant';
-import { Quirm, QuirmToGeppUnion } from '../../core/quirm';
+import { QuirmTupleToGeppTuple } from '../../core/quirm';
 import { Tropoignant2 } from '../../core/tropoignant';
 import { Struss } from '../../utilities/struss';
 import { kodatar } from '../kodataring';
+import {
+  QuirmOption,
+  QuirmOptionTuple,
+  QuirmOptionTupleToGeppOptionIntersection,
+} from '../quirmOptionTuple';
 
-export type Haqueler<TInputQuirm extends Quirm> = (input: TInputQuirm) => void;
+/**
+ * Like a Wortinator, but it's return value is abstracted from the Engine's concerns
+ */
+export type Haqueler<TInputQuirmOptionTuple extends QuirmOptionTuple> = (
+  input: QuirmOption<TInputQuirmOptionTuple>,
+) => void;
 
 /**
  * A one to zero Tropoignant
  */
-export type Wortinator<TInputQuirm extends Quirm> = Tropoignant2<
-  [TInputQuirm],
-  []
->;
+export type Wortinator<TInputQuirmOptionTuple extends QuirmOptionTuple> =
+  Tropoignant2<[QuirmOption<TInputQuirmOptionTuple>], []>;
 
 /**
  * A one to zero Estinant
  */
-export type WortinatorHamletive<TInputQuirm extends Quirm> = Estinant2<
-  [TInputQuirm],
-  Struss
->;
+export type WortinatorHamletive<
+  TInputQuirmOptionTuple extends QuirmOptionTuple,
+> = Estinant2<[QuirmOption<TInputQuirmOptionTuple>], Struss>;
 
-export type WortinatorHamletiveBuilderInput<TInputQuirm extends Quirm> = {
-  inputGepp: QuirmToGeppUnion<TInputQuirm>;
-  haquel: Haqueler<TInputQuirm>;
+export type WortinatorHamletiveBuilderInput<
+  TInputQuirmOptionTuple extends QuirmOptionTuple,
+> = {
+  inputGepp: QuirmOptionTupleToGeppOptionIntersection<TInputQuirmOptionTuple>;
+  haquel: Haqueler<TInputQuirmOptionTuple>;
 };
 
-export const buildWortinatorHamletive = <TInputQuirm extends Quirm>({
+export const buildWortinatorHamletive = <
+  TInputQuirmOptionTuple extends QuirmOptionTuple,
+>({
   inputGepp,
   haquel,
-}: WortinatorHamletiveBuilderInput<TInputQuirm>): WortinatorHamletive<TInputQuirm> => {
-  const tropoig: Wortinator<TInputQuirm> = (input) => {
+}: WortinatorHamletiveBuilderInput<TInputQuirmOptionTuple>): WortinatorHamletive<TInputQuirmOptionTuple> => {
+  const tropoig: Wortinator<TInputQuirmOptionTuple> = (input) => {
     haquel(input);
     return [];
   };
 
-  const hamletive: WortinatorHamletive<TInputQuirm> = {
-    inputGeppTuple: [inputGepp],
+  const hamletive: WortinatorHamletive<TInputQuirmOptionTuple> = {
+    inputGeppTuple: [inputGepp] as QuirmTupleToGeppTuple<
+      [QuirmOption<TInputQuirmOptionTuple>]
+    >,
     tropoig,
     croard: kodatar,
   };

--- a/packages/open-schema-type-script/src/type-script-adapter/quirmOptionTuple.ts
+++ b/packages/open-schema-type-script/src/type-script-adapter/quirmOptionTuple.ts
@@ -1,0 +1,22 @@
+import { QuirmTuple } from '../core/quirm';
+import { MergeTuple } from '../utilities/mergeTuple';
+import { OptionTuple } from '../utilities/optionTuple';
+
+/**
+ * A collection where only one Quirm is expected to be used, and not the collection as a whole
+ */
+export type QuirmOptionTuple<TQuirmTuple extends QuirmTuple = QuirmTuple> =
+  OptionTuple<TQuirmTuple>;
+
+export type QuirmOption<TQuirmOptionTuple extends QuirmOptionTuple> =
+  TQuirmOptionTuple[number];
+
+export type QuirmOptionTupleToGeppOptionTuple<
+  TQuirmOptionTuple extends QuirmOptionTuple,
+> = {
+  [Index in keyof TQuirmOptionTuple]: TQuirmOptionTuple[Index]['geppTuple'][number];
+};
+
+export type QuirmOptionTupleToGeppOptionIntersection<
+  TQuirmOptionTuple extends QuirmOptionTuple,
+> = MergeTuple<QuirmOptionTupleToGeppOptionTuple<TQuirmOptionTuple>>;

--- a/packages/open-schema-type-script/src/utilities/mergeTuple.ts
+++ b/packages/open-schema-type-script/src/utilities/mergeTuple.ts
@@ -1,0 +1,12 @@
+import { StralineTuple } from '../core/straline';
+
+type RecursivelyMergeTuple<TTuple extends StralineTuple> = TTuple extends [
+  infer TOnlyItem,
+]
+  ? TOnlyItem
+  : TTuple extends [infer TFirstItem, ...infer TRestItems]
+  ? TFirstItem & RecursivelyMergeTuple<TRestItems>
+  : never;
+
+export type MergeTuple<TTuple extends StralineTuple> =
+  RecursivelyMergeTuple<TTuple>;

--- a/packages/open-schema-type-script/src/utilities/optionTuple.ts
+++ b/packages/open-schema-type-script/src/utilities/optionTuple.ts
@@ -1,0 +1,4 @@
+/**
+ * A collection where only one element is expected to be used, and not the collection as a whole
+ */
+export type OptionTuple<TTuple extends readonly unknown[]> = TTuple;


### PR DESCRIPTION
Update Wortinator, and add Onama and Mentursection to the TypeScript adapter layer in a way that adds type safety to Estinants.

Some examples:
- An Estinant inputGepp must exist in the intersection of the input option Quirm Gepp tuples
- The Mentursection Estinant builder requires a predicate for each input to output type conversion