### PR TITLE
Render interactive TypeScript file relationship graph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.47.1",
         "@typescript-eslint/parser": "^5.47.1",
+        "cheerio": "^1.0.0-rc.12",
         "eslint": "^8.30.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-airbnb-typescript": "^17.0.0",
@@ -4578,7 +4579,8 @@
         "uuid": "^9.0.0"
       },
       "devDependencies": {
-        "@typescript-eslint/typescript-estree": "^5.54.0"
+        "@typescript-eslint/typescript-estree": "^5.54.0",
+        "cheerio": "^1.0.0-rc.12"
       }
     },
     "packages/voictents-and-estinants-engine/node_modules/@typescript-eslint/types": {
@@ -7524,6 +7526,7 @@
       "version": "file:packages/voictents-and-estinants-engine",
       "requires": {
         "@typescript-eslint/typescript-estree": "^5.54.0",
+        "cheerio": "^1.0.0-rc.12",
         "uuid": "^9.0.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Testing frameworks on testing frameworks",
   "private": true,
   "scripts": {
-    "scaffold": "npx ts-node packages/pipes-and-filters-engine/src/custom/programs/scaffoldVoictentFile.ts",
+    "scaffold": "npx ts-node packages/voictents-and-estinants-engine/src/custom/programs/scaffoldVoictentFile.ts",
     "example-core": "ts-node packages/open-schema-type-script/src/example/core/exampleCore.ts",
     "example-adapter": "ts-node packages/open-schema-type-script/src/example/adapter/exampleAdapter.ts",
     "example-custom": "ts-node packages/open-schema-type-script/src/example/custom/exampleCustom.ts",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.47.1",
     "@typescript-eslint/parser": "^5.47.1",
+    "cheerio": "^1.0.0-rc.12",
     "eslint": "^8.30.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-airbnb-typescript": "^17.0.0",

--- a/packages/voictents-and-estinants-engine/package.json
+++ b/packages/voictents-and-estinants-engine/package.json
@@ -3,6 +3,7 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
-    "@typescript-eslint/typescript-estree": "^5.54.0"
+    "@typescript-eslint/typescript-estree": "^5.54.0",
+    "cheerio": "^1.0.0-rc.12"
   }
 }

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/odeshin.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/odeshin.ts
@@ -15,4 +15,4 @@ export type OdeshinFromGrition<TGrition extends Grition = Grition> = Odeshin<
 >;
 
 export const isOdeshin = (hubblepup: Hubblepup): hubblepup is Odeshin =>
-  'identifier' in hubblepup && typeof hubblepup.identifier === 'string';
+  'zorn' in hubblepup && typeof hubblepup.zorn === 'string';

--- a/packages/voictents-and-estinants-engine/src/custom/debugger/debugOdeshin.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/debugger/debugOdeshin.ts
@@ -9,7 +9,8 @@ type IdentifiableHubblepup = {
 
 const odeshinCache = new Map<Odeshin, IdentifiableHubblepup>();
 
-const escapePathSeparator = (text: string): string =>
+// TODO: move to a utility or something
+export const escapePathSeparator = (text: string): string =>
   text.replaceAll(/\//g, ' | ');
 
 const getOrInstantiateAndCacheIdentifiableHubblepup = (

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/datum-test-case-input/datumTestCaseInput.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/datum-test-case-input/datumTestCaseInput.ts
@@ -1,0 +1,170 @@
+import { Grition } from '../../adapter/grition';
+import { OdeshinFromGrition } from '../../adapter/odeshin';
+import { Voictent } from '../../adapter/voictent';
+
+export type DatumTestCaseInput = unknown;
+
+export type DatumTestCaseInputGrition = Grition<DatumTestCaseInput>;
+
+export type DatumTestCaseInputOdeshin =
+  OdeshinFromGrition<DatumTestCaseInputGrition>;
+
+export const DATUM_TEST_CASE_INPUT_GEPP = 'datum-test-case-input';
+
+export type DatumTestCaseInputGepp = typeof DATUM_TEST_CASE_INPUT_GEPP;
+
+export type DatumTestCaseInputVoictent = Voictent<
+  DatumTestCaseInputGepp,
+  DatumTestCaseInputOdeshin
+>;
+
+class CustomObject {
+  constructor(public datumList: unknown[]) {}
+}
+
+const primitiveTestCaseList: DatumTestCaseInputOdeshin[] = [
+  {
+    zorn: '0/primitive/0/empty/0/null',
+    grition: null,
+  },
+  {
+    zorn: '0/primitive/0/empty/1/undefined',
+    grition: undefined,
+  },
+  {
+    zorn: '0/primitive/1/string/0/single-line',
+    grition: 'this is a single line string',
+  },
+  {
+    zorn: '0/primitive/1/string/1/multiline',
+    grition: `this
+  is
+a multiline
+  string`,
+  },
+  {
+    zorn: '0/primitive/2/number/3/bigint',
+    grition: 99999999999999999999999999n,
+  },
+  {
+    zorn: '0/primitive/2/number/1/float',
+    grition: 12.34,
+  },
+  {
+    zorn: '0/primitive/2/number/0/integer',
+    grition: 123,
+  },
+  {
+    zorn: '0/primitive/2/number/2/leading-decimal',
+    // eslint-disable-next-line prettier/prettier
+    grition: .123,
+  },
+  {
+    zorn: '0/primitive/3/boolean/0/true',
+    grition: true,
+  },
+  {
+    zorn: '0/primitive/3/boolean/1/false',
+    grition: false,
+  },
+  {
+    zorn: '0/primitive/4/symbol/0/without-description',
+    // eslint-disable-next-line symbol-description
+    grition: Symbol(),
+  },
+  {
+    zorn: '0/primitive/4/symbol/1/with-description',
+    // eslint-disable-next-line symbol-description
+    grition: Symbol('this is a symbol description'),
+  },
+];
+
+const primitiveTestCaseListGritionList = primitiveTestCaseList.map(
+  ({ grition }) => grition,
+);
+
+const primitiveCollectionTestCaseList: DatumTestCaseInputOdeshin[] = [
+  {
+    zorn: '1/primitive-collection/0/list',
+    grition: primitiveTestCaseListGritionList,
+  },
+  {
+    zorn: '1/primitive-collection/1/set',
+    grition: new Set(primitiveTestCaseListGritionList),
+  },
+  {
+    zorn: '1/primitive-collection/2/object/0/with-string-keys',
+    grition: Object.fromEntries(
+      primitiveTestCaseListGritionList.map<[string, unknown]>(
+        (grition, index) => [`key-${index}`, grition],
+      ),
+    ),
+  },
+  {
+    zorn: '1/primitive-collection/2/object/1/with-symbol-keys',
+    grition: Object.fromEntries(
+      primitiveTestCaseListGritionList.map<[symbol, unknown]>(
+        (grition, index) => [Symbol(`key-${index}`), grition],
+      ),
+    ),
+  },
+  {
+    zorn: '1/primitive-collection/2/object/2/custom',
+    grition: new CustomObject(primitiveTestCaseListGritionList),
+  },
+  {
+    zorn: '1/primitive-collection/3/map',
+    grition: new Map(
+      primitiveTestCaseList.map(({ grition }) => [grition, grition]),
+    ),
+  },
+];
+
+const primitiveCollectionTestCaseListGritionList =
+  primitiveCollectionTestCaseList.map(({ grition }) => grition);
+
+const collectionCollectionTestCaseList: DatumTestCaseInputOdeshin[] = [
+  {
+    zorn: '2/collection-collection/0/list',
+    grition: primitiveCollectionTestCaseListGritionList,
+  },
+  {
+    zorn: '2/collection-collection/1/set',
+    grition: new Set(primitiveCollectionTestCaseListGritionList),
+  },
+  {
+    zorn: '2/collection-collection/2/object/0/with-string-keys',
+    grition: Object.fromEntries(
+      primitiveCollectionTestCaseListGritionList.map<[string, unknown]>(
+        (grition, index) => [`key-${index}`, grition],
+      ),
+    ),
+  },
+  {
+    zorn: '2/collection-collection/2/object/1/with-symbol-keys',
+    grition: Object.fromEntries(
+      primitiveCollectionTestCaseListGritionList.map<[symbol, unknown]>(
+        (grition, index) => [Symbol(`key-${index}`), grition],
+      ),
+    ),
+  },
+  {
+    zorn: '2/collection-collection/2/object/2/custom',
+    grition: new CustomObject(primitiveCollectionTestCaseListGritionList),
+  },
+  {
+    zorn: '2/collection-collection/3/map',
+    grition: new Map(
+      primitiveCollectionTestCaseListGritionList.map((grition) => [
+        grition,
+        grition,
+      ]),
+    ),
+  },
+];
+
+export const DATUM_TEST_CASE_INPUT_ODESHIN_LIST: DatumTestCaseInputOdeshin[] = [
+  ...primitiveTestCaseList,
+  ...primitiveCollectionTestCaseList,
+  ...collectionCollectionTestCaseList,
+];

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/estinant-call-expression-parameter/estinantCallExpressionParameterCortmum.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/estinant-call-expression-parameter/estinantCallExpressionParameterCortmum.ts
@@ -13,6 +13,7 @@ import {
   ENGINE_ESTINANT_GEPP,
 } from '../engineEstinant';
 import { isCortmumCallExpression } from '../estinant-call-expression/cortmumCallExpression';
+import { isDisatingerCallExpression } from '../estinant-call-expression/disatingerCallExpression';
 import { isMattomerCallExpression } from '../estinant-call-expression/mattomerCallExpression';
 import { isMentursectionCallExpression } from '../estinant-call-expression/mentursectionCallExpression';
 import { isOnamaCallExpression } from '../estinant-call-expression/onamaCallExpression';
@@ -83,7 +84,8 @@ export const estinantCallExpressionParameterCortmum = buildCortmum<
       isOnamaCallExpression(callExpression) ||
       isMattomerCallExpression(callExpression) ||
       isWattlectionCallExpression(callExpression) ||
-      isWortinatorCallExpression(callExpression)
+      isWortinatorCallExpression(callExpression) ||
+      isDisatingerCallExpression(callExpression)
     ) {
       const { programName, estinantName } = engineEstinant;
 

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/estinant-call-expression/disatingerCallExpression.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/estinant-call-expression/disatingerCallExpression.ts
@@ -1,0 +1,12 @@
+import { TSESTree, AST_NODE_TYPES } from '@typescript-eslint/typescript-estree';
+import { PredicateAssertionType } from '../../../../utilities/predicate';
+import { buildIsEstinantCallExpression } from './baseEstinantCallExpression';
+
+export const isDisatingerCallExpression = buildIsEstinantCallExpression<
+  'buildDisatinger',
+  [TSESTree.TSTypeReference]
+>('buildDisatinger', [AST_NODE_TYPES.TSTypeReference]);
+
+export type DisatingerCallExpression = PredicateAssertionType<
+  typeof isDisatingerCallExpression
+>;

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/file/directory.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/file/directory.ts
@@ -1,0 +1,18 @@
+import { Grition } from '../../adapter/grition';
+import { OdeshinFromGrition } from '../../adapter/odeshin';
+import { Voictent } from '../../adapter/voictent';
+
+export type Directory = {
+  directoryPath: string;
+  directoryPathPartList: string[];
+};
+
+export type DirectoryGrition = Grition<Directory>;
+
+export type DirectoryOdeshin = OdeshinFromGrition<DirectoryGrition>;
+
+export const DIRECTORY_GEPP = 'directory';
+
+export type DirectoryGepp = typeof DIRECTORY_GEPP;
+
+export type DirectoryVoictent = Voictent<DirectoryGepp, DirectoryOdeshin>;

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/file/file.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/file/file.ts
@@ -15,6 +15,7 @@ export type File<
   TAdditionalMetadata extends object | null = null,
 > = {
   filePath: string;
+  directoryPath: string;
   onDiskFileName: FileName;
   inMemoryFileName: FileName;
   extension: {

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/file/fileExtensionSuffixIdentifier.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/file/fileExtensionSuffixIdentifier.ts
@@ -1,13 +1,16 @@
 import { swapEntries } from '../../../utilities/swapEntries';
 
 export enum FileExtensionSuffixIdentifier {
-  TypeScript = 'TypeScript',
+  Html = 'Html',
   Json = 'Json',
-  Unknown = 'Unknown',
+  TypeScript = 'TypeScript',
   Yaml = 'Yaml',
+
+  Unknown = 'Unknown',
 }
 
 const fileExtensionSuffixesByFileExtensionSuffixIdentifer = {
+  [FileExtensionSuffixIdentifier.Html]: 'html',
   [FileExtensionSuffixIdentifier.Json]: 'json',
   [FileExtensionSuffixIdentifier.TypeScript]: 'ts',
   [FileExtensionSuffixIdentifier.Yaml]: 'yaml',

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/file/fileMattomer.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/file/fileMattomer.ts
@@ -11,10 +11,15 @@ import {
   YamlFile,
 } from '../yaml-file/yamlFile';
 import { FileExtensionSuffixIdentifier } from './fileExtensionSuffixIdentifier';
+import {
+  HtmlFile,
+  HtmlFileVoictent,
+  HTML_FILE_GEPP,
+} from '../html-file/htmlFile';
 
 export const fileMattomer = buildMattomer<
   FileVoictent,
-  [TypeScriptFileVoictent, YamlFileVoictent]
+  [TypeScriptFileVoictent, YamlFileVoictent, HtmlFileVoictent]
 >({
   inputGepp: FILE_GEPP,
   kerzTuple: [
@@ -28,6 +33,11 @@ export const fileMattomer = buildMattomer<
       gepp: YAML_FILE_GEPP,
       pinbe: (input): input is YamlFile =>
         input.extension.suffixIdentifier === FileExtensionSuffixIdentifier.Yaml,
+    },
+    {
+      gepp: HTML_FILE_GEPP,
+      pinbe: (input): input is HtmlFile =>
+        input.extension.suffixIdentifier === FileExtensionSuffixIdentifier.Html,
     },
   ],
 });

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/file/fileMentursectionConfiguration.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/file/fileMentursectionConfiguration.ts
@@ -28,7 +28,7 @@ export type FileMentursectionConfigurationVoictent = Voictent<
 export const FULL_FILE_MENTURSECTION_CONFIGURATION: FileMentursectionConfigurationHubblepup =
   {
     directoryPath: '.',
-    ignoredNodePathConfigurations: [
+    ignoredNodePathConfigurationList: [
       {
         typeName: ComparisonConfigurationTypeName.Equals,
         value: '.git',
@@ -47,11 +47,11 @@ export const FULL_FILE_MENTURSECTION_CONFIGURATION: FileMentursectionConfigurati
 export const VOICTENTS_AND_ESTINANTS_FILE_MENTURSECTION_CONFIGURATION: FileMentursectionConfigurationHubblepup =
   {
     directoryPath: 'packages/voictents-and-estinants-engine/src',
-    ignoredNodePathConfigurations: [],
+    ignoredNodePathConfigurationList: [],
   };
 
 export const CI_FILE_MENTURSECTION_CONFIGURATION: FileMentursectionConfigurationHubblepup =
   {
     directoryPath: '.github',
-    ignoredNodePathConfigurations: [],
+    ignoredNodePathConfigurationList: [],
   };

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/file/fileMentursectionConfiguration.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/file/fileMentursectionConfiguration.ts
@@ -44,7 +44,7 @@ export const FULL_FILE_MENTURSECTION_CONFIGURATION: FileMentursectionConfigurati
     ],
   };
 
-export const PIPES_AND_FILTERS_FILE_MENTURSECTION_CONFIGURATION: FileMentursectionConfigurationHubblepup =
+export const VOICTENTS_AND_ESTINANTS_FILE_MENTURSECTION_CONFIGURATION: FileMentursectionConfigurationHubblepup =
   {
     directoryPath: 'packages/voictents-and-estinants-engine/src',
     ignoredNodePathConfigurations: [],

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/directed-graph/directedGraph.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/directed-graph/directedGraph.ts
@@ -1,0 +1,26 @@
+import { Grition } from '../../../adapter/grition';
+import { OdeshinFromGrition } from '../../../adapter/odeshin';
+import { Voictent } from '../../../adapter/voictent';
+import { DirectedGraphEdge } from './directedGraphEdge';
+import { DirectedGraphNode } from './directedGraphNode';
+
+export type DirectedGraph = {
+  id: string;
+  label: string;
+  nodeList: DirectedGraphNode[];
+  edgeList: DirectedGraphEdge[];
+  subgraphList: DirectedGraph[];
+};
+
+export type DirectedGraphGrition = Grition<DirectedGraph>;
+
+export type DirectedGraphOdeshin = OdeshinFromGrition<DirectedGraphGrition>;
+
+export const DIRECTED_GRAPH_GEPP = 'directed-graph';
+
+export type DirectedGraphGepp = typeof DIRECTED_GRAPH_GEPP;
+
+export type DirectedGraphVoictent = Voictent<
+  DirectedGraphGepp,
+  DirectedGraphOdeshin
+>;

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/directed-graph/directedGraphEdge.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/directed-graph/directedGraphEdge.ts
@@ -1,0 +1,4 @@
+export type DirectedGraphEdge = {
+  tailId: string;
+  headId: string;
+};

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/directed-graph/directedGraphNode.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/directed-graph/directedGraphNode.ts
@@ -1,0 +1,4 @@
+export type DirectedGraphNode = {
+  id: string;
+  label: string;
+};

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/directed-graph/getGraphvizCode.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/directed-graph/getGraphvizCode.ts
@@ -1,0 +1,78 @@
+import { DirectedGraphEdge } from './directedGraphEdge';
+import { DirectedGraph } from './directedGraph';
+import { DirectedGraphNode } from './directedGraphNode';
+
+export type DirectedGraphCodeLineListAccessorInput = {
+  graph: DirectedGraph;
+  isRoot: boolean;
+};
+
+const indent = '  ' as const;
+
+const getEdgeCodeLine = (edge: DirectedGraphEdge): string => {
+  return `"${edge.tailId}" -> "${edge.headId}"`;
+};
+
+const getNodeCodeLine = (node: DirectedGraphNode): string => {
+  return `"${node.id}" [ "label"="${node.label}"; "shape"="rounded" ]`;
+};
+
+const getDirectedGraphCodeLineList = ({
+  graph,
+  isRoot,
+}: DirectedGraphCodeLineListAccessorInput): string[] => {
+  const graphKeyword = isRoot ? 'digraph' : 'subgraph';
+  const id = isRoot ? graph.id : `cluster_${graph.id}`;
+
+  const linesA = [`${graphKeyword} "${id}" {`];
+
+  const linesB = isRoot
+    ? ['  "rankdir"="LR"', '  "fontname"="sans-serif"']
+    : [];
+
+  const linesL = [`  "label"="${graph.label}"`, '  "labelloc"="t"'];
+
+  const linesN = graph.nodeList.map((node) => {
+    return `${indent}${getNodeCodeLine(node)}`;
+  });
+
+  const linesE = graph.edgeList.map((edge) => {
+    return `${indent}${getEdgeCodeLine(edge)}`;
+  });
+
+  const linesS = graph.subgraphList
+    .map((subgraph) => {
+      return getDirectedGraphCodeLineList({
+        graph: subgraph,
+        isRoot: false,
+      });
+    })
+    .flat()
+    .map((line) => `${indent}${line}`);
+
+  const linesZ = [`}`];
+
+  return [
+    ...linesA,
+    ...linesB,
+    ...linesL,
+    '',
+    ...linesN,
+    '',
+    ...linesE,
+    '',
+    ...linesS,
+    ...linesZ,
+  ];
+};
+
+export const getGraphvizCode = (graph: DirectedGraph): string => {
+  const lines = getDirectedGraphCodeLineList({
+    graph,
+    isRoot: true,
+  });
+
+  const code = lines.join('\n');
+
+  return code;
+};

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/directed-graph/graphvizCode.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/directed-graph/graphvizCode.ts
@@ -1,0 +1,18 @@
+import { Grition } from '../../../adapter/grition';
+import { OdeshinFromGrition } from '../../../adapter/odeshin';
+import { Voictent } from '../../../adapter/voictent';
+
+export type GraphvizCode = string;
+
+export type GraphvizCodeGrition = Grition<GraphvizCode>;
+
+export type GraphvizCodeOdeshin = OdeshinFromGrition<GraphvizCodeGrition>;
+
+export const GRAPHVIZ_CODE_GEPP = 'graphviz-code';
+
+export type GraphvizCodeGepp = typeof GRAPHVIZ_CODE_GEPP;
+
+export type GraphvizCodeVoictent = Voictent<
+  GraphvizCodeGepp,
+  GraphvizCodeOdeshin
+>;

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/directedGraphToGraphvizCode.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/directedGraphToGraphvizCode.ts
@@ -1,0 +1,19 @@
+import { buildOnama } from '../../adapter/estinant/onama';
+import {
+  DirectedGraphVoictent,
+  DIRECTED_GRAPH_GEPP,
+} from './directed-graph/directedGraph';
+import { getGraphvizCode } from './directed-graph/getGraphvizCode';
+import { GraphvizCodeVoictent, GRAPHVIZ_CODE_GEPP } from './graphvizCode';
+
+export const directedGraphToGraphvizCode = buildOnama<
+  DirectedGraphVoictent,
+  GraphvizCodeVoictent
+>({
+  inputGepp: DIRECTED_GRAPH_GEPP,
+  outputGepp: GRAPHVIZ_CODE_GEPP,
+  pinbe: (input) => {
+    const code = getGraphvizCode(input);
+    return code;
+  },
+});

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/graphvizCode.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/graphvizCode.ts
@@ -1,0 +1,18 @@
+import { Grition } from '../../adapter/grition';
+import { OdeshinFromGrition } from '../../adapter/odeshin';
+import { Voictent } from '../../adapter/voictent';
+
+export type GraphvizCode = string;
+
+export type GraphvizCodeGrition = Grition<GraphvizCode>;
+
+export type GraphvizCodeOdeshin = OdeshinFromGrition<GraphvizCodeGrition>;
+
+export const GRAPHVIZ_CODE_GEPP = 'graphviz-code';
+
+export type GraphvizCodeGepp = typeof GRAPHVIZ_CODE_GEPP;
+
+export type GraphvizCodeVoictent = Voictent<
+  GraphvizCodeGepp,
+  GraphvizCodeOdeshin
+>;

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/graphvizCodeToSvgDocument.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/graphvizCodeToSvgDocument.ts
@@ -1,0 +1,51 @@
+import childProcessUtilities from 'child_process';
+import * as cheerio from 'cheerio';
+import { buildMentursection } from '../../../type-script-adapter/estinant/mentursection';
+import { GraphvizCodeVoictent, GRAPHVIZ_CODE_GEPP } from './graphvizCode';
+import { SvgDocumentVoictent, SVG_DOCUMENT_GEPP } from './svgDocument';
+
+export const graphvizCodeToSvgDocument = buildMentursection<
+  GraphvizCodeVoictent,
+  [SvgDocumentVoictent]
+>({
+  inputGepp: GRAPHVIZ_CODE_GEPP,
+  outputGeppTuple: [SVG_DOCUMENT_GEPP],
+  pinbe: ({ zorn, grition }) => {
+    const result = childProcessUtilities.spawnSync('dot', ['-Tsvg'], {
+      encoding: 'utf8',
+      input: grition,
+    });
+
+    const originalDocument = result.output
+      .filter((value) => value !== null)
+      .join('');
+
+    const $ = cheerio.load(originalDocument);
+
+    const $svg = $('svg');
+
+    $svg.attr('width', '100%');
+    $svg.attr('height', '100%');
+
+    // $svg.find('title').remove();
+
+    $svg.find('.edge > path').attr('stroke', 'gray');
+    $svg.find('.edge > polygon').attr('stroke', 'gray');
+    $svg.find('.edge > polygon').attr('fill', 'gray');
+
+    const modifiedDocument = $svg.toString() ?? '';
+
+    return {
+      [SVG_DOCUMENT_GEPP]: [
+        {
+          zorn: `${zorn}/original`,
+          grition: originalDocument,
+        },
+        {
+          zorn: `${zorn}/modified`,
+          grition: modifiedDocument,
+        },
+      ],
+    };
+  },
+});

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/interactiveSvg.html
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/interactiveSvg.html
@@ -1,0 +1,19 @@
+<script src="https://cdn.jsdelivr.net/npm/svg-pan-zoom@3.5.0/dist/svg-pan-zoom.min.js"></script>
+<body>
+  <!-- SVG_PLACEHOLDER -->
+</body>
+<script>
+  svgPanZoom('svg', {
+    zoomScaleSensitivity: .3,
+    minZoom: .2,
+    maxZoom: 20,
+  })
+
+  const nodeList = [...document.getElementsByClassName('node')];
+
+  nodeList.forEach((node) => {
+    node.addEventListener('click', () => {
+      console.log(node.textContent.trim())
+    })
+  })
+</script>

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/svgDocument.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/svgDocument.ts
@@ -1,0 +1,15 @@
+import { Grition } from '../../adapter/grition';
+import { OdeshinFromGrition } from '../../adapter/odeshin';
+import { Voictent } from '../../adapter/voictent';
+
+export type SvgDocument = string;
+
+export type SvgDocumentGrition = Grition<SvgDocument>;
+
+export type SvgDocumentOdeshin = OdeshinFromGrition<SvgDocumentGrition>;
+
+export const SVG_DOCUMENT_GEPP = 'svg-document';
+
+export type SvgDocumentGepp = typeof SVG_DOCUMENT_GEPP;
+
+export type SvgDocumentVoictent = Voictent<SvgDocumentGepp, SvgDocumentOdeshin>;

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/svgDocumentToInteractivePage.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/svgDocumentToInteractivePage.ts
@@ -1,0 +1,41 @@
+import fs from 'fs';
+import { buildDisatinger } from '../../../type-script-adapter/estinant/disatinger';
+import { Vicken } from '../../../type-script-adapter/vicken';
+import { Vition } from '../../../type-script-adapter/vition';
+import { fileUtilities } from '../../../utilities/debugger/fileUtilities';
+import { HtmlFileVoictent, HTML_FILE_GEPP } from '../html-file/htmlFile';
+import { SvgDocumentVoictent, SVG_DOCUMENT_GEPP } from './svgDocument';
+
+const INTERACTIVE_HTML_FILE_PATH =
+  'packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/interactiveSvg.html';
+
+export const svgDocumentToInteractivePage = buildDisatinger<
+  Vition<
+    SvgDocumentVoictent,
+    [Vicken<HtmlFileVoictent, [HtmlFileVoictent], string>]
+  >
+>({
+  leftGepp: SVG_DOCUMENT_GEPP,
+  rightAppreffingeTuple: [
+    {
+      gepp: HTML_FILE_GEPP,
+      framate: (): [string] => [INTERACTIVE_HTML_FILE_PATH],
+      croard: (rightInput): string => rightInput.zorn,
+    },
+  ],
+  pinbe: (leftInput, [rightInput]) => {
+    const svgText = leftInput.grition;
+    const templateFile = rightInput.grition;
+
+    const templateText = fs.readFileSync(templateFile.filePath, 'utf8');
+
+    const outputTemplate = templateText.replace(
+      '<!-- SVG_PLACEHOLDER -->',
+      svgText,
+    );
+
+    const fileId = leftInput.zorn.replaceAll(/\//g, '-');
+
+    fileUtilities.writeOutputFile(`${fileId}.html`, outputTemplate);
+  },
+});

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/html-file/htmlFile.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/html-file/htmlFile.ts
@@ -1,0 +1,17 @@
+import { Grition } from '../../adapter/grition';
+import { OdeshinFromGrition } from '../../adapter/odeshin';
+import { Voictent } from '../../adapter/voictent';
+import { File } from '../file/file';
+import { FileExtensionSuffixIdentifier } from '../file/fileExtensionSuffixIdentifier';
+
+export type HtmlFile = File<FileExtensionSuffixIdentifier.Html>;
+
+export type HtmlFileGrition = Grition<HtmlFile>;
+
+export type HtmlFileOdeshin = OdeshinFromGrition<HtmlFileGrition>;
+
+export const HTML_FILE_GEPP = 'html-file';
+
+export type HtmlFileGepp = typeof HTML_FILE_GEPP;
+
+export type HtmlFileVoictent = Voictent<HtmlFileGepp, HtmlFileOdeshin>;

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file-relationships/typeScriptFileRelationshipList.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file-relationships/typeScriptFileRelationshipList.ts
@@ -1,0 +1,99 @@
+import { buildWattlection } from '../../../type-script-adapter/estinant/wattlection';
+import { Vicken } from '../../../type-script-adapter/vicken';
+import { Vition } from '../../../type-script-adapter/vition';
+import { Grition } from '../../adapter/grition';
+import { OdeshinFromGrition } from '../../adapter/odeshin';
+import { Voictent } from '../../adapter/voictent';
+import {
+  TypeScriptFileVoictent,
+  TYPE_SCRIPT_FILE_GEPP,
+} from '../type-script-file/typeScriptFile';
+import {
+  getSourcePath,
+  TypeScriptFileImportListVoictent,
+  TypeScriptFileImportTypeName,
+  TYPE_SCRIPT_FILE_IMPORT_LIST_GEPP,
+} from '../type-script-file/typeScriptFileImportList';
+
+export type RelationshipNodeMetadata =
+  | {
+      typeName: TypeScriptFileImportTypeName.Local;
+      directoryPath: string;
+      nodePath: string;
+    }
+  | {
+      typeName: TypeScriptFileImportTypeName;
+      directoryPath?: never;
+      nodePath: string;
+    };
+
+export const getNodeId = (node: RelationshipNodeMetadata): string =>
+  `${node.typeName}:${node.nodePath}`;
+
+export type TypeScriptFileRelationship = {
+  node: RelationshipNodeMetadata;
+  importedNode: RelationshipNodeMetadata;
+};
+
+export type TypeScriptFileRelationshipList = TypeScriptFileRelationship[];
+
+export type TypeScriptFileRelationshipListGrition =
+  Grition<TypeScriptFileRelationshipList>;
+
+export type TypeScriptFileRelationshipListOdeshin =
+  OdeshinFromGrition<TypeScriptFileRelationshipListGrition>;
+
+export const TYPE_SCRIPT_FILE_RELATIONSHIP_LIST_GEPP =
+  'type-script-file-relationship-list';
+
+export type TypeScriptFileRelationshipListGepp =
+  typeof TYPE_SCRIPT_FILE_RELATIONSHIP_LIST_GEPP;
+
+export type TypeScriptFileRelationshipListVoictent = Voictent<
+  TypeScriptFileRelationshipListGepp,
+  TypeScriptFileRelationshipListOdeshin
+>;
+
+export const typeScriptFileRelationshipWattlection = buildWattlection<
+  Vition<
+    TypeScriptFileVoictent,
+    [
+      Vicken<
+        TypeScriptFileImportListVoictent,
+        [TypeScriptFileImportListVoictent],
+        string
+      >,
+    ]
+  >,
+  TypeScriptFileRelationshipListVoictent
+>({
+  leftGepp: TYPE_SCRIPT_FILE_GEPP,
+  rightAppreffingeTuple: [
+    {
+      gepp: TYPE_SCRIPT_FILE_IMPORT_LIST_GEPP,
+      framate: (leftInput): [string] => [leftInput.zorn],
+      croard: (rightInput): string => rightInput.zorn,
+    },
+  ],
+  outputGepp: TYPE_SCRIPT_FILE_RELATIONSHIP_LIST_GEPP,
+  pinbe: (leftInput, [{ grition: importList }]) => {
+    const typeScriptFile = leftInput.grition;
+
+    return {
+      zorn: leftInput.zorn,
+      grition: importList.map<TypeScriptFileRelationship>((importedItem) => {
+        return {
+          node: {
+            typeName: TypeScriptFileImportTypeName.Local,
+            directoryPath: typeScriptFile.directoryPath,
+            nodePath: typeScriptFile.filePath,
+          },
+          importedNode: {
+            typeName: importedItem.typeName,
+            nodePath: getSourcePath(importedItem),
+          },
+        };
+      }),
+    };
+  },
+});

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file-relationships/typeScriptFileRelationshipListToDirectedGraph.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file-relationships/typeScriptFileRelationshipListToDirectedGraph.ts
@@ -1,0 +1,193 @@
+import { posix } from 'path';
+import { buildCortmum } from '../../../type-script-adapter/estinant/cortmum';
+import { Vicken } from '../../../type-script-adapter/vicken';
+import { Vition } from '../../../type-script-adapter/vition';
+import {
+  Directory,
+  DirectoryOdeshin,
+  DirectoryVoictent,
+  DIRECTORY_GEPP,
+} from '../file/directory';
+import {
+  DirectedGraph,
+  DirectedGraphVoictent,
+  DIRECTED_GRAPH_GEPP,
+} from '../graph-visualization/directed-graph/directedGraph';
+import { DirectedGraphEdge } from '../graph-visualization/directed-graph/directedGraphEdge';
+import { DirectedGraphNode } from '../graph-visualization/directed-graph/directedGraphNode';
+import {
+  TypeScriptFileOdeshin,
+  TypeScriptFileVoictent,
+  TYPE_SCRIPT_FILE_GEPP,
+} from '../type-script-file/typeScriptFile';
+import { TypeScriptFileImportTypeName } from '../type-script-file/typeScriptFileImportList';
+import {
+  RelationshipNodeMetadata,
+  TypeScriptFileRelationship,
+  TypeScriptFileRelationshipListOdeshin,
+  TypeScriptFileRelationshipListVoictent,
+  TYPE_SCRIPT_FILE_RELATIONSHIP_LIST_GEPP,
+} from './typeScriptFileRelationshipList';
+
+export const typeScriptFileRelationshipListToDirectedGraph = buildCortmum<
+  Vition<
+    TypeScriptFileRelationshipListVoictent,
+    [
+      Vicken<DirectoryVoictent, [DirectoryVoictent], string>,
+      Vicken<TypeScriptFileVoictent, [TypeScriptFileVoictent], string>,
+    ]
+  >,
+  [DirectedGraphVoictent]
+>({
+  leftGepp: TYPE_SCRIPT_FILE_RELATIONSHIP_LIST_GEPP,
+  isWibiz: true,
+  rightAppreffingeTuple: [
+    {
+      gepp: DIRECTORY_GEPP,
+      isWibiz: true,
+      framate: (): [string] => [''],
+      croard: (): string => '',
+    },
+    {
+      gepp: TYPE_SCRIPT_FILE_GEPP,
+      isWibiz: true,
+      framate: (): [string] => [''],
+      croard: (): string => '',
+    },
+  ],
+  outputGeppTuple: [DIRECTED_GRAPH_GEPP],
+  pinbe: (leftInput, [rightInput1], [rightInput2]) => {
+    // TODO: update the type adapter layer to provide type safety for "isWibiz"
+    const typedLeftInput =
+      leftInput as unknown as TypeScriptFileRelationshipListOdeshin[];
+    const typedRightInput1 = rightInput1 as unknown as DirectoryOdeshin[];
+    const typedRightInput2 = rightInput2 as unknown as TypeScriptFileOdeshin[];
+
+    const directoryList = typedRightInput1.map<Directory>(
+      ({ grition }) => grition,
+    );
+
+    const typeScriptFileList = typedRightInput2.map(({ grition }) => grition);
+
+    const relationshipList = typedLeftInput.flatMap<TypeScriptFileRelationship>(
+      ({ grition }) => grition,
+    );
+
+    let rootDirectoryPathPartList: string[] = [];
+    directoryList.forEach((directory) => {
+      rootDirectoryPathPartList =
+        directory.directoryPathPartList.length <
+          rootDirectoryPathPartList.length ||
+        rootDirectoryPathPartList.length === 0
+          ? directory.directoryPathPartList
+          : rootDirectoryPathPartList;
+    });
+
+    // TODO: move this join to a utility
+    const rootDirectoryPath = rootDirectoryPathPartList.join('/');
+
+    const isRoot = (directoryPath: string): boolean =>
+      directoryPath === rootDirectoryPath;
+
+    const graphByDirectoryPath = new Map<string, DirectedGraph>();
+
+    const getOrInstantiateGraph = (directoryPath: string): DirectedGraph => {
+      const directoryName = posix.basename(directoryPath);
+
+      const graph: DirectedGraph = graphByDirectoryPath.get(directoryPath) ?? {
+        id: directoryPath,
+        label: isRoot(directoryPath) ? directoryPath : directoryName,
+        nodeList: [],
+        edgeList: [],
+        subgraphList: [],
+      };
+
+      graphByDirectoryPath.set(directoryPath, graph);
+
+      return graph;
+    };
+
+    directoryList.forEach((directory) => {
+      // TODO: move these insights to the "File" type
+      const { directoryPath } = directory;
+      const parentDirectoryPath = posix.dirname(directoryPath);
+
+      const graph = getOrInstantiateGraph(directoryPath);
+
+      if (!isRoot(directoryPath)) {
+        const parentGraph = getOrInstantiateGraph(parentDirectoryPath);
+        parentGraph.subgraphList.push(graph);
+      }
+    });
+
+    typeScriptFileList.forEach((file) => {
+      const node: DirectedGraphNode = {
+        id: file.filePath,
+        label: posix.basename(file.filePath),
+      };
+
+      const graph = graphByDirectoryPath.get(
+        posix.dirname(file.filePath),
+      ) as DirectedGraph;
+      graph.nodeList.push(node);
+    });
+
+    const rootDirectoryGraph = graphByDirectoryPath.get(
+      rootDirectoryPath,
+    ) as DirectedGraph;
+
+    const rootGraph: DirectedGraph = {
+      id: '',
+      label: 'TypeScript File Relationships',
+      nodeList: [],
+      edgeList: [],
+      subgraphList: [rootDirectoryGraph],
+    };
+
+    relationshipList.forEach(({ node, importedNode }) => {
+      const edge: DirectedGraphEdge = {
+        tailId: node.nodePath,
+        headId: importedNode.nodePath,
+      };
+
+      rootGraph.edgeList.push(edge);
+    });
+
+    const externalNodeByNodePath = new Map<string, RelationshipNodeMetadata>();
+    relationshipList
+      .map(({ importedNode }) => importedNode)
+      .filter(
+        (importedNode) =>
+          importedNode.typeName === TypeScriptFileImportTypeName.External,
+      )
+      .forEach((importedNode) => {
+        const node =
+          externalNodeByNodePath.get(importedNode.nodePath) ?? importedNode;
+        externalNodeByNodePath.set(importedNode.nodePath, node);
+      });
+
+    const externalSubGraph: DirectedGraph = {
+      id: 'Node Modules',
+      label: 'Node Modules',
+      nodeList: [...externalNodeByNodePath.values()].map<DirectedGraphNode>(
+        ({ nodePath }) => ({
+          id: nodePath,
+          label: nodePath,
+        }),
+      ),
+      edgeList: [],
+      subgraphList: [],
+    };
+
+    rootGraph.subgraphList.unshift(externalSubGraph);
+
+    return {
+      [DIRECTED_GRAPH_GEPP]: [
+        {
+          zorn: 'type-script-file-relationship-graph',
+          grition: rootGraph,
+        },
+      ],
+    };
+  },
+});

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file/typeScriptFileImportList.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file/typeScriptFileImportList.ts
@@ -35,6 +35,11 @@ export type TypeScriptFileImport =
   | LocalTypeScriptFileImport
   | ExternalTypeScriptFileImport;
 
+export const getSourcePath = (importItem: TypeScriptFileImport): string =>
+  importItem.typeName === TypeScriptFileImportTypeName.Local
+    ? importItem.filePath
+    : importItem.moduleName;
+
 export type TypeScriptFileImportList = TypeScriptFileImport[];
 
 export type TypeScriptFileImportListGrition = Grition<TypeScriptFileImportList>;

--- a/packages/voictents-and-estinants-engine/src/custom/programs/modelPrograms.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/modelPrograms.ts
@@ -2,7 +2,7 @@ import { digikikify } from '../../type-script-adapter/digikikify';
 import { debugHubblepup } from '../debugger/debugHubblepup';
 import {
   FILE_MENTURSECTION_CONFIGURATION_GEPP,
-  PIPES_AND_FILTERS_FILE_MENTURSECTION_CONFIGURATION,
+  VOICTENTS_AND_ESTINANTS_FILE_MENTURSECTION_CONFIGURATION,
 } from '../programmable-units/file/fileMentursectionConfiguration';
 import { fileMattomer } from '../programmable-units/file/fileMattomer';
 import { fileMentursection } from '../programmable-units/file/fileMentursection';
@@ -27,7 +27,7 @@ import { engineProgramRendererWortinator } from '../programmable-units/engine-pr
 digikikify({
   initialVoictentsByGepp: {
     [FILE_MENTURSECTION_CONFIGURATION_GEPP]: [
-      PIPES_AND_FILTERS_FILE_MENTURSECTION_CONFIGURATION,
+      VOICTENTS_AND_ESTINANTS_FILE_MENTURSECTION_CONFIGURATION,
     ],
     [ENGINE_FUNCTION_CONFIGURATION_GEPP]: [ENGINE_FUNCTION_CONFIGURATION],
   },

--- a/packages/voictents-and-estinants-engine/src/custom/programs/renderTypeScriptFileRelationships.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/renderTypeScriptFileRelationships.ts
@@ -1,0 +1,41 @@
+import { digikikify } from '../../type-script-adapter/digikikify';
+import { debugHubblepup } from '../debugger/debugHubblepup';
+import { fileMattomer } from '../programmable-units/file/fileMattomer';
+import { fileMentursection } from '../programmable-units/file/fileMentursection';
+import {
+  FILE_MENTURSECTION_CONFIGURATION_GEPP,
+  VOICTENTS_AND_ESTINANTS_FILE_MENTURSECTION_CONFIGURATION,
+} from '../programmable-units/file/fileMentursectionConfiguration';
+import { directedGraphToGraphvizCode } from '../programmable-units/graph-visualization/directedGraphToGraphvizCode';
+import { graphvizCodeToSvgDocument } from '../programmable-units/graph-visualization/graphvizCodeToSvgDocument';
+import { svgDocumentToInteractivePage } from '../programmable-units/graph-visualization/svgDocumentToInteractivePage';
+import { typeScriptFileRelationshipWattlection } from '../programmable-units/type-script-file-relationships/typeScriptFileRelationshipList';
+import { typeScriptFileRelationshipListToDirectedGraph } from '../programmable-units/type-script-file-relationships/typeScriptFileRelationshipListToDirectedGraph';
+import { parsedTypeScriptFileMentursection } from '../programmable-units/type-script-file/parsedTypeScriptFile';
+import { typeScriptFileConfigurationOnama } from '../programmable-units/type-script-file/typeScriptFileConfiguration';
+import { typeScriptFileImportListOnama } from '../programmable-units/type-script-file/typeScriptFileImportList';
+
+digikikify({
+  initialVoictentsByGepp: {
+    [FILE_MENTURSECTION_CONFIGURATION_GEPP]: [
+      VOICTENTS_AND_ESTINANTS_FILE_MENTURSECTION_CONFIGURATION,
+    ],
+  },
+  estinantTuple: [
+    fileMentursection,
+    fileMattomer,
+
+    typeScriptFileConfigurationOnama,
+    parsedTypeScriptFileMentursection,
+    typeScriptFileImportListOnama,
+
+    typeScriptFileRelationshipWattlection,
+    typeScriptFileRelationshipListToDirectedGraph,
+
+    directedGraphToGraphvizCode,
+    graphvizCodeToSvgDocument,
+    svgDocumentToInteractivePage,
+    // relationshipRendererWortinator,
+  ],
+  onHubblepupAddedToVoictents: debugHubblepup,
+});

--- a/packages/voictents-and-estinants-engine/src/custom/programs/test-typed-datum/customDatumTypeName.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/test-typed-datum/customDatumTypeName.ts
@@ -1,0 +1,18 @@
+import { CustomDatumTypeName } from '../../../utilities/typed-datum/customTypedDatum';
+import { Grition } from '../../adapter/grition';
+import { OdeshinFromGrition } from '../../adapter/odeshin';
+import { Voictent } from '../../adapter/voictent';
+
+export type CustomDatumTypeNameGrition = Grition<CustomDatumTypeName>;
+
+export type CustomDatumTypeNameOdeshin =
+  OdeshinFromGrition<CustomDatumTypeNameGrition>;
+
+export const CUSTOM_DATUM_TYPE_NAME_GEPP = 'custom-datum-type-name';
+
+export type CustomDatumTypeNameGepp = typeof CUSTOM_DATUM_TYPE_NAME_GEPP;
+
+export type CustomDatumTypeNameVoictent = Voictent<
+  CustomDatumTypeNameGepp,
+  CustomDatumTypeNameOdeshin
+>;

--- a/packages/voictents-and-estinants-engine/src/custom/programs/test-typed-datum/datumTestCaseInputToCustomDatumTypeName.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/test-typed-datum/datumTestCaseInputToCustomDatumTypeName.ts
@@ -1,0 +1,22 @@
+import { getCustomTypedDatum } from '../../../utilities/typed-datum/customTypedDatum';
+import { buildOnama } from '../../adapter/estinant/onama';
+import {
+  DatumTestCaseInputVoictent,
+  DATUM_TEST_CASE_INPUT_GEPP,
+} from '../../programmable-units/datum-test-case-input/datumTestCaseInput';
+import {
+  CustomDatumTypeNameVoictent,
+  CUSTOM_DATUM_TYPE_NAME_GEPP,
+} from './customDatumTypeName';
+
+export const datumTestCaseInputToCustomDatumTypeName = buildOnama<
+  DatumTestCaseInputVoictent,
+  CustomDatumTypeNameVoictent
+>({
+  inputGepp: DATUM_TEST_CASE_INPUT_GEPP,
+  outputGepp: CUSTOM_DATUM_TYPE_NAME_GEPP,
+  pinbe: (input) => {
+    const typedDatum = getCustomTypedDatum(input);
+    return typedDatum.typeName;
+  },
+});

--- a/packages/voictents-and-estinants-engine/src/custom/programs/test-typed-datum/datumTestCaseInputToSerializedDatum.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/test-typed-datum/datumTestCaseInputToSerializedDatum.ts
@@ -1,0 +1,22 @@
+import { serialize } from '../../../utilities/typed-datum/serializer/serialize';
+import { buildOnama } from '../../adapter/estinant/onama';
+import {
+  DatumTestCaseInputVoictent,
+  DATUM_TEST_CASE_INPUT_GEPP,
+} from '../../programmable-units/datum-test-case-input/datumTestCaseInput';
+import {
+  SerializedDatumVoictent,
+  SERIALIZED_DATUM_GEPP,
+} from './serializedDatum';
+
+export const datumTestCaseInputToSerializedDatum = buildOnama<
+  DatumTestCaseInputVoictent,
+  SerializedDatumVoictent
+>({
+  inputGepp: DATUM_TEST_CASE_INPUT_GEPP,
+  outputGepp: SERIALIZED_DATUM_GEPP,
+  pinbe: (input) => {
+    const text = serialize(input);
+    return text;
+  },
+});

--- a/packages/voictents-and-estinants-engine/src/custom/programs/test-typed-datum/datumTestCaseInputToTypeScriptDatumTypeName.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/test-typed-datum/datumTestCaseInputToTypeScriptDatumTypeName.ts
@@ -1,0 +1,22 @@
+import { getTypeScriptTypedDatum } from '../../../utilities/typed-datum/type-script/typeScriptTypedDatum';
+import { buildOnama } from '../../adapter/estinant/onama';
+import {
+  DatumTestCaseInputVoictent,
+  DATUM_TEST_CASE_INPUT_GEPP,
+} from '../../programmable-units/datum-test-case-input/datumTestCaseInput';
+import {
+  TypeScriptDatumTypeNameVoictent,
+  TYPE_SCRIPT_DATUM_TYPE_NAME_GEPP,
+} from './typeScriptDatumTypeName';
+
+export const datumTestCaseInputToTypeScriptDatumTypeName = buildOnama<
+  DatumTestCaseInputVoictent,
+  TypeScriptDatumTypeNameVoictent
+>({
+  inputGepp: DATUM_TEST_CASE_INPUT_GEPP,
+  outputGepp: TYPE_SCRIPT_DATUM_TYPE_NAME_GEPP,
+  pinbe: (input) => {
+    const typedDatum = getTypeScriptTypedDatum(input);
+    return typedDatum.typeName;
+  },
+});

--- a/packages/voictents-and-estinants-engine/src/custom/programs/test-typed-datum/datumTestCaseInputToTypeScriptTypeName.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/test-typed-datum/datumTestCaseInputToTypeScriptTypeName.ts
@@ -1,0 +1,23 @@
+// import { getTypeScriptTypedDatum } from '../../../utilities/typed-datum/type-script/typeScriptTypedDatum';
+// import { buildOnama } from '../../adapter/estinant/onama';
+// import {
+//   DatumTestCaseInputVoictent,
+//   DATUM_TEST_CASE_INPUT_GEPP,
+// } from '../../programmable-units/datum-test-case-input/datumTestCaseInput';
+
+// import {
+//   TypeScriptTypeNameVoictent,
+//   TYPE_SCRIPT_TYPE_NAME_GEPP,
+// } from './typeScriptTypeName';
+
+// export const datumTestCaseInputToTypeScriptTypeName = buildOnama<
+//   DatumTestCaseInputVoictent,
+//   TypeScriptTypeNameVoictent
+// >({
+//   inputGepp: DATUM_TEST_CASE_INPUT_GEPP,
+//   outputGepp: TYPE_SCRIPT_TYPE_NAME_GEPP,
+//   pinbe: (input) => {
+//     const typedDatum = getTypeScriptTypedDatum(input);
+//     return typedDatum.typeName;
+//   },
+// });

--- a/packages/voictents-and-estinants-engine/src/custom/programs/test-typed-datum/serializedDatum.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/test-typed-datum/serializedDatum.ts
@@ -1,0 +1,18 @@
+import { Grition } from '../../adapter/grition';
+import { OdeshinFromGrition } from '../../adapter/odeshin';
+import { Voictent } from '../../adapter/voictent';
+
+export type SerializedDatum = string;
+
+export type SerializedDatumGrition = Grition<SerializedDatum>;
+
+export type SerializedDatumOdeshin = OdeshinFromGrition<SerializedDatumGrition>;
+
+export const SERIALIZED_DATUM_GEPP = 'serialized-datum';
+
+export type SerializedDatumGepp = typeof SERIALIZED_DATUM_GEPP;
+
+export type SerializedDatumVoictent = Voictent<
+  SerializedDatumGepp,
+  SerializedDatumOdeshin
+>;

--- a/packages/voictents-and-estinants-engine/src/custom/programs/test-typed-datum/testTypedDatum.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/test-typed-datum/testTypedDatum.ts
@@ -1,0 +1,36 @@
+import { digikikify } from '../../../type-script-adapter/digikikify';
+import { debugHubblepup } from '../../debugger/debugHubblepup';
+import {
+  DATUM_TEST_CASE_INPUT_GEPP,
+  DATUM_TEST_CASE_INPUT_ODESHIN_LIST,
+} from '../../programmable-units/datum-test-case-input/datumTestCaseInput';
+import { datumTestCaseInputToTypeScriptDatumTypeName } from './datumTestCaseInputToTypeScriptDatumTypeName';
+import { datumTestCaseInputToCustomDatumTypeName } from './datumTestCaseInputToCustomDatumTypeName';
+import { datumTestCaseInputToSerializedDatum } from './datumTestCaseInputToSerializedDatum';
+import { SERIALIZED_DATUM_GEPP } from './serializedDatum';
+import { fileUtilities } from '../../../utilities/debugger/fileUtilities';
+import { escapePathSeparator } from '../../debugger/debugOdeshin';
+
+digikikify({
+  initialVoictentsByGepp: {
+    [DATUM_TEST_CASE_INPUT_GEPP]: DATUM_TEST_CASE_INPUT_ODESHIN_LIST,
+  },
+  estinantTuple: [
+    datumTestCaseInputToTypeScriptDatumTypeName,
+    datumTestCaseInputToCustomDatumTypeName,
+    datumTestCaseInputToSerializedDatum,
+  ],
+  onHubblepupAddedToVoictents: (plifal) => {
+    if (plifal.gepp === SERIALIZED_DATUM_GEPP) {
+      fileUtilities.writeCacheFile({
+        directoryName: plifal.gepp,
+        fileName: escapePathSeparator(plifal.hubblepup.zorn),
+        text: plifal.hubblepup.grition,
+        fileExtensionSuffix: 'yml',
+      });
+      return;
+    }
+
+    debugHubblepup(plifal);
+  },
+});

--- a/packages/voictents-and-estinants-engine/src/custom/programs/test-typed-datum/typeScriptDatumTypeName.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/test-typed-datum/typeScriptDatumTypeName.ts
@@ -1,0 +1,19 @@
+import { TypeScriptDatumTypeName } from '../../../utilities/typed-datum/type-script/typeScriptTypedDatum';
+import { Grition } from '../../adapter/grition';
+import { OdeshinFromGrition } from '../../adapter/odeshin';
+import { Voictent } from '../../adapter/voictent';
+
+export type TypeScriptDatumTypeNameGrition = Grition<TypeScriptDatumTypeName>;
+
+export type TypeScriptDatumTypeNameOdeshin =
+  OdeshinFromGrition<TypeScriptDatumTypeNameGrition>;
+
+export const TYPE_SCRIPT_DATUM_TYPE_NAME_GEPP = 'type-script-datum-type-name';
+
+export type TypeScriptDatumTypeNameGepp =
+  typeof TYPE_SCRIPT_DATUM_TYPE_NAME_GEPP;
+
+export type TypeScriptDatumTypeNameVoictent = Voictent<
+  TypeScriptDatumTypeNameGepp,
+  TypeScriptDatumTypeNameOdeshin
+>;

--- a/packages/voictents-and-estinants-engine/src/custom/programs/testGraphRender.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/testGraphRender.ts
@@ -1,0 +1,92 @@
+import { digikikify } from '../../type-script-adapter/digikikify';
+import { debugHubblepup } from '../debugger/debugHubblepup';
+import { fileMattomer } from '../programmable-units/file/fileMattomer';
+import { fileMentursection } from '../programmable-units/file/fileMentursection';
+import { FILE_MENTURSECTION_CONFIGURATION_GEPP } from '../programmable-units/file/fileMentursectionConfiguration';
+import { DIRECTED_GRAPH_GEPP } from '../programmable-units/graph-visualization/directed-graph/directedGraph';
+import { directedGraphToGraphvizCode } from '../programmable-units/graph-visualization/directedGraphToGraphvizCode';
+import { graphvizCodeToSvgDocument } from '../programmable-units/graph-visualization/graphvizCodeToSvgDocument';
+import { svgDocumentToInteractivePage } from '../programmable-units/graph-visualization/svgDocumentToInteractivePage';
+import { typeScriptFileRelationshipWattlection } from '../programmable-units/type-script-file-relationships/typeScriptFileRelationshipList';
+import { parsedTypeScriptFileMentursection } from '../programmable-units/type-script-file/parsedTypeScriptFile';
+import { typeScriptFileConfigurationOnama } from '../programmable-units/type-script-file/typeScriptFileConfiguration';
+import { typeScriptFileImportListOnama } from '../programmable-units/type-script-file/typeScriptFileImportList';
+
+digikikify({
+  initialVoictentsByGepp: {
+    [FILE_MENTURSECTION_CONFIGURATION_GEPP]: [
+      {
+        directoryPath:
+          'packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization',
+        ignoredNodePathConfigurationList: [],
+      },
+    ],
+    [DIRECTED_GRAPH_GEPP]: [
+      {
+        zorn: 'my-graph',
+        grition: {
+          id: 'my graph',
+          label: 'my graph',
+          nodeList: [
+            {
+              id: 'a',
+              label: 'node a',
+            },
+            {
+              id: 'b',
+              label: 'node b',
+            },
+          ],
+          edgeList: [
+            {
+              tailId: 'a',
+              headId: 'b',
+            },
+            {
+              tailId: 'a',
+              headId: 'c',
+            },
+          ],
+          subgraphList: [
+            {
+              id: 'my subgraph',
+              label: 'my subgraph',
+              nodeList: [
+                {
+                  id: 'c',
+                  label: 'node c',
+                },
+                {
+                  id: 'd',
+                  label: 'node d',
+                },
+              ],
+              edgeList: [
+                {
+                  tailId: 'c',
+                  headId: 'd',
+                },
+              ],
+              subgraphList: [],
+            },
+          ],
+        },
+      },
+    ],
+  },
+  estinantTuple: [
+    fileMentursection,
+    fileMattomer,
+
+    typeScriptFileConfigurationOnama,
+    parsedTypeScriptFileMentursection,
+    typeScriptFileImportListOnama,
+
+    typeScriptFileRelationshipWattlection,
+
+    directedGraphToGraphvizCode,
+    graphvizCodeToSvgDocument,
+    svgDocumentToInteractivePage,
+  ],
+  onHubblepupAddedToVoictents: debugHubblepup,
+});

--- a/packages/voictents-and-estinants-engine/src/type-script-adapter/appreffinge.ts
+++ b/packages/voictents-and-estinants-engine/src/type-script-adapter/appreffinge.ts
@@ -5,6 +5,7 @@ import { Vition } from './vition';
 
 export type LeftAppreffinge<TInputVition extends Vition> = {
   gepp: TInputVition['leftVoictent']['gepp'];
+  isWibiz?: boolean;
 };
 
 export type RightAppreffinge<
@@ -12,6 +13,7 @@ export type RightAppreffinge<
   TVicken extends Vicken = Vicken,
 > = {
   gepp: TVicken['voictent']['gepp'];
+  isWibiz?: boolean;
   croard: Croarder<TVicken>;
   framate: Framation<TInputVition, TVicken>;
 };

--- a/packages/voictents-and-estinants-engine/src/type-script-adapter/estinant/cortmum.ts
+++ b/packages/voictents-and-estinants-engine/src/type-script-adapter/estinant/cortmum.ts
@@ -36,6 +36,7 @@ export type CortmumBuilderInput<
   TOutputVoictentTuple extends VoictentTuple,
 > = {
   leftGepp: TInputVition['leftVoictent']['gepp'];
+  isWibiz?: boolean;
   rightAppreffingeTuple: RightAppreffingeTuple<TInputVition>;
   outputGeppTuple: VoictentTupleToGeppTuple<TOutputVoictentTuple>;
   pinbe: CortmumPinbetunf<TInputVition, TOutputVoictentTuple>;
@@ -46,6 +47,7 @@ export const buildCortmum = <
   TOutputVoictentTuple extends VoictentTuple,
 >({
   leftGepp,
+  isWibiz,
   rightAppreffingeTuple,
   outputGeppTuple,
   pinbe,
@@ -75,6 +77,7 @@ export const buildCortmum = <
   const estinant: Cortmum<TInputVition, TOutputVoictentTuple> = {
     leftAppreffinge: {
       gepp: leftGepp,
+      isWibiz,
     },
     rightAppreffingeTuple,
     tropoig,

--- a/packages/voictents-and-estinants-engine/src/type-script-adapter/estinant/disatinger.ts
+++ b/packages/voictents-and-estinants-engine/src/type-script-adapter/estinant/disatinger.ts
@@ -24,12 +24,14 @@ export type Disatinger<TInputVition extends Vition> = Estinant<
 
 export type DisatingerBuilderInput<TInputVition extends Vition> = {
   leftGepp: TInputVition['leftVoictent']['gepp'];
+  isWibiz?: boolean;
   rightAppreffingeTuple: RightAppreffingeTuple<TInputVition>;
   pinbe: DisatingerPinbetunf<TInputVition>;
 };
 
 export const buildDisatinger = <TInputVition extends Vition>({
   leftGepp,
+  isWibiz,
   rightAppreffingeTuple,
   pinbe,
 }: DisatingerBuilderInput<TInputVition>): Disatinger<TInputVition> => {
@@ -39,7 +41,7 @@ export const buildDisatinger = <TInputVition extends Vition>({
   };
 
   const estinant: Disatinger<TInputVition> = {
-    leftAppreffinge: { gepp: leftGepp },
+    leftAppreffinge: { gepp: leftGepp, isWibiz },
     rightAppreffingeTuple,
     tropoig,
   };

--- a/packages/voictents-and-estinants-engine/src/type-script-adapter/estinant/wortinator.ts
+++ b/packages/voictents-and-estinants-engine/src/type-script-adapter/estinant/wortinator.ts
@@ -20,13 +20,21 @@ export type Wortinator<TInputVoictent extends Voictent> = Estinant<
   []
 >;
 
-export type WortinatorBuilderInput<TInputVoictent extends Voictent> = {
-  inputGepp: TInputVoictent['gepp'];
-  pinbe: WortinatorPinbetunf<TInputVoictent>;
-};
+export type WortinatorBuilderInput<TInputVoictent extends Voictent> =
+  | {
+      inputGepp: TInputVoictent['gepp'];
+      isWibiz?: never;
+      pinbe: WortinatorPinbetunf<TInputVoictent>;
+    }
+  | {
+      inputGepp: TInputVoictent['gepp'];
+      isWibiz: boolean;
+      pinbe: WortinatorPinbetunf<TInputVoictent>;
+    };
 
 export const buildWortinator = <TInputVoictent extends Voictent>({
   inputGepp,
+  isWibiz,
   pinbe,
 }: WortinatorBuilderInput<TInputVoictent>): Wortinator<TInputVoictent> => {
   const tropoig: WortinatorTropoignant<TInputVoictent> = (input) => {
@@ -35,7 +43,7 @@ export const buildWortinator = <TInputVoictent extends Voictent>({
   };
 
   const estinant: Wortinator<TInputVoictent> = {
-    leftAppreffinge: { gepp: inputGepp },
+    leftAppreffinge: { gepp: inputGepp, isWibiz },
     rightAppreffingeTuple: [],
     tropoig,
   };

--- a/packages/voictents-and-estinants-engine/src/utilities/debugger/fileUtilities.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/debugger/fileUtilities.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { posix } from 'path';
-import { serialize } from '../serialize';
+import { serialize } from '../typed-datum/serializer/serialize';
 
 const DEBUG_DIR_PATH = './debug/' as const;
 const CACHE_PATH = posix.join(DEBUG_DIR_PATH, 'cache');
@@ -38,7 +38,7 @@ export const fileUtilities = {
     if (input.fileExtensionSuffix !== undefined) {
       fileExtensionSuffix = input.fileExtensionSuffix;
     } else if (hasData(input)) {
-      fileExtensionSuffix = 'json';
+      fileExtensionSuffix = 'yml';
     } else {
       fileExtensionSuffix = 'txt';
     }

--- a/packages/voictents-and-estinants-engine/src/utilities/semantic-types/list.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/semantic-types/list.ts
@@ -1,3 +1,3 @@
 import { Tuple } from './tuple';
 
-export type List<T> = T[] | Tuple<T>;
+export type List<T> = Array<T> | Tuple<T>;

--- a/packages/voictents-and-estinants-engine/src/utilities/typed-datum/customTypedDatum.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/typed-datum/customTypedDatum.ts
@@ -1,0 +1,200 @@
+import { TypeScriptFunction } from './type-script/function';
+import {
+  TypeScriptArray,
+  TypeScriptMap,
+  TypeScriptObjectInstance,
+  TypeScriptSet,
+} from './type-script/object';
+import {
+  getTypeScriptTypedDatum,
+  TypeScriptDatumTypeName,
+} from './type-script/typeScriptTypedDatum';
+
+export enum CustomDatumTypeName {
+  Array = 'Array',
+  BigInteger = 'BigInteger',
+  Boolean = 'Boolean',
+  CustomObjectInstance = 'CustomObjectInstance',
+  Function = 'Function',
+  Map = 'Map',
+  Null = 'Null',
+  Number = 'Number',
+  RootObjectInstance = 'RootObjectInstance',
+  Set = 'Set',
+  String = 'String',
+  Symbol = 'Symbol',
+  Undefined = 'Undefined',
+}
+
+type BaseCustomTypedDatum<
+  TCustomDatumTypeName extends CustomDatumTypeName,
+  TDatum,
+> = {
+  typeName: TCustomDatumTypeName;
+  datum: TDatum;
+};
+
+export type CustomTypedArray = BaseCustomTypedDatum<
+  CustomDatumTypeName.Array,
+  TypeScriptArray
+>;
+
+export type CustomTypedBigInteger = BaseCustomTypedDatum<
+  CustomDatumTypeName.BigInteger,
+  bigint
+>;
+
+export type CustomTypedBoolean = BaseCustomTypedDatum<
+  CustomDatumTypeName.Boolean,
+  boolean
+>;
+
+export type CustomTypedCustomObjectInstance = BaseCustomTypedDatum<
+  CustomDatumTypeName.CustomObjectInstance,
+  TypeScriptObjectInstance
+>;
+
+export type CustomTypedFunction = BaseCustomTypedDatum<
+  CustomDatumTypeName.Function,
+  TypeScriptFunction
+>;
+
+export type CustomTypedMap = BaseCustomTypedDatum<
+  CustomDatumTypeName.Map,
+  TypeScriptMap
+>;
+
+export type CustomTypedNull = BaseCustomTypedDatum<
+  CustomDatumTypeName.Null,
+  null
+>;
+
+export type CustomTypedNumber = BaseCustomTypedDatum<
+  CustomDatumTypeName.Number,
+  number
+>;
+
+export type CustomTypedRootObjectInstance = BaseCustomTypedDatum<
+  CustomDatumTypeName.RootObjectInstance,
+  TypeScriptObjectInstance
+>;
+
+export type CustomTypedSet = BaseCustomTypedDatum<
+  CustomDatumTypeName.Set,
+  TypeScriptSet
+>;
+
+export type CustomTypedString = BaseCustomTypedDatum<
+  CustomDatumTypeName.String,
+  string
+>;
+
+export type CustomTypedSymbol = BaseCustomTypedDatum<
+  CustomDatumTypeName.Symbol,
+  symbol
+>;
+
+export type CustomTypedUndefined = BaseCustomTypedDatum<
+  CustomDatumTypeName.Undefined,
+  undefined
+>;
+
+export type CustomTypedDatum =
+  | CustomTypedArray
+  | CustomTypedBigInteger
+  | CustomTypedBoolean
+  | CustomTypedCustomObjectInstance
+  | CustomTypedFunction
+  | CustomTypedMap
+  | CustomTypedNull
+  | CustomTypedNumber
+  | CustomTypedRootObjectInstance
+  | CustomTypedSet
+  | CustomTypedString
+  | CustomTypedSymbol
+  | CustomTypedUndefined;
+
+export const getCustomTypedDatum = (inputDatum: unknown): CustomTypedDatum => {
+  const typeScriptTypedDatum = getTypeScriptTypedDatum(inputDatum);
+
+  switch (typeScriptTypedDatum.typeName) {
+    case TypeScriptDatumTypeName.bigint:
+      return {
+        typeName: CustomDatumTypeName.BigInteger,
+        datum: typeScriptTypedDatum.datum,
+      };
+    case TypeScriptDatumTypeName.boolean:
+      return {
+        typeName: CustomDatumTypeName.Boolean,
+        datum: typeScriptTypedDatum.datum,
+      };
+    case TypeScriptDatumTypeName.function:
+      return {
+        typeName: CustomDatumTypeName.Function,
+        datum: typeScriptTypedDatum.datum,
+      };
+    case TypeScriptDatumTypeName.number:
+      return {
+        typeName: CustomDatumTypeName.Number,
+        datum: typeScriptTypedDatum.datum,
+      };
+    case TypeScriptDatumTypeName.object: {
+      if (typeScriptTypedDatum.datum === null) {
+        return {
+          typeName: CustomDatumTypeName.Null,
+          datum: typeScriptTypedDatum.datum,
+        };
+      }
+
+      if (Array.isArray(typeScriptTypedDatum.datum)) {
+        return {
+          typeName: CustomDatumTypeName.Array,
+          datum: typeScriptTypedDatum.datum,
+        };
+      }
+
+      if (typeScriptTypedDatum.datum instanceof Set) {
+        return {
+          typeName: CustomDatumTypeName.Set,
+          datum: typeScriptTypedDatum.datum,
+        };
+      }
+
+      if (typeScriptTypedDatum.datum instanceof Map) {
+        return {
+          typeName: CustomDatumTypeName.Map,
+          datum: typeScriptTypedDatum.datum,
+        };
+      }
+
+      if (
+        Object.getPrototypeOf(typeScriptTypedDatum.datum) === Object.prototype
+      ) {
+        return {
+          typeName: CustomDatumTypeName.RootObjectInstance,
+          datum: typeScriptTypedDatum.datum,
+        };
+      }
+
+      return {
+        typeName: CustomDatumTypeName.CustomObjectInstance,
+        datum: typeScriptTypedDatum.datum,
+      };
+    }
+    case TypeScriptDatumTypeName.string:
+      return {
+        typeName: CustomDatumTypeName.String,
+        datum: typeScriptTypedDatum.datum,
+      };
+    case TypeScriptDatumTypeName.symbol:
+      return {
+        typeName: CustomDatumTypeName.Symbol,
+        datum: typeScriptTypedDatum.datum,
+      };
+    case TypeScriptDatumTypeName.undefined:
+      return {
+        typeName: CustomDatumTypeName.Undefined,
+        datum: typeScriptTypedDatum.datum,
+      };
+  }
+};

--- a/packages/voictents-and-estinants-engine/src/utilities/typed-datum/serializer/buildSerializeableNode.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/typed-datum/serializer/buildSerializeableNode.ts
@@ -1,0 +1,267 @@
+import * as uuid from 'uuid';
+import { getPrototypeNameTuple } from '../../getPrototypeNameTuple';
+import {
+  CustomDatumTypeName,
+  CustomTypedArray,
+  CustomTypedBigInteger,
+  CustomTypedBoolean,
+  CustomTypedCustomObjectInstance,
+  CustomTypedFunction,
+  CustomTypedMap,
+  CustomTypedNull,
+  CustomTypedNumber,
+  CustomTypedRootObjectInstance,
+  CustomTypedSet,
+  CustomTypedString,
+  CustomTypedSymbol,
+  CustomTypedUndefined,
+  getCustomTypedDatum,
+} from '../customTypedDatum';
+import { getTypeScriptObjectEntryList } from '../type-script/object';
+import {
+  isSimpleObjectEntryKey,
+  SerializeableBooleanNode,
+  SerializeableListNode,
+  SerializeableNode,
+  SerializeableNodeName,
+  SerializeableNullDatum,
+  SerializeableNullNode,
+  SerializeableNumberNode,
+  SerializeableObjectNode,
+  SerializeableStringNode,
+  SimpleSerializeableObjectEntry,
+} from './serializeableNode';
+
+const symbolReferenceMap = new Map<symbol, string>();
+
+type MappedSerializeableNode<TDatum> =
+  // this comment forces prettier to make this readable >:(
+  TDatum extends CustomTypedBoolean['datum']
+    ? SerializeableBooleanNode
+    : TDatum extends CustomTypedArray['datum'] | CustomTypedSet['datum']
+    ? SerializeableListNode
+    : TDatum extends CustomTypedNull['datum'] | CustomTypedUndefined['datum']
+    ? SerializeableNullDatum
+    : TDatum extends CustomTypedBigInteger['datum'] | CustomTypedNumber['datum']
+    ? SerializeableNumberNode
+    : TDatum extends
+        | CustomTypedCustomObjectInstance['datum']
+        | CustomTypedFunction['datum']
+        | CustomTypedMap['datum']
+        | CustomTypedRootObjectInstance['datum']
+    ? SerializeableObjectNode
+    : TDatum extends CustomTypedString['datum'] | CustomTypedSymbol['datum']
+    ? SerializeableStringNode
+    : SerializeableNode;
+
+export const buildSerializeableNode = <TDatum>(
+  inputDatum: TDatum,
+): MappedSerializeableNode<TDatum> => {
+  const { typeName, datum } = getCustomTypedDatum(inputDatum);
+
+  switch (typeName) {
+    // Boolean
+    case CustomDatumTypeName.Boolean:
+      return {
+        nodeName: SerializeableNodeName.Boolean,
+        metadata: {
+          value: datum,
+        },
+      } satisfies SerializeableBooleanNode as MappedSerializeableNode<TDatum>;
+
+    // List
+    case CustomDatumTypeName.Array:
+      return {
+        nodeName: SerializeableNodeName.List,
+        metadata: {
+          typeName,
+          valueTuple: datum.map((element) => {
+            const serializeableElement = buildSerializeableNode(element);
+            return serializeableElement;
+          }),
+        },
+        // TODO: investigate this broken cast
+      } satisfies SerializeableListNode as unknown as MappedSerializeableNode<TDatum>;
+    case CustomDatumTypeName.Set:
+      return {
+        nodeName: SerializeableNodeName.List,
+        metadata: {
+          typeName,
+          valueTuple: [...datum].map((element) => {
+            const serializeableElement = buildSerializeableNode(element);
+            return serializeableElement;
+          }),
+        },
+        // TODO: investigate this broken cast
+      } satisfies SerializeableListNode as unknown as MappedSerializeableNode<TDatum>;
+
+    // Null
+    case CustomDatumTypeName.Null:
+      return {
+        nodeName: SerializeableNodeName.Null,
+        metadata: {
+          typeName,
+          value: datum,
+        },
+      } satisfies SerializeableNullNode as MappedSerializeableNode<TDatum>;
+    case CustomDatumTypeName.Undefined:
+      return {
+        nodeName: SerializeableNodeName.Null,
+        metadata: {
+          typeName,
+          value: datum,
+        },
+      } satisfies SerializeableNullNode as MappedSerializeableNode<TDatum>;
+
+    // Number
+    case CustomDatumTypeName.BigInteger:
+      return {
+        nodeName: SerializeableNodeName.Number,
+        metadata: {
+          typeName,
+          value: datum,
+        },
+      } satisfies SerializeableNumberNode as MappedSerializeableNode<TDatum>;
+    case CustomDatumTypeName.Number:
+      return {
+        nodeName: SerializeableNodeName.Number,
+        metadata: {
+          typeName,
+          value: datum,
+        },
+      } satisfies SerializeableNumberNode as MappedSerializeableNode<TDatum>;
+
+    // Object
+    case CustomDatumTypeName.CustomObjectInstance: {
+      const entryList = getTypeScriptObjectEntryList(datum);
+
+      const serializeableEntryList =
+        entryList.map<SimpleSerializeableObjectEntry>(([key, value]) => {
+          const keyNode = buildSerializeableNode(key);
+          const valueNode = buildSerializeableNode(value);
+          return [keyNode, valueNode];
+        });
+
+      return {
+        nodeName: SerializeableNodeName.Object,
+        metadata: {
+          typeName,
+          isSimple: true,
+          entryList: serializeableEntryList,
+          prototypeNameTuple: getPrototypeNameTuple(datum),
+        },
+      } satisfies SerializeableObjectNode as unknown as MappedSerializeableNode<TDatum>;
+    }
+    case CustomDatumTypeName.Function: {
+      const serializeableFunctionNameEntry: SimpleSerializeableObjectEntry = [
+        buildSerializeableNode('name'),
+        buildSerializeableNode(datum.name),
+      ];
+
+      return {
+        nodeName: SerializeableNodeName.Object,
+        metadata: {
+          typeName,
+          isSimple: true,
+          entryList: [serializeableFunctionNameEntry],
+        },
+      } satisfies SerializeableObjectNode as MappedSerializeableNode<TDatum>;
+    }
+    case CustomDatumTypeName.Map: {
+      const entryList = [...datum.entries()];
+
+      const isSimple = entryList.every(isSimpleObjectEntryKey);
+
+      if (isSimple) {
+        const serializeableEntryList =
+          entryList.map<SimpleSerializeableObjectEntry>(([key, value]) => {
+            const keyNode = buildSerializeableNode(key);
+            const valueNode = buildSerializeableNode(value);
+            return [keyNode, valueNode];
+          });
+
+        return {
+          nodeName: SerializeableNodeName.Object,
+          metadata: {
+            typeName,
+            isSimple,
+            entryList: serializeableEntryList,
+            prototypeNameTuple: getPrototypeNameTuple(datum),
+          },
+          // TODO: investigate this broken cast
+        } satisfies SerializeableObjectNode as unknown as MappedSerializeableNode<TDatum>;
+      }
+
+      const serializeableEntryList = buildSerializeableNode(entryList);
+
+      return {
+        nodeName: SerializeableNodeName.Object,
+        metadata: {
+          typeName,
+          isSimple,
+          entryList: serializeableEntryList,
+          prototypeNameTuple: getPrototypeNameTuple(datum),
+        },
+        // TODO: investigate this broken cast
+      } satisfies SerializeableObjectNode as unknown as MappedSerializeableNode<TDatum>;
+    }
+    case CustomDatumTypeName.RootObjectInstance: {
+      const entryList = getTypeScriptObjectEntryList(datum);
+
+      const serializeableEntryList =
+        entryList.map<SimpleSerializeableObjectEntry>(([key, value]) => {
+          const keyNode = buildSerializeableNode(key);
+          const valueNode = buildSerializeableNode(value);
+          return [keyNode, valueNode];
+        });
+
+      return {
+        nodeName: SerializeableNodeName.Object,
+        metadata: {
+          typeName,
+          isSimple: true,
+          entryList: serializeableEntryList,
+          prototypeNameTuple: getPrototypeNameTuple(datum),
+        },
+      } satisfies SerializeableObjectNode as unknown as MappedSerializeableNode<TDatum>;
+    }
+
+    // String
+    case CustomDatumTypeName.String: {
+      const isMultiline = datum.includes('\n');
+
+      if (isMultiline) {
+        return {
+          nodeName: SerializeableNodeName.String,
+          metadata: {
+            typeName,
+            isMultiline,
+            lineList: datum.split('\n'),
+          },
+        } satisfies SerializeableStringNode as MappedSerializeableNode<TDatum>;
+      }
+
+      return {
+        nodeName: SerializeableNodeName.String,
+        metadata: {
+          typeName,
+          isMultiline,
+          value: datum,
+        },
+      } satisfies SerializeableStringNode as MappedSerializeableNode<TDatum>;
+    }
+    case CustomDatumTypeName.Symbol: {
+      const referenceId = symbolReferenceMap.get(datum) ?? uuid.v4();
+      symbolReferenceMap.set(datum, referenceId);
+
+      return {
+        nodeName: SerializeableNodeName.String,
+        metadata: {
+          typeName,
+          description: datum.description ?? '',
+          referenceId,
+        },
+      } satisfies SerializeableStringNode as MappedSerializeableNode<TDatum>;
+    }
+  }
+};

--- a/packages/voictents-and-estinants-engine/src/utilities/typed-datum/serializer/getSerializeableNodeLineList.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/typed-datum/serializer/getSerializeableNodeLineList.ts
@@ -1,0 +1,195 @@
+import { CustomDatumTypeName } from '../customTypedDatum';
+import {
+  SerializeableNode,
+  SerializeableNodeName,
+  SimpleSerializeableObjectEntry,
+} from './serializeableNode';
+
+const isCommentLine = (line: string): boolean => /^ *#/.test(line);
+
+const indentLine = (line: string): string => `  ${line}`;
+
+type LineListMetadata = {
+  isOneLine: boolean;
+  firstLine: string;
+  middleLineList: string[];
+  lastLine: string;
+};
+
+// TODO: move this to a utility file and account for empty lists
+const getLineListMetadata = (lineList: string[]): LineListMetadata => {
+  const firstIndex = 0;
+  const lineCount = lineList.length;
+  const lastIndex = lineCount - 1;
+
+  let firstLine = '';
+  const middleLineList: string[] = [];
+  let lastLine = '';
+
+  lineList.forEach((line, index) => {
+    if (index === firstIndex) {
+      firstLine = line;
+    }
+
+    if (index === lastIndex) {
+      lastLine = line;
+    }
+
+    if (index > firstIndex && index < lastIndex) {
+      middleLineList.push(line);
+    }
+  });
+
+  return {
+    isOneLine: lineCount === 1,
+    firstLine,
+    middleLineList,
+    lastLine,
+  };
+};
+
+export const getSerializeableNodeLineList = (
+  node: SerializeableNode,
+): string[] => {
+  switch (node.nodeName) {
+    case SerializeableNodeName.Boolean: {
+      return [node.metadata.value.toString()];
+    }
+    case SerializeableNodeName.List: {
+      const lineList: string[] = [];
+
+      if (node.metadata.typeName === CustomDatumTypeName.Set) {
+        lineList.push('# Set');
+      }
+
+      node.metadata.valueTuple.forEach((subnode) => {
+        const sublist = getSerializeableNodeLineList(subnode);
+
+        const hasCommentLine = isCommentLine(sublist[0]);
+
+        const sublistMetadata = hasCommentLine
+          ? getLineListMetadata(sublist.slice(1))
+          : getLineListMetadata(sublist);
+
+        if (hasCommentLine) {
+          lineList.push(indentLine(sublist[0]));
+        }
+
+        lineList.push(`- ${sublistMetadata.firstLine}`);
+
+        if (!sublistMetadata.isOneLine) {
+          lineList.push(
+            ...[
+              ...sublistMetadata.middleLineList,
+              sublistMetadata.lastLine,
+            ].map(indentLine),
+          );
+        }
+      });
+
+      return lineList;
+    }
+    case SerializeableNodeName.Null: {
+      switch (node.metadata.typeName) {
+        case CustomDatumTypeName.Null:
+          return ['null'];
+        case CustomDatumTypeName.Undefined:
+          return ['~'];
+      }
+    }
+    // eslint-disable-next-line no-fallthrough
+    case SerializeableNodeName.Number: {
+      switch (node.metadata.typeName) {
+        case CustomDatumTypeName.BigInteger:
+          return ['# bigint', `${node.metadata.value}`];
+        case CustomDatumTypeName.Number:
+          return [`${node.metadata.value}`];
+      }
+    }
+    // eslint-disable-next-line no-fallthrough
+    case SerializeableNodeName.Object: {
+      const lineList: string[] = [];
+
+      if (node.metadata.typeName !== CustomDatumTypeName.Function) {
+        // All objects extend "Object", so trim the end for simplicity
+        const prototypeNameTuple = node.metadata.prototypeNameTuple.slice(
+          0,
+          -1,
+        );
+        const prototypeNameTupleText = prototypeNameTuple.join(',');
+
+        if (prototypeNameTuple.length > 0) {
+          lineList.push(`# ${prototypeNameTupleText}`);
+        }
+      }
+
+      if (node.metadata.isSimple) {
+        node.metadata.entryList.forEach(
+          ([key, value]: SimpleSerializeableObjectEntry) => {
+            const serializeableKeyLineList = getSerializeableNodeLineList(key);
+            const serializeableValueLineList =
+              getSerializeableNodeLineList(value);
+
+            const keyLineListMetadata = getLineListMetadata(
+              serializeableKeyLineList,
+            );
+            const valueLineListMetadata = getLineListMetadata(
+              serializeableValueLineList,
+            );
+
+            if (
+              keyLineListMetadata.isOneLine &&
+              valueLineListMetadata.isOneLine
+            ) {
+              lineList.push(
+                `${keyLineListMetadata.firstLine}: ${valueLineListMetadata.firstLine}`,
+              );
+            } else if (keyLineListMetadata.isOneLine) {
+              lineList.push(
+                `${keyLineListMetadata.firstLine}:`,
+                ...serializeableValueLineList.map(indentLine),
+              );
+            } else if (valueLineListMetadata.isOneLine) {
+              lineList.push(
+                keyLineListMetadata.firstLine,
+                ...keyLineListMetadata.middleLineList,
+                `${keyLineListMetadata.lastLine}: ${valueLineListMetadata.firstLine}`,
+              );
+            } else {
+              lineList.push(
+                keyLineListMetadata.firstLine,
+                ...keyLineListMetadata.middleLineList,
+                `${keyLineListMetadata.lastLine}:`,
+                ...serializeableValueLineList.map(indentLine),
+              );
+            }
+          },
+        );
+      } else {
+        const entryListLineList = getSerializeableNodeLineList(
+          node.metadata.entryList,
+        );
+
+        lineList.push(...entryListLineList);
+      }
+
+      return lineList;
+    }
+    // eslint-disable-next-line no-fallthrough
+    case SerializeableNodeName.String: {
+      switch (node.metadata.typeName) {
+        case CustomDatumTypeName.String:
+          if (node.metadata.isMultiline) {
+            return ['"---', ...node.metadata.lineList, '---"'];
+          }
+
+          return [`"${node.metadata.value}"`];
+        case CustomDatumTypeName.Symbol:
+          return [
+            `# symbol: "${node.metadata.description}"`,
+            `${node.metadata.referenceId}`,
+          ];
+      }
+    }
+  }
+};

--- a/packages/voictents-and-estinants-engine/src/utilities/typed-datum/serializer/serialize.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/typed-datum/serializer/serialize.ts
@@ -1,0 +1,9 @@
+import { buildSerializeableNode } from './buildSerializeableNode';
+import { getSerializeableNodeLineList } from './getSerializeableNodeLineList';
+
+export const serialize = (datum: unknown): string => {
+  const rootNode = buildSerializeableNode(datum);
+  const rootNodeLineList = getSerializeableNodeLineList(rootNode);
+  const text = rootNodeLineList.join('\n');
+  return text;
+};

--- a/packages/voictents-and-estinants-engine/src/utilities/typed-datum/serializer/serializeableNode.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/typed-datum/serializer/serializeableNode.ts
@@ -1,0 +1,180 @@
+import { Tuple } from '../../semantic-types/tuple';
+import { CustomDatumTypeName, getCustomTypedDatum } from '../customTypedDatum';
+import { TypeScriptObjectInstance } from '../type-script/object';
+
+export enum SerializeableNodeName {
+  Boolean = 'Boolean',
+  List = 'List',
+  Null = 'Null',
+  Number = 'Number',
+  Object = 'Object',
+  String = 'String',
+}
+
+type BaseSerializeableNode<
+  TNodeName extends SerializeableNodeName,
+  TMetadata extends TypeScriptObjectInstance,
+> = {
+  nodeName: TNodeName;
+  metadata: TMetadata;
+};
+
+// Boolean
+export type SerializeableBooleanNode = BaseSerializeableNode<
+  SerializeableNodeName.Boolean,
+  { value: boolean }
+>;
+
+// List
+export type SerializeableListNode = BaseSerializeableNode<
+  SerializeableNodeName.List,
+  {
+    typeName: CustomDatumTypeName.Array | CustomDatumTypeName.Set;
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    valueTuple: Tuple<SerializeableNode>;
+  }
+>;
+
+// Null
+export type SerializeableNullDatum = {
+  typeName: CustomDatumTypeName.Null;
+  value: null;
+};
+
+export type SerializeableUndefinedDatum = {
+  typeName: CustomDatumTypeName.Undefined;
+  value: undefined;
+};
+
+export type SerializeableNullNodeDatum =
+  | SerializeableNullDatum
+  | SerializeableUndefinedDatum;
+
+export type SerializeableNullNode = BaseSerializeableNode<
+  SerializeableNodeName.Null,
+  SerializeableNullNodeDatum
+>;
+
+// Number
+export type SerializeablBigIntegerDatum = {
+  typeName: CustomDatumTypeName.BigInteger;
+  value: bigint;
+};
+
+export type SerializeableNumberDatum = {
+  typeName: CustomDatumTypeName.Number;
+  value: number;
+};
+
+export type SerializeableNumberNodeDatum =
+  | SerializeablBigIntegerDatum
+  | SerializeableNumberDatum;
+
+export type SerializeableNumberNode = BaseSerializeableNode<
+  SerializeableNodeName.Number,
+  SerializeableNumberNodeDatum
+>;
+
+// String
+export type SerializeableMultilineStringDatum = {
+  typeName: CustomDatumTypeName.String;
+  lineList: string[];
+  isMultiline: true;
+};
+
+export type SerializeableSingeLineStringMetadata<
+  TValue extends string = string,
+> = {
+  typeName: CustomDatumTypeName.String;
+  value: TValue;
+  isMultiline: false;
+};
+
+export type SerializeableSymbolMetadata = {
+  typeName: CustomDatumTypeName.Symbol;
+  description: string;
+  referenceId: string;
+};
+
+export type SerializeableStringNodeMetadata =
+  | SerializeableMultilineStringDatum
+  | SerializeableSingeLineStringMetadata
+  | SerializeableSymbolMetadata;
+
+export type SerializeableStringNode = BaseSerializeableNode<
+  SerializeableNodeName.String,
+  SerializeableStringNodeMetadata
+>;
+
+// Object
+export type SimpleSerializeableObjectEntry = [
+  SerializeableBooleanNode | SerializeableNumberNode | SerializeableStringNode,
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  SerializeableNode,
+];
+
+// TODO: make a single source of truth for the predicate type, the list type in the comparison and "SimpleSerializeableObjectEntry"
+export const isSimpleObjectEntryKey = (
+  entry: [unknown, unknown],
+): entry is [boolean | bigint | number | string | symbol, unknown] =>
+  [
+    CustomDatumTypeName.Boolean,
+    CustomDatumTypeName.BigInteger,
+    CustomDatumTypeName.Number,
+    CustomDatumTypeName.String,
+    CustomDatumTypeName.Symbol,
+  ].includes(getCustomTypedDatum(entry[0]).typeName);
+
+export type SerializeableCustomObjectInstanceMetadata = {
+  typeName: CustomDatumTypeName.CustomObjectInstance;
+  isSimple: true;
+  entryList: SimpleSerializeableObjectEntry[];
+  prototypeNameTuple: Tuple<string>;
+};
+
+export type SerializeableFunctionMetadata = {
+  typeName: CustomDatumTypeName.Function;
+  isSimple: true;
+  entryList: SimpleSerializeableObjectEntry[];
+};
+
+export type SerializeableSimpleMapMetadata = {
+  typeName: CustomDatumTypeName.Map;
+  isSimple: true;
+  entryList: SimpleSerializeableObjectEntry[];
+  prototypeNameTuple: Tuple<string>;
+};
+
+export type SerializeableComplexMapMetadata = {
+  typeName: CustomDatumTypeName.Map;
+  isSimple: false;
+  entryList: SerializeableListNode;
+  prototypeNameTuple: Tuple<string>;
+};
+
+export type SerializeableRootObjectInstanceMetadata = {
+  typeName: CustomDatumTypeName.RootObjectInstance;
+  isSimple: true;
+  entryList: SimpleSerializeableObjectEntry[];
+  prototypeNameTuple: Tuple<string>;
+};
+
+export type SerializeableObjectNodeMetadata =
+  | SerializeableCustomObjectInstanceMetadata
+  | SerializeableFunctionMetadata
+  | SerializeableSimpleMapMetadata
+  | SerializeableComplexMapMetadata
+  | SerializeableRootObjectInstanceMetadata;
+
+export type SerializeableObjectNode = BaseSerializeableNode<
+  SerializeableNodeName.Object,
+  SerializeableObjectNodeMetadata
+>;
+
+export type SerializeableNode =
+  | SerializeableBooleanNode
+  | SerializeableListNode
+  | SerializeableNullNode
+  | SerializeableNumberNode
+  | SerializeableObjectNode
+  | SerializeableStringNode;

--- a/packages/voictents-and-estinants-engine/src/utilities/typed-datum/type-script/function.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/typed-datum/type-script/function.ts
@@ -1,0 +1,3 @@
+import { Tuple } from '../../semantic-types/tuple';
+
+export type TypeScriptFunction = (...argumentTuple: Tuple<unknown>) => unknown;

--- a/packages/voictents-and-estinants-engine/src/utilities/typed-datum/type-script/object.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/typed-datum/type-script/object.ts
@@ -1,0 +1,44 @@
+export type TypeScriptArray = unknown[];
+
+export type TypeScriptSet = Set<unknown>;
+
+export type TypeScriptMapEntry = [unknown, unknown];
+
+export type TypeScriptMapEntryList = TypeScriptMapEntry[];
+
+export type TypeScriptMap = Map<unknown, unknown>;
+
+export type TypeScriptObjectInstanceKey = string | number | symbol;
+
+export type TypeScriptObjectInstance = Record<
+  TypeScriptObjectInstanceKey,
+  unknown
+>;
+
+export type TypeScriptObjectInstanceEntry = [
+  TypeScriptObjectInstanceKey,
+  unknown,
+];
+
+export type TypeScriptObjectInstanceEntryList = TypeScriptObjectInstanceEntry[];
+
+export type TypeScriptObject =
+  | null
+  | TypeScriptArray
+  | TypeScriptSet
+  | TypeScriptMap
+  | TypeScriptObjectInstance;
+
+export const getTypeScriptObjectEntryList = (
+  datum: TypeScriptObjectInstance,
+): TypeScriptObjectInstanceEntryList => {
+  const simpleEntryList = Reflect.ownKeys(
+    datum,
+  ).map<TypeScriptObjectInstanceEntry>((key) => {
+    const value = datum[key];
+
+    return [key, value];
+  });
+
+  return simpleEntryList;
+};

--- a/packages/voictents-and-estinants-engine/src/utilities/typed-datum/type-script/primitive.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/typed-datum/type-script/primitive.ts
@@ -1,0 +1,11 @@
+export type TypeScriptPrimitiveOptionTuple = readonly [
+  bigint,
+  boolean,
+  null,
+  number,
+  string,
+  symbol,
+  undefined,
+];
+
+export type TypeScriptPrimitive = TypeScriptPrimitiveOptionTuple[number];

--- a/packages/voictents-and-estinants-engine/src/utilities/typed-datum/type-script/typeScriptTypedDatum.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/typed-datum/type-script/typeScriptTypedDatum.ts
@@ -1,0 +1,86 @@
+import { TypeScriptFunction } from './function';
+import { TypeScriptObject } from './object';
+
+export enum TypeScriptDatumTypeName {
+  bigint = 'bigint',
+  boolean = 'boolean',
+  function = 'function',
+  number = 'number',
+  object = 'object',
+  string = 'string',
+  symbol = 'symbol',
+  undefined = 'undefined',
+}
+
+type BaseTypeScriptTypedDatum<
+  TTypeScriptDatumTypeName extends TypeScriptDatumTypeName,
+  TDatum,
+> = {
+  typeName: TTypeScriptDatumTypeName;
+  datum: TDatum;
+};
+
+export type TypeScriptTypedBigint = BaseTypeScriptTypedDatum<
+  TypeScriptDatumTypeName.bigint,
+  bigint
+>;
+
+export type TypeScriptTypedBoolean = BaseTypeScriptTypedDatum<
+  TypeScriptDatumTypeName.boolean,
+  boolean
+>;
+
+export type TypeScriptTypedFunction = BaseTypeScriptTypedDatum<
+  TypeScriptDatumTypeName.function,
+  TypeScriptFunction
+>;
+
+export type TypeScriptTypedNumber = BaseTypeScriptTypedDatum<
+  TypeScriptDatumTypeName.number,
+  number
+>;
+
+export type TypeScriptTypedObject = BaseTypeScriptTypedDatum<
+  TypeScriptDatumTypeName.object,
+  TypeScriptObject
+>;
+
+export type TypeScriptTypedString = BaseTypeScriptTypedDatum<
+  TypeScriptDatumTypeName.string,
+  string
+>;
+
+export type TypeScriptTypedSymbol = BaseTypeScriptTypedDatum<
+  TypeScriptDatumTypeName.symbol,
+  symbol
+>;
+
+export type TypeScriptTypedUndefined = BaseTypeScriptTypedDatum<
+  TypeScriptDatumTypeName.undefined,
+  undefined
+>;
+
+export type TypeScriptTypedDatumOptionTuple = readonly [
+  TypeScriptTypedBigint,
+  TypeScriptTypedBoolean,
+  TypeScriptTypedFunction,
+  TypeScriptTypedNumber,
+  TypeScriptTypedObject,
+  TypeScriptTypedString,
+  TypeScriptTypedSymbol,
+  TypeScriptTypedUndefined,
+];
+
+export type TypeScriptTypedDatum = TypeScriptTypedDatumOptionTuple[number];
+
+export const getTypeScriptTypedDatum = (
+  datum: unknown,
+): TypeScriptTypedDatum => {
+  const nativeTypeName = typeof datum;
+  const enumeratedTypeName = nativeTypeName as TypeScriptDatumTypeName;
+
+  return {
+    typeName: enumeratedTypeName,
+    datum,
+  } as TypeScriptTypedDatum;
+};


### PR DESCRIPTION
- created functions to abstract the `typeof` operator as a type guard for both TypeScript types and custom datum types
- drove a new serialization function off of the new datum types
    - it renders to YAML for human readability
- added programmable units for rendering interactive directed graphs
- added a program to render WIP graph of file relationships