### PR TITLE
Better dreanor logic

### DIFF
--- a/packages/voictents-and-estinants-engine/src/core/ajorken.ts
+++ b/packages/voictents-and-estinants-engine/src/core/ajorken.ts
@@ -1,4 +1,8 @@
 import { Zorn } from '../utilities/semantic-types/zorn';
 import { CologySet } from './cology';
 
+/**
+ * This lets the engine find any Cology that might be ready to be processed whenever
+ * an element of that cology changes. Right inputs can be part of multiple cologies for various left inputs.
+ */
 export class Ajorken extends Map<Zorn, CologySet> {}

--- a/packages/voictents-and-estinants-engine/src/core/cology.ts
+++ b/packages/voictents-and-estinants-engine/src/core/cology.ts
@@ -1,12 +1,37 @@
-import { Hubblepup } from './hubblepup';
+import { Zorn } from '../utilities/semantic-types/zorn';
+import { Gepp } from './gepp';
 import { Mabz } from './mabz';
+import { Quirm } from './quirm';
 
 /**
- * A left Hubblepup and a respective Mabz
+ * A left Hubblepup and a respective Mabz.
+ * This helps the engine find all of the right Hubblepups associated with the left Hubblepup
  */
 export type Cology = {
-  leftHubblepup: Hubblepup;
+  leftQuirm: Quirm;
   mabz: Mabz;
+};
+
+export type CologyEntry = [Gepp, Zorn];
+
+export const getCologyEntryList = (cology: Cology): CologyEntry[] => {
+  const leftEntry: CologyEntry = [
+    cology.leftQuirm.gepp,
+    cology.leftQuirm.hubblepup,
+  ];
+
+  const nestedRightEntryList = [...cology.mabz.entries()];
+
+  const flattenedRightEntryList = nestedRightEntryList.flatMap<CologyEntry>(
+    ([gepp, zornTuple]) => {
+      return zornTuple.map<CologyEntry>((zorn) => {
+        return [gepp, zorn];
+      });
+    },
+  );
+
+  const entryList = [leftEntry, ...flattenedRightEntryList];
+  return entryList;
 };
 
 export class CologySet extends Set<Cology> {}

--- a/packages/voictents-and-estinants-engine/src/core/dreanor.ts
+++ b/packages/voictents-and-estinants-engine/src/core/dreanor.ts
@@ -1,34 +1,43 @@
-import { Merge } from '../utilities/merge';
-import { MergeTuple } from '../utilities/mergeTuple';
 import { Croarder } from './croarder';
 import { Framation } from './framation';
 import { Gepp } from './gepp';
-import { Lanbe } from './lanbe';
+import { Lanbe, VoictentItemLanbe, VoictentLanbe } from './lanbe';
 import { Prected } from './prected';
 
-type Dreanor = {
-  gepp: Gepp;
-  lanbe: Lanbe;
-};
+export enum DreanorTypeName {
+  LeftDreanor = 'LeftDreanor',
+  RightVoictentDreanor = 'RightVoictentDreanor',
+  RightVoictentItemDreanor = 'RightVoictentItemDreanor',
+}
 
 /**
  * Contains the information needed to identify a Voictent, and to stream its Hubblepups
  */
-export type LeftDreanor = Merge<{ isLeft: true }, Dreanor>;
+export type LeftDreanor = {
+  typeName: DreanorTypeName.LeftDreanor;
+  gepp: Gepp;
+  lanbe: Lanbe;
+};
+
+export type RightVoictentDreanor = {
+  typeName: DreanorTypeName.RightVoictentDreanor;
+  gepp: Gepp;
+  lanbe: VoictentLanbe;
+  isReady: boolean;
+};
+
+export type RightVoictentItemDreanor = {
+  typeName: DreanorTypeName.RightVoictentItemDreanor;
+  gepp: Gepp;
+  lanbe: VoictentItemLanbe;
+  framate: Framation;
+  croard: Croarder;
+  prected: Prected;
+};
 
 /**
  * Contains the information needed to identify a Voictent, and to stream and cache its Hubblepups
  */
-export type RightDreanor = MergeTuple<
-  [
-    { isLeft: false },
-    Dreanor,
-    {
-      framate: Framation;
-      croard: Croarder;
-      prected: Prected;
-    },
-  ]
->;
+export type RightDreanor = RightVoictentDreanor | RightVoictentItemDreanor;
 
 export type RightDreanorTuple = readonly RightDreanor[];

--- a/packages/voictents-and-estinants-engine/src/core/lanbe.ts
+++ b/packages/voictents-and-estinants-engine/src/core/lanbe.ts
@@ -1,19 +1,34 @@
 import { Hubblepup, HubblepupTuple } from './hubblepup';
 
-type BaseLanbe<TOutput extends Hubblepup | HubblepupTuple> = {
+export enum LanbeTypeName {
+  VoictentLanbe = 'VoictentLanbe',
+  VoictentItemLanbe = 'VoictentItemLanbe',
+}
+
+type BaseLanbe<
+  TTypeName extends LanbeTypeName,
+  TOutput extends Hubblepup | HubblepupTuple,
+> = {
+  typeName: TTypeName;
   debugName: string;
   hasNext: () => boolean;
   advance: () => void;
   dereference: () => TOutput | null;
 };
 
-export type VoictentItemLanbe = BaseLanbe<Hubblepup>;
+export type VoictentLanbe = BaseLanbe<
+  LanbeTypeName.VoictentLanbe,
+  HubblepupTuple
+>;
 
-export type VoictentLanbe = BaseLanbe<HubblepupTuple>;
+export type VoictentItemLanbe = BaseLanbe<
+  LanbeTypeName.VoictentItemLanbe,
+  Hubblepup
+>;
 
 /**
  * A data structure that facilitates streaming Hubblepups from a voictent or the entire tuple from the Voictent at once.
  * It encapsulates stream operations on a Voictent.
  * This allows an external entity to read a Voictent without needing a direct reference to it.
  */
-export type Lanbe = VoictentItemLanbe | VoictentLanbe;
+export type Lanbe = VoictentLanbe | VoictentItemLanbe;

--- a/packages/voictents-and-estinants-engine/src/core/mabz.ts
+++ b/packages/voictents-and-estinants-engine/src/core/mabz.ts
@@ -2,6 +2,9 @@ import { ZornTuple } from '../utilities/semantic-types/zorn';
 import { Gepp } from './gepp';
 
 /**
- * A cache of right Zorn tuples by their respective Gepps
+ * A cache of right Zorn tuples by their respective Gepps.
+ * This helps the engine find the identifiers for a specific right collection.
  */
 export class Mabz extends Map<Gepp, ZornTuple> {}
+
+export type MabzEntry = [Gepp, ZornTuple];

--- a/packages/voictents-and-estinants-engine/src/core/prected.ts
+++ b/packages/voictents-and-estinants-engine/src/core/prected.ts
@@ -1,5 +1,8 @@
 import { Zorn } from '../utilities/semantic-types/zorn';
 import { Hubblepup } from './hubblepup';
 
-/** A cache of Hubblepups by Zorn */
+/**
+ * A cache of Hubblepups by Zorn
+ * This contains the information that the engine needs to know if a Cology has all of the expected inputs
+ */
 export class Prected extends Map<Zorn, Hubblepup> {}

--- a/packages/voictents-and-estinants-engine/src/core/procody.ts
+++ b/packages/voictents-and-estinants-engine/src/core/procody.ts
@@ -2,6 +2,7 @@ import { Gepp } from './gepp';
 import { Ajorken } from './ajorken';
 
 /**
- * Cologies cached by their left Hubblepups
+ * Sets of cologies by the identifiers of everything in each cology, by the collection the identifiable
+ * elements are in.
  */
 export class Procody extends Map<Gepp, Ajorken> {}

--- a/packages/voictents-and-estinants-engine/src/core/voictent.ts
+++ b/packages/voictents-and-estinants-engine/src/core/voictent.ts
@@ -1,4 +1,4 @@
-import { VoictentItemLanbe, VoictentLanbe } from './lanbe';
+import { LanbeTypeName, VoictentItemLanbe, VoictentLanbe } from './lanbe';
 import { Hubblepup } from './hubblepup';
 
 class MissingLanbeError extends Error {
@@ -50,6 +50,7 @@ export class Voictent {
 
   createVoictentLanbe(debugName: string): VoictentLanbe {
     const lanbe: VoictentLanbe = {
+      typeName: LanbeTypeName.VoictentLanbe,
       debugName,
       hasNext: () => {
         return this.didStopAccumulating;
@@ -65,6 +66,7 @@ export class Voictent {
 
   createVoictentItemLanbe(debugName: string): VoictentItemLanbe {
     const lanbe: VoictentItemLanbe = {
+      typeName: LanbeTypeName.VoictentItemLanbe,
       debugName,
       hasNext: () => {
         return this.hasNext(lanbe);

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file-relationships/typeScriptFileRelationshipListToDirectedGraph.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file-relationships/typeScriptFileRelationshipListToDirectedGraph.ts
@@ -59,7 +59,7 @@ export const typeScriptFileRelationshipListToDirectedGraph = buildCortmum<
     },
   ],
   outputGeppTuple: [DIRECTED_GRAPH_GEPP],
-  pinbe: (leftInput, [rightInput1], [rightInput2]) => {
+  pinbe: (leftInput, rightInput1, rightInput2) => {
     // TODO: update the type adapter layer to provide type safety for "isWibiz"
     const typedLeftInput =
       leftInput as unknown as TypeScriptFileRelationshipListOdeshin[];

--- a/packages/voictents-and-estinants-engine/src/custom/programs/testGraphRender.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/testGraphRender.ts
@@ -1,5 +1,5 @@
 import { digikikify } from '../../type-script-adapter/digikikify';
-import { buildBasicQuirmDebugger } from '../debugger/quirmDebugger';
+import { buildQuirmDebugger } from '../debugger/quirmDebugger';
 import { fileMattomer } from '../programmable-units/file/fileMattomer';
 import { fileMentursection } from '../programmable-units/file/fileMentursection';
 import { FILE_MENTURSECTION_CONFIGURATION_GEPP } from '../programmable-units/file/fileMentursectionConfiguration';
@@ -7,10 +7,6 @@ import { DIRECTED_GRAPH_GEPP } from '../programmable-units/graph-visualization/d
 import { directedGraphToGraphvizCode } from '../programmable-units/graph-visualization/directedGraphToGraphvizCode';
 import { graphvizCodeToSvgDocument } from '../programmable-units/graph-visualization/graphvizCodeToSvgDocument';
 import { svgDocumentToInteractivePage } from '../programmable-units/graph-visualization/svgDocumentToInteractivePage';
-import { typeScriptFileRelationshipWattlection } from '../programmable-units/type-script-file-relationships/typeScriptFileRelationshipList';
-import { parsedTypeScriptFileMentursection } from '../programmable-units/type-script-file/parsedTypeScriptFile';
-import { typeScriptFileConfigurationOnama } from '../programmable-units/type-script-file/typeScriptFileConfiguration';
-import { typeScriptFileImportListOnama } from '../programmable-units/type-script-file/typeScriptFileImportList';
 
 digikikify({
   initialVoictentsByGepp: {
@@ -25,46 +21,69 @@ digikikify({
       {
         zorn: 'my-graph',
         grition: {
-          id: 'my graph',
-          label: 'my graph',
+          isRoot: true,
+          attributeByKey: {
+            id: 'my graph',
+            label: 'my graph',
+          },
           nodeList: [
             {
-              id: 'a',
-              label: 'node a',
+              attributeByKey: {
+                id: 'a',
+                label: 'node a',
+              },
             },
             {
-              id: 'b',
-              label: 'node b',
+              attributeByKey: {
+                id: 'b',
+                label: 'node b',
+              },
             },
           ],
           edgeList: [
             {
               tailId: 'a',
               headId: 'b',
+              attributeByKey: {
+                id: 'a:b',
+              },
             },
             {
               tailId: 'a',
               headId: 'c',
+              attributeByKey: {
+                id: 'a:c',
+              },
             },
           ],
           subgraphList: [
             {
-              id: 'my subgraph',
-              label: 'my subgraph',
+              isRoot: false,
+              attributeByKey: {
+                id: 'cluster_my_subgraph',
+                label: 'my subgraph',
+              },
               nodeList: [
                 {
-                  id: 'c',
-                  label: 'node c',
+                  attributeByKey: {
+                    id: 'c',
+                    label: 'node c',
+                  },
                 },
                 {
-                  id: 'd',
-                  label: 'node d',
+                  attributeByKey: {
+                    id: 'd',
+                    label: 'node d',
+                  },
                 },
               ],
               edgeList: [
                 {
                   tailId: 'c',
                   headId: 'd',
+                  attributeByKey: {
+                    id: 'c:d',
+                  },
                 },
               ],
               subgraphList: [],
@@ -78,15 +97,9 @@ digikikify({
     fileMentursection,
     fileMattomer,
 
-    typeScriptFileConfigurationOnama,
-    parsedTypeScriptFileMentursection,
-    typeScriptFileImportListOnama,
-
-    typeScriptFileRelationshipWattlection,
-
     directedGraphToGraphvizCode,
     graphvizCodeToSvgDocument,
     svgDocumentToInteractivePage,
   ],
-  quirmDebugger: buildBasicQuirmDebugger('testGraphRender'),
+  quirmDebugger: buildQuirmDebugger('testGraphRender'),
 });


### PR DESCRIPTION
Now when an estinant streams a collection as a whole it will expose a reference to the collection (technically a copy of the collection) instead of putting the collection in an array. 

```ts
// before
const myTransform = (leftInput, [rightInputCollection]) => void;


// after
const myTransform = (leftInput, rightInputCollection) => void;

```