### PR TITLE
Add a TypeScript adapter for Cortmum

### DIFF
--- a/packages/open-schema-type-script/src/core/estinant.ts
+++ b/packages/open-schema-type-script/src/core/estinant.ts
@@ -2,7 +2,6 @@ import { Croarder } from './croarder';
 import { Gepp } from './gepp';
 import { Hubblepup } from './hubblepup';
 import { QuirmTuple, QuirmTupleToGeppTuple } from './quirm';
-import { Straline } from './straline';
 import {
   Mentursection,
   Onama,
@@ -10,6 +9,7 @@ import {
   Tropoignant2,
   Wortinator,
 } from './tropoignant';
+import { Zorn } from './zorn';
 
 type BaseEstinant<
   TInputHubblepup extends Hubblepup,
@@ -59,14 +59,14 @@ export type EstinantTuple<
  */
 export type Estinant2<
   TInputQuirmTuple extends QuirmTuple = QuirmTuple,
-  TIntersectionIdentity extends Straline = Straline,
+  TZorn extends Zorn = Zorn,
 > = {
   inputGeppTuple: QuirmTupleToGeppTuple<TInputQuirmTuple>;
   tropoig: Tropoignant2<TInputQuirmTuple>;
-  croard: Croarder<TInputQuirmTuple[number], TIntersectionIdentity>;
+  croard: Croarder<TInputQuirmTuple[number], TZorn>;
 };
 
 export type Estinant2Tuple<
   TInputQuirmTuple extends QuirmTuple = QuirmTuple,
-  TIntersectionIdentity extends Straline = Straline,
-> = readonly Estinant2<TInputQuirmTuple, TIntersectionIdentity>[];
+  TZorn extends Zorn = Zorn,
+> = readonly Estinant2<TInputQuirmTuple, TZorn>[];

--- a/packages/open-schema-type-script/src/core/quirm.ts
+++ b/packages/open-schema-type-script/src/core/quirm.ts
@@ -30,6 +30,9 @@ export type QuirmToGeppUnion<TQuirm extends Quirm> =
 export type QuirmTuple<THubblepup extends Hubblepup = Hubblepup> =
   readonly Quirm<THubblepup>[];
 
+export type QuirmTupleTuple<TQuirmTuple extends QuirmTuple = QuirmTuple> =
+  readonly TQuirmTuple[];
+
 export type QuirmTupleToGeppTuple<TQuirmTuple extends QuirmTuple> = {
   [Index in keyof TQuirmTuple]: TQuirmTuple[Index]['geppTuple'][number];
 };

--- a/packages/open-schema-type-script/src/example/adapter/constructs/exampleAggregate.ts
+++ b/packages/open-schema-type-script/src/example/adapter/constructs/exampleAggregate.ts
@@ -1,0 +1,19 @@
+import { Gepp } from '../../../core/gepp';
+import { Hubblepup } from '../../../core/hubblepup';
+import { Quirm2 } from '../../../core/quirm';
+import { ExampleA } from './exampleA';
+import { ExampleB } from './exampleB';
+
+export type ExampleAggregate = {
+  a: ExampleA;
+  b: ExampleB;
+};
+
+export type ExampleAggregateHubblepup = Hubblepup<ExampleAggregate>;
+
+export type ExampleAggregateGepp = Gepp<'example-aggregate'>;
+
+export type ExampleAggregateQuirm = Quirm2<
+  [ExampleAggregateGepp],
+  ExampleAggregateHubblepup
+>;

--- a/packages/open-schema-type-script/src/example/adapter/constructs/exampleCortmumHamletive.ts
+++ b/packages/open-schema-type-script/src/example/adapter/constructs/exampleCortmumHamletive.ts
@@ -1,0 +1,50 @@
+import {
+  buildCortmumHamletive,
+  Cortmum,
+  CortmumCroader,
+} from '../../../type-script-adapter/hamletive/cortmum';
+import { QuirmOptionTupleTuple } from '../../../type-script-adapter/quirmOptionTuple';
+import { ExampleAQuirm } from './exampleA';
+import { ExampleAggregateQuirm } from './exampleAggregate';
+import { ExampleBQuirm } from './exampleB';
+
+type InputQuirmOptionTupleTuple = QuirmOptionTupleTuple<
+  [[ExampleAQuirm], [ExampleBQuirm]]
+>;
+type OutputQuirmOptionTupleTuple = QuirmOptionTupleTuple<
+  [[ExampleAggregateQuirm]]
+>;
+
+type InputZorn = number;
+
+const aggregateByNumber: Cortmum<
+  InputQuirmOptionTupleTuple,
+  OutputQuirmOptionTupleTuple
+> = (inputA, inputB) => {
+  const output: ExampleAggregateQuirm = {
+    geppTuple: ['example-aggregate'],
+    hubblepup: {
+      a: inputA.hubblepup,
+      b: inputB.hubblepup,
+    },
+  };
+
+  return [output];
+};
+
+const croard: CortmumCroader<InputQuirmOptionTupleTuple, InputZorn> = (
+  input,
+) => {
+  const zorn: InputZorn = parseInt(input.hubblepup.split('-')[1], 10);
+  return zorn;
+};
+
+export const exampleCortmumHamletive = buildCortmumHamletive<
+  InputQuirmOptionTupleTuple,
+  OutputQuirmOptionTupleTuple,
+  InputZorn
+>({
+  inputGeppTuple: ['example-a', 'example-b'],
+  croard,
+  tropoig: aggregateByNumber,
+});

--- a/packages/open-schema-type-script/src/example/adapter/exampleAdapter.ts
+++ b/packages/open-schema-type-script/src/example/adapter/exampleAdapter.ts
@@ -7,6 +7,7 @@ import { exampleBQuirmTuple } from './constructs/exampleB';
 import { exampleWortinatorHamletive } from './constructs/exampleWortinatorHamletive';
 import { exampleOnamaHamletive } from './constructs/exampleOnamaHamletive';
 import { exampleMentursectionHamletive } from './constructs/exampleMentursectionHamletive';
+import { exampleCortmumHamletive } from './constructs/exampleCortmumHamletive';
 
 digikikify({
   initialQuirmTuple: [...exampleAQuirmTuple, ...exampleBQuirmTuple],
@@ -16,6 +17,7 @@ digikikify({
     exampleWortinatorHamletive,
     exampleOnamaHamletive,
     exampleMentursectionHamletive,
+    exampleCortmumHamletive,
   ]),
 });
 

--- a/packages/open-schema-type-script/src/example/custom/ciYamlFile/assertableCiYamlFileContents.ts
+++ b/packages/open-schema-type-script/src/example/custom/ciYamlFile/assertableCiYamlFileContents.ts
@@ -1,6 +1,12 @@
 import fs from 'fs';
 import yaml from 'yaml';
-import { Estinant2 } from '../../../core/estinant';
+import { Zorn } from '../../../core/zorn';
+import {
+  buildCortmumHamletive,
+  Cortmum,
+  CortmumCroader,
+} from '../../../type-script-adapter/hamletive/cortmum';
+import { QuirmOptionTupleTuple } from '../../../type-script-adapter/quirmOptionTuple';
 import { Grition } from '../custom-constructs/grition';
 import { Odeshin } from '../custom-constructs/odeshin';
 import { Plifal } from '../custom-constructs/plifal';
@@ -44,47 +50,64 @@ export type AssertableCiYamlFileContentsPlifal = Plifal<
   AssertableCiYamlFileContentsOdeshin
 >;
 
+type InputQuirmOptionTupleTuple = QuirmOptionTupleTuple<
+  [[ActualCiYamlFilePlifal], [ExpectedCiYamlFileContentsPlifal]]
+>;
+type OutputQuirmOptionTupleTuple = QuirmOptionTupleTuple<
+  [[AssertableCiYamlFileContentsPlifal]]
+>;
+
+type InputZorn = Zorn;
+
 // Each input collection only has one item, so any arbitrary Zorn will do
-const CI_YAML_FILE_JOIN_ID = Symbol('ci-yaml-file');
-export const assertableCiYamlFileCortmumEstinant: Estinant2<
-  [ActualCiYamlFilePlifal, ExpectedCiYamlFileContentsPlifal],
-  typeof CI_YAML_FILE_JOIN_ID
-> = {
+const CI_YAML_FILE_ZORN = Symbol('ci-yaml-file');
+const croard: CortmumCroader<InputQuirmOptionTupleTuple, InputZorn> = () => {
+  return CI_YAML_FILE_ZORN;
+};
+
+const buildAssertableCiYamlFileContents: Cortmum<
+  InputQuirmOptionTupleTuple,
+  OutputQuirmOptionTupleTuple
+> = (actual, expected) => {
+  const actualStringContents: string = fs.readFileSync(
+    actual.hubblepup.grition.filePath,
+    'utf8',
+  );
+
+  const expectedStringContentsWithPlaceholders = yaml.stringify(
+    expected.hubblepup.grition,
+  );
+
+  // TODO: learn how to properly manage comments with the yaml library and remove this hack
+  const expectedStringContents =
+    expectedStringContentsWithPlaceholders.replaceAll(
+      /( +)- COMMENT_PLACE_HOLDER:([^:]+): ""/g,
+      '\n$1# $2',
+    );
+
+  const output: AssertableCiYamlFileContentsPlifal = {
+    geppTuple: [ASSERTABLE_CI_YAML_FILE_CONTENTS_GEPPP],
+    hubblepup: {
+      identifier: ASSERTABLE_CI_YAML_FILE_CONTENTS_IDENTIFIER,
+      grition: {
+        actualStringContents,
+        expectedStringContents,
+      },
+    },
+  };
+
+  return [output];
+};
+
+export const assertableCiYamlFileCortmumEstinant = buildCortmumHamletive<
+  InputQuirmOptionTupleTuple,
+  OutputQuirmOptionTupleTuple,
+  InputZorn
+>({
   inputGeppTuple: [
     ACTUAL_CI_YAML_FILE_GEPPP,
     EXPECTED_CI_YAML_FILE_CONTENTS_GEPPP,
   ],
-  croard: function getZorn() {
-    return CI_YAML_FILE_JOIN_ID;
-  },
-  tropoig: function merge(actual, expected) {
-    const actualStringContents: string = fs.readFileSync(
-      actual.hubblepup.grition.filePath,
-      'utf8',
-    );
-
-    const expectedStringContentsWithPlaceholders = yaml.stringify(
-      expected.hubblepup.grition,
-    );
-
-    // TODO: learn how to properly manage comments with the yaml library and remove this hack
-    const expectedStringContents =
-      expectedStringContentsWithPlaceholders.replaceAll(
-        /( +)- COMMENT_PLACE_HOLDER:([^:]+): ""/g,
-        '\n$1# $2',
-      );
-
-    const output: AssertableCiYamlFileContentsPlifal = {
-      geppTuple: [ASSERTABLE_CI_YAML_FILE_CONTENTS_GEPPP],
-      hubblepup: {
-        identifier: ASSERTABLE_CI_YAML_FILE_CONTENTS_IDENTIFIER,
-        grition: {
-          actualStringContents,
-          expectedStringContents,
-        },
-      },
-    };
-
-    return [output];
-  },
-};
+  croard,
+  tropoig: buildAssertableCiYamlFileContents,
+});

--- a/packages/open-schema-type-script/src/type-script-adapter/hamletive/cortmum.ts
+++ b/packages/open-schema-type-script/src/type-script-adapter/hamletive/cortmum.ts
@@ -1,1 +1,80 @@
-// many to many
+import { Croarder } from '../../core/croarder';
+import { Estinant2 } from '../../core/estinant';
+import { QuirmTupleToGeppTuple } from '../../core/quirm';
+import { Tropoignant2 } from '../../core/tropoignant';
+import { Zorn } from '../../core/zorn';
+import {
+  QuirmOption,
+  QuirmOptionTupleTuple,
+  QuirmOptionTupleTupleToGeppOptionIntersectionTuple,
+  QuirmOptionTupleTupleToQuirmTuple,
+} from '../quirmOptionTuple';
+
+/**
+ * A Croarder that can take any input Quirm
+ *
+ * @todo this should probably live somewhere else
+ */
+export type CortmumCroader<
+  TInputQuirmOptionTupleTuple extends QuirmOptionTupleTuple,
+  TZorn extends Zorn,
+> = Croarder<
+  QuirmOption<QuirmOptionTupleTupleToQuirmTuple<TInputQuirmOptionTupleTuple>>,
+  TZorn
+>;
+
+/**
+ * A many to many Tropoignant (ie a Tropoignant)
+ */
+export type Cortmum<
+  TInputQuirmOptionTupleTuple extends QuirmOptionTupleTuple,
+  TOutputQuirmOptionTupleTuple extends QuirmOptionTupleTuple,
+> = Tropoignant2<
+  QuirmOptionTupleTupleToQuirmTuple<TInputQuirmOptionTupleTuple>,
+  QuirmOptionTupleTupleToQuirmTuple<TOutputQuirmOptionTupleTuple>
+>;
+
+/**
+ * A many to many Estinant (ie an Estinant)
+ */
+export type CortmumHamletive<
+  TInputQuirmOptionTupleTuple extends QuirmOptionTupleTuple,
+  TZorn extends Zorn,
+> = Estinant2<
+  QuirmOptionTupleTupleToQuirmTuple<TInputQuirmOptionTupleTuple>,
+  TZorn
+>;
+
+export type CortmumHamletiveBuilderInput<
+  TInputQuirmOptionTupleTuple extends QuirmOptionTupleTuple,
+  TOutputQuirmOptionTupleTuple extends QuirmOptionTupleTuple,
+  TZorn extends Zorn,
+> = {
+  inputGeppTuple: QuirmOptionTupleTupleToGeppOptionIntersectionTuple<TInputQuirmOptionTupleTuple>;
+  croard: CortmumCroader<TInputQuirmOptionTupleTuple, TZorn>;
+  tropoig: Cortmum<TInputQuirmOptionTupleTuple, TOutputQuirmOptionTupleTuple>;
+};
+
+export const buildCortmumHamletive = <
+  TInputQuirmOptionTupleTuple extends QuirmOptionTupleTuple,
+  TOutputQuirmOptionTupleTuple extends QuirmOptionTupleTuple,
+  TZorn extends Zorn,
+>({
+  inputGeppTuple,
+  croard,
+  tropoig,
+}: CortmumHamletiveBuilderInput<
+  TInputQuirmOptionTupleTuple,
+  TOutputQuirmOptionTupleTuple,
+  TZorn
+>): CortmumHamletive<TInputQuirmOptionTupleTuple, TZorn> => {
+  const hamletive: CortmumHamletive<TInputQuirmOptionTupleTuple, TZorn> = {
+    inputGeppTuple: inputGeppTuple as QuirmTupleToGeppTuple<
+      QuirmOptionTupleTupleToQuirmTuple<TInputQuirmOptionTupleTuple>
+    >,
+    croard,
+    tropoig,
+  };
+
+  return hamletive;
+};

--- a/packages/open-schema-type-script/src/type-script-adapter/quirmOptionTuple.ts
+++ b/packages/open-schema-type-script/src/type-script-adapter/quirmOptionTuple.ts
@@ -1,4 +1,4 @@
-import { QuirmTuple } from '../core/quirm';
+import { QuirmTuple, QuirmTupleTuple } from '../core/quirm';
 import { MergeTuple } from '../utilities/mergeTuple';
 import { OptionTuple } from '../utilities/optionTuple';
 
@@ -20,3 +20,26 @@ export type QuirmOptionTupleToGeppOptionTuple<
 export type QuirmOptionTupleToGeppOptionIntersection<
   TQuirmOptionTuple extends QuirmOptionTuple,
 > = MergeTuple<QuirmOptionTupleToGeppOptionTuple<TQuirmOptionTuple>>;
+
+/**
+ * A collection of collections where only one Quirm in each collection is expected to be used, and not each collection as a whole
+ */
+export type QuirmOptionTupleTuple<
+  TQuirmTupleTuple extends QuirmTupleTuple = QuirmTupleTuple,
+> = TQuirmTupleTuple;
+
+export type QuirmOptionTupleTupleToQuirmTuple<
+  TQuirmOptionTupleTuple extends QuirmOptionTupleTuple,
+> = {
+  [Index in keyof TQuirmOptionTupleTuple]: QuirmOption<
+    TQuirmOptionTupleTuple[Index]
+  >;
+};
+
+export type QuirmOptionTupleTupleToGeppOptionIntersectionTuple<
+  TQuirmOptionTupleTuple extends QuirmOptionTupleTuple,
+> = {
+  [Index in keyof TQuirmOptionTupleTuple]: QuirmOptionTupleToGeppOptionIntersection<
+    TQuirmOptionTupleTuple[Index]
+  >;
+};

--- a/packages/open-schema-type-script/src/utilities/optionTuple.ts
+++ b/packages/open-schema-type-script/src/utilities/optionTuple.ts
@@ -1,4 +1,12 @@
 /**
  * A collection where only one element is expected to be used, and not the collection as a whole
  */
-export type OptionTuple<TTuple extends readonly unknown[]> = TTuple;
+export type OptionTuple<
+  TTuple extends readonly unknown[] = readonly unknown[],
+> = TTuple;
+
+/**
+ * A collection of collections where only one element in each collection is expected to be used, and not each collection as a whole
+ */
+export type OptionTupleTuple<TTupleTuple extends readonly OptionTuple[]> =
+  TTupleTuple;


### PR DESCRIPTION
A Cortmum and a Tropoignant are basically the same thing, but the TypeScript adapter layer allows us to provide the expected input and output type tuples to get the a custom Croarder, Tropoignant, and Estinant type.