### PR TITLE
Estinant builder

### DIFF
--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/additionalOutputHubblepupAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/additionalOutputHubblepupAppreffingeBuilder.ts
@@ -1,0 +1,117 @@
+import { Simplify, UnionToIntersection } from 'type-fest';
+import {
+  AppendOutputVickenToTuple,
+  LeftVicken,
+  OutputHubblepupVicken,
+  OutputVickenTuple,
+  RightVickenTuple,
+} from '../../../type-script-adapter/vicken';
+import { StralineTuple } from '../../../utilities/semantic-types/straline';
+import { Voictent } from '../voictent';
+import { InputOutputContext } from './estinantBuilderContext';
+import {
+  buildPinbetunfBuilder,
+  PinbetunfBuilderParent,
+} from './pinbetunfBuilder';
+import {
+  buildOutputHubblepupNormalizer,
+  extendInputOutputContext,
+} from './tropoignantInputOutputModifier';
+
+type OutputAppreffinge<TOutputVoictent extends Voictent> = {
+  gepp: TOutputVoictent['gepp'];
+};
+
+type OutputVoictentTuple<TOutputVoictent> = [TOutputVoictent];
+
+type OutputVicken<TOutputVoictent extends Voictent> =
+  OutputHubblepupVicken<TOutputVoictent>;
+
+type PinbetunfOutput2<TOutputVickenTuple extends OutputVickenTuple> = {
+  [Index in keyof TOutputVickenTuple]: {
+    [Key in TOutputVickenTuple[Index]['voictent']['gepp']]: TOutputVickenTuple[Index]['pinbeOutput'];
+  };
+}[number];
+
+type PinbetunfOutput1<
+  TOutputVickenTuple extends OutputVickenTuple,
+  TOutputVoictent extends Voictent,
+> = Simplify<
+  UnionToIntersection<
+    PinbetunfOutput2<
+      AppendOutputVickenToTuple<
+        TOutputVickenTuple,
+        OutputVicken<TOutputVoictent>
+      >
+    >
+  >
+>;
+
+export type AdditionalOutputHubblepupAppreffingeBuilder<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TOutputVickenTuple extends OutputVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+> = <TOutputVoictent extends Voictent>(
+  outputAppreffinge: OutputAppreffinge<TOutputVoictent>,
+) => PinbetunfBuilderParent<
+  TLeftVicken,
+  TRightVickenTuple,
+  OutputVoictentTuple<TOutputVoictent>,
+  TPinbetunfInputTuple,
+  PinbetunfOutput1<TOutputVickenTuple, TOutputVoictent>
+>;
+
+export const buildAdditionalOutputHubblepupAppreffingeBuilder = <
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TOutputVickenTuple extends OutputVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+>(
+  inputOutputContext: InputOutputContext,
+): AdditionalOutputHubblepupAppreffingeBuilder<
+  TLeftVicken,
+  TRightVickenTuple,
+  TOutputVickenTuple,
+  TPinbetunfInputTuple
+> => {
+  const buildAdditionalOutputVoictentAppreffinge: AdditionalOutputHubblepupAppreffingeBuilder<
+    TLeftVicken,
+    TRightVickenTuple,
+    TOutputVickenTuple,
+    TPinbetunfInputTuple
+  > = <TOutputVoictent extends Voictent>(
+    outputAppreffinge: OutputAppreffinge<TOutputVoictent>,
+  ) => {
+    const nextContext = extendInputOutputContext(
+      inputOutputContext,
+      buildOutputHubblepupNormalizer(outputAppreffinge.gepp),
+    );
+
+    return {
+      onPinbe: buildPinbetunfBuilder<
+        TLeftVicken,
+        TRightVickenTuple,
+        OutputVoictentTuple<TOutputVoictent>,
+        TPinbetunfInputTuple,
+        PinbetunfOutput1<TOutputVickenTuple, TOutputVoictent>
+      >(nextContext),
+    };
+  };
+
+  return buildAdditionalOutputVoictentAppreffinge;
+};
+
+export type AdditionalOutputHubblepupAppreffingeBuilderParent<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TOutputVickenTuple extends OutputVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+> = {
+  toHubblepup: AdditionalOutputHubblepupAppreffingeBuilder<
+    TLeftVicken,
+    TRightVickenTuple,
+    TOutputVickenTuple,
+    TPinbetunfInputTuple
+  >;
+};

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/additionalOutputHubblepupTupleAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/additionalOutputHubblepupTupleAppreffingeBuilder.ts
@@ -1,0 +1,133 @@
+import { UnionToIntersection, Simplify } from 'type-fest';
+import {
+  AppendOutputVickenToTuple,
+  LeftVicken,
+  OutputVickenTuple,
+  OutputVoictentVicken,
+  RightVickenTuple,
+} from '../../../type-script-adapter/vicken';
+import { StralineTuple } from '../../../utilities/semantic-types/straline';
+import { Voictent } from '../voictent';
+import { InputOutputContext } from './estinantBuilderContext';
+import {
+  buildPinbetunfBuilder,
+  PinbetunfBuilderParent,
+} from './pinbetunfBuilder';
+import {
+  buildOutputHubblepupTupleNormalizer,
+  extendInputOutputContext,
+} from './tropoignantInputOutputModifier';
+
+type OutputAppreffinge<TOutputVoictent extends Voictent> = {
+  gepp: TOutputVoictent['gepp'];
+};
+
+type OutputVoictentTuple<TOutputVoictent extends Voictent> = [TOutputVoictent];
+
+type OutputVicken<TOutputVoictent extends Voictent> =
+  OutputVoictentVicken<TOutputVoictent>;
+
+type PinbetunfOutput2<TOutputVickenTuple extends OutputVickenTuple> = {
+  [Index in keyof TOutputVickenTuple]: {
+    [Key in TOutputVickenTuple[Index]['voictent']['gepp']]: TOutputVickenTuple[Index]['pinbeOutput'];
+  };
+}[number];
+
+type PinbetunfOutput1<
+  TOutputVickenTuple extends OutputVickenTuple,
+  TOutputVoictent extends Voictent,
+> = Simplify<
+  UnionToIntersection<
+    PinbetunfOutput2<
+      AppendOutputVickenToTuple<
+        TOutputVickenTuple,
+        OutputVicken<TOutputVoictent>
+      >
+    >
+  >
+>;
+
+export type AdditionalOutputHubblepupTupleAppreffingeBuilder<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TOutputVickenTuple extends OutputVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+> = <TOutputVoictent extends Voictent>(
+  outputAppreffinge: OutputAppreffinge<TOutputVoictent>,
+) => AdditionalOutputHubblepupTupleAppreffingeBuilderParent<
+  TLeftVicken,
+  TRightVickenTuple,
+  AppendOutputVickenToTuple<TOutputVickenTuple, OutputVicken<TOutputVoictent>>,
+  TPinbetunfInputTuple
+> &
+  PinbetunfBuilderParent<
+    TLeftVicken,
+    TRightVickenTuple,
+    OutputVoictentTuple<TOutputVoictent>,
+    TPinbetunfInputTuple,
+    PinbetunfOutput1<TOutputVickenTuple, TOutputVoictent>
+  >;
+
+export const buildAdditionalOutputHubblepupTupleAppreffingeBuilder = <
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TOutputVickenTuple extends OutputVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+>(
+  inputOutputContext: InputOutputContext,
+): AdditionalOutputHubblepupTupleAppreffingeBuilder<
+  TLeftVicken,
+  TRightVickenTuple,
+  TOutputVickenTuple,
+  TPinbetunfInputTuple
+> => {
+  const buildAdditionalOutputHubblepupTupleAppreffinge: AdditionalOutputHubblepupTupleAppreffingeBuilder<
+    TLeftVicken,
+    TRightVickenTuple,
+    TOutputVickenTuple,
+    TPinbetunfInputTuple
+  > = <TOutputVoictent extends Voictent>(
+    outputAppreffinge: OutputAppreffinge<TOutputVoictent>,
+  ) => {
+    const nextContext = extendInputOutputContext(
+      inputOutputContext,
+      buildOutputHubblepupTupleNormalizer(outputAppreffinge.gepp),
+    );
+
+    return {
+      andToHubblepupTuple:
+        buildAdditionalOutputHubblepupTupleAppreffingeBuilder<
+          TLeftVicken,
+          TRightVickenTuple,
+          AppendOutputVickenToTuple<
+            TOutputVickenTuple,
+            OutputVicken<TOutputVoictent>
+          >,
+          TPinbetunfInputTuple
+        >(nextContext),
+      onPinbe: buildPinbetunfBuilder<
+        TLeftVicken,
+        TRightVickenTuple,
+        OutputVoictentTuple<TOutputVoictent>,
+        TPinbetunfInputTuple,
+        PinbetunfOutput1<TOutputVickenTuple, TOutputVoictent>
+      >(nextContext),
+    };
+  };
+
+  return buildAdditionalOutputHubblepupTupleAppreffinge;
+};
+
+export type AdditionalOutputHubblepupTupleAppreffingeBuilderParent<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TOutputVickenTuple extends OutputVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+> = {
+  andToHubblepupTuple: AdditionalOutputHubblepupTupleAppreffingeBuilder<
+    TLeftVicken,
+    TRightVickenTuple,
+    TOutputVickenTuple,
+    TPinbetunfInputTuple
+  >;
+};

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/estinantAssembler.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/estinantAssembler.ts
@@ -1,0 +1,107 @@
+import { Estinant as CoreEstinant } from '../../../core/estinant';
+import { Estinant2 } from '../../../type-script-adapter/estinant/estinant';
+import { QuirmList } from '../../../type-script-adapter/quirm';
+import {
+  LeftVicken,
+  RightVickenTuple,
+} from '../../../type-script-adapter/vicken';
+import { VoictentTuple } from '../../../type-script-adapter/voictent';
+import { AssemblerContext } from './estinantBuilderContext';
+
+export type EstinantAssembler<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TOutputVoictentTuple extends VoictentTuple,
+> = () => Estinant2<TLeftVicken, TRightVickenTuple, TOutputVoictentTuple>;
+
+export const buildEstinantAssembler = <
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TOutputVoictentTuple extends VoictentTuple,
+>(
+  assemblerContext: AssemblerContext,
+): EstinantAssembler<TLeftVicken, TRightVickenTuple, TOutputVoictentTuple> => {
+  const assembleEstinant: EstinantAssembler<
+    TLeftVicken,
+    TRightVickenTuple,
+    TOutputVoictentTuple
+  > = () => {
+    const {
+      inputContext: { leftInputContext, rightInputContextTuple },
+      outputContext,
+    } = assemblerContext;
+
+    const estinant = {
+      leftAppreffinge: {
+        gepp: leftInputContext.gepp,
+        isWibiz: leftInputContext.isWibiz,
+      },
+      rightAppreffingeTuple: rightInputContextTuple.map((rightInputContext) => {
+        if (rightInputContext.isWibiz) {
+          return {
+            gepp: rightInputContext.gepp,
+            isWibiz: rightInputContext.isWibiz,
+            framate: () => [''],
+            croard: () => '',
+          };
+        }
+
+        return {
+          gepp: rightInputContext.gepp,
+          isWibiz: rightInputContext.isWibiz,
+          framate: rightInputContext.framate,
+          croard: rightInputContext.croard,
+        };
+      }),
+      tropoig: (leftInput, ...rightInputTuple): QuirmList => {
+        /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+        const modifiedLeftInput =
+          leftInputContext.modifyTropoignantInput(leftInput);
+        const modifiedRightInputTuple = rightInputContextTuple.map(
+          (rightInputContext, index) => {
+            const rightInput = rightInputTuple[index];
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+            return rightInputContext.modifyTropoignantInput(rightInput);
+          },
+        );
+        const modifiedOutput = assemblerContext.pinbe(
+          modifiedLeftInput,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          ...modifiedRightInputTuple,
+        );
+
+        const aggregatedOutput =
+          outputContext.aggregatePinbetunfOutput(modifiedOutput);
+
+        const quirmList = outputContext.constituentResultNormalizerList.flatMap(
+          (normalizeResult) => {
+            const resultList = normalizeResult(leftInput, aggregatedOutput);
+            return resultList;
+          },
+        );
+        /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+
+        return quirmList;
+      },
+    } satisfies CoreEstinant as Estinant2<
+      TLeftVicken,
+      TRightVickenTuple,
+      TOutputVoictentTuple
+    >;
+    return estinant;
+  };
+
+  return assembleEstinant;
+};
+
+export type EstinantAssemblerParent<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TOutputVoictentTuple extends VoictentTuple,
+> = {
+  assemble: EstinantAssembler<
+    TLeftVicken,
+    TRightVickenTuple,
+    TOutputVoictentTuple
+  >;
+};

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/estinantBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/estinantBuilder.ts
@@ -1,0 +1,28 @@
+import {
+  buildLeftInputVoictentAppreffingeBuilder,
+  LeftInputVoictentAppreffingeBuilderParent,
+} from './leftInputVoictentAppreffingeBuilder';
+import {
+  buildLeftInputHubblepupAppreffingeBuilder,
+  LeftInputHubblepupAppreffingeBuilderParent,
+} from './leftInputHubblepupAppreffingeBuilder';
+import {
+  buildLeftInputGritionAppreffingeBuilder,
+  LeftInputGritionBuilderParent,
+} from './leftInputGritionAppreffingeBuilder';
+import {
+  buildLeftInputOdeshinVoictentAppreffingeBuilder,
+  LeftInputOdeshinVoictentAppreffingeBuilderParent,
+} from './leftInputOdeshinVoictentAppreffingeBuilder';
+
+export const buildEstinant = (): LeftInputVoictentAppreffingeBuilderParent &
+  LeftInputOdeshinVoictentAppreffingeBuilderParent &
+  LeftInputHubblepupAppreffingeBuilderParent &
+  LeftInputGritionBuilderParent => {
+  return {
+    fromGrition: buildLeftInputGritionAppreffingeBuilder(),
+    fromHubblepup: buildLeftInputHubblepupAppreffingeBuilder(),
+    fromOdeshinVoictent: buildLeftInputOdeshinVoictentAppreffingeBuilder(),
+    fromVoictent: buildLeftInputVoictentAppreffingeBuilder(),
+  };
+};

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/estinantBuilderContext.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/estinantBuilderContext.ts
@@ -1,0 +1,123 @@
+import { Gepp } from '../../../type-script-adapter/gepp';
+import { QuirmList } from '../../../type-script-adapter/quirm';
+import { Voictent } from '../../../type-script-adapter/voictent';
+import {
+  Straline,
+  StralineTuple,
+} from '../../../utilities/semantic-types/straline';
+import { Tuple } from '../../../utilities/semantic-types/tuple';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyLeftInputAccessor = (leftInput: any) => any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyRightInputAccessor = (leftInput: any) => any;
+
+export type TropoignantInput<
+  TVoictent extends Voictent,
+  TIsWibiz extends boolean,
+> = [TIsWibiz] extends [true]
+  ? TVoictent['hubblepupTuple']
+  : TVoictent['hubblepupTuple'][number];
+
+export type LeftInputContext = {
+  gepp: Gepp;
+  isWibiz: boolean;
+  modifyTropoignantInput: AnyLeftInputAccessor;
+};
+
+export type RightInputVoictentContext = {
+  gepp: Gepp;
+  isWibiz: true;
+  modifyTropoignantInput: AnyRightInputAccessor;
+};
+
+export type RightInputHubblepupContext = {
+  gepp: Gepp;
+  isWibiz: false;
+  framate: AnyLeftInputAccessor;
+  croard: AnyRightInputAccessor;
+  modifyTropoignantInput: AnyRightInputAccessor;
+};
+
+export type RightInputContext =
+  | RightInputVoictentContext
+  | RightInputHubblepupContext;
+
+export type RightInputContextTuple = Tuple<RightInputContext>;
+
+export type AggregatedOutput = Record<Gepp, unknown>;
+
+export type PinbetunfOutputAggregator<> = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  modifiedOutput: any,
+) => AggregatedOutput;
+
+export type ConstituentResultNormalizer = (
+  leftInput: unknown,
+  aggregatedOutput: AggregatedOutput,
+) => QuirmList;
+
+export type AggregatedOutputContext = {
+  aggregatePinbetunfOutput: PinbetunfOutputAggregator;
+  constituentResultNormalizerList: ConstituentResultNormalizer[];
+};
+
+export type RightInputContextTupleToModifiedInputTuple<
+  TRightInputContextTuple extends RightInputContextTuple,
+> = {
+  [Index in keyof TRightInputContextTuple]: ReturnType<
+    TRightInputContextTuple[Index]['modifyTropoignantInput']
+  >;
+};
+
+export type AppendInputToPinbetunfInputTuple<
+  TInputTuple extends StralineTuple,
+  TNextInput extends Straline,
+> = [...TInputTuple, TNextInput];
+
+export type Pinbetunf<
+  TInputTuple extends StralineTuple,
+  TOutput extends Straline,
+> = (...input: TInputTuple) => TOutput;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyPinbetunf = Pinbetunf<any, any>;
+
+export type InputContext = {
+  leftInputContext: LeftInputContext;
+  rightInputContextTuple: RightInputContextTuple;
+};
+
+type InputContextExtenderInput<
+  TNextRightInputContext extends RightInputContext,
+> = {
+  inputContext: InputContext;
+  nextRightInputContext: TNextRightInputContext;
+};
+
+export const extendInputContext = <
+  TNextRightInputContext extends RightInputContext,
+>({
+  inputContext,
+  nextRightInputContext,
+}: InputContextExtenderInput<TNextRightInputContext>): InputContext => {
+  const nextRightInputContextTuple = [
+    ...inputContext.rightInputContextTuple,
+    nextRightInputContext,
+  ];
+  return {
+    leftInputContext: inputContext.leftInputContext,
+    rightInputContextTuple: nextRightInputContextTuple,
+  };
+};
+
+export type InputOutputContext = {
+  inputContext: InputContext;
+  outputContext: AggregatedOutputContext;
+};
+
+export type AssemblerContext = {
+  inputContext: InputContext;
+  outputContext: AggregatedOutputContext;
+  pinbe: AnyPinbetunf;
+};

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/leftInputGritionAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/leftInputGritionAppreffingeBuilder.ts
@@ -1,0 +1,132 @@
+import { LeftHubblepupVicken } from '../../../type-script-adapter/vicken';
+import { OdeshinVoictent, OdeshinVoictentToGrition } from '../odeshinVoictent';
+import { InputContext } from './estinantBuilderContext';
+import { LeftAppreffinge } from './leftInputHubblepupAppreffingeBuilder';
+import {
+  buildOutputGritionAppreffingeBuilder,
+  OutputGritionAppreffingeBuilderParent,
+} from './outputGritionAppreffingeBuilder';
+import {
+  buildOutputHubblepupAppreffingeBuilder,
+  OutputHubblepupAppreffingeBuilderParent,
+} from './outputHubblepupAppreffingeBuilder';
+import {
+  buildOutputHubblepupTupleAppreffingeBuilder,
+  OutputHubblepupTupleAppreffingeBuilderParent,
+} from './outputHubblepupTupleAppreffingeBuilder';
+import {
+  RightInputHubblepupTupleAppreffingeBuilderParent,
+  buildRightInputHubblepupTupleAppreffingeBuilder,
+} from './rightInputHubblepupTupleAppreffingeBuilder';
+import {
+  buildRightInputOdeshinVoictentAppreffingeBuilder,
+  RightInputOdeshinVoictentAppreffingeBuilderParent,
+} from './rightInputOdeshinVoictentAppreffingeBuilder';
+import {
+  buildRightInputVoictentAppreffingeBuilder,
+  RightInputVoictentAppreffingeBuilderParent,
+} from './rightInputVoictentAppreffingeBuilder';
+import { odeshinToGrition } from './tropoignantInputOutputModifier';
+
+type LeftVicken<TInputVoictent extends OdeshinVoictent> =
+  LeftHubblepupVicken<TInputVoictent>;
+
+type RightInputVickenTuple = [];
+
+type PinbetunfInputTuple<TInputVoictent extends OdeshinVoictent> = [
+  OdeshinVoictentToGrition<TInputVoictent>,
+];
+
+export type LeftInputGritionAppreffingeBuilder = <
+  TInputVoictent extends OdeshinVoictent,
+>(
+  leftAppreffinge: LeftAppreffinge<TInputVoictent>,
+) => RightInputHubblepupTupleAppreffingeBuilderParent<
+  LeftVicken<TInputVoictent>,
+  RightInputVickenTuple,
+  PinbetunfInputTuple<TInputVoictent>
+> &
+  RightInputOdeshinVoictentAppreffingeBuilderParent<
+    LeftVicken<TInputVoictent>,
+    RightInputVickenTuple,
+    PinbetunfInputTuple<TInputVoictent>
+  > &
+  RightInputVoictentAppreffingeBuilderParent<
+    LeftVicken<TInputVoictent>,
+    RightInputVickenTuple,
+    PinbetunfInputTuple<TInputVoictent>
+  > &
+  OutputGritionAppreffingeBuilderParent<
+    LeftVicken<TInputVoictent>,
+    RightInputVickenTuple,
+    PinbetunfInputTuple<TInputVoictent>
+  > &
+  OutputHubblepupAppreffingeBuilderParent<
+    LeftVicken<TInputVoictent>,
+    RightInputVickenTuple,
+    PinbetunfInputTuple<TInputVoictent>
+  > &
+  OutputHubblepupTupleAppreffingeBuilderParent<
+    LeftVicken<TInputVoictent>,
+    RightInputVickenTuple,
+    PinbetunfInputTuple<TInputVoictent>
+  >;
+
+export const buildLeftInputGritionAppreffingeBuilder =
+  (): LeftInputGritionAppreffingeBuilder => {
+    const buildLeftInputGritionAppreffinge: LeftInputGritionAppreffingeBuilder =
+      <TInputVoictent extends OdeshinVoictent>(
+        leftAppreffinge: LeftAppreffinge<TInputVoictent>,
+      ) => {
+        const nextContext: InputContext = {
+          leftInputContext: {
+            gepp: leftAppreffinge.gepp,
+            isWibiz: false,
+            modifyTropoignantInput: odeshinToGrition,
+          },
+          rightInputContextTuple: [],
+        };
+
+        return {
+          andFromHubblepupTuple:
+            buildRightInputHubblepupTupleAppreffingeBuilder<
+              LeftVicken<TInputVoictent>,
+              RightInputVickenTuple,
+              PinbetunfInputTuple<TInputVoictent>
+            >(nextContext),
+          andFromOdeshinVoictent:
+            buildRightInputOdeshinVoictentAppreffingeBuilder<
+              LeftVicken<TInputVoictent>,
+              RightInputVickenTuple,
+              PinbetunfInputTuple<TInputVoictent>
+            >(nextContext),
+          andFromVoictent: buildRightInputVoictentAppreffingeBuilder<
+            LeftVicken<TInputVoictent>,
+            RightInputVickenTuple,
+            PinbetunfInputTuple<TInputVoictent>
+          >(nextContext),
+
+          toGrition: buildOutputGritionAppreffingeBuilder<
+            LeftVicken<TInputVoictent>,
+            RightInputVickenTuple,
+            PinbetunfInputTuple<TInputVoictent>
+          >(nextContext),
+          toHubblepup: buildOutputHubblepupAppreffingeBuilder<
+            LeftVicken<TInputVoictent>,
+            RightInputVickenTuple,
+            PinbetunfInputTuple<TInputVoictent>
+          >(nextContext),
+          toHubblepupTuple: buildOutputHubblepupTupleAppreffingeBuilder<
+            LeftVicken<TInputVoictent>,
+            RightInputVickenTuple,
+            PinbetunfInputTuple<TInputVoictent>
+          >(nextContext),
+        };
+      };
+
+    return buildLeftInputGritionAppreffinge;
+  };
+
+export type LeftInputGritionBuilderParent = {
+  fromGrition: LeftInputGritionAppreffingeBuilder;
+};

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/leftInputHubblepupAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/leftInputHubblepupAppreffingeBuilder.ts
@@ -1,0 +1,173 @@
+import { LeftHubblepupVicken } from '../../../type-script-adapter/vicken';
+import { VoictentToHubblepup } from '../../../type-script-adapter/voictent';
+import { Voictent } from '../voictent';
+import {
+  AggregatedOutput,
+  InputContext,
+  InputOutputContext,
+} from './estinantBuilderContext';
+import {
+  buildOutputGritionAppreffingeBuilder,
+  OutputGritionAppreffingeBuilderParent,
+} from './outputGritionAppreffingeBuilder';
+import {
+  buildOutputHubblepupAppreffingeBuilder,
+  OutputHubblepupAppreffingeBuilderParent,
+} from './outputHubblepupAppreffingeBuilder';
+import {
+  buildOutputHubblepupTupleAppreffingeBuilder,
+  OutputHubblepupTupleAppreffingeBuilderParent,
+} from './outputHubblepupTupleAppreffingeBuilder';
+import {
+  buildPinbetunfBuilder,
+  PinbetunfBuilderParent,
+} from './pinbetunfBuilder';
+import {
+  buildRightInputGritionTupleAppreffingeBuilder,
+  RightInputGritionTupleAppreffingeBuilderParent,
+} from './rightInputGritionTupleAppreffingeBuilder';
+import {
+  buildRightInputHubblepupTupleAppreffingeBuilder,
+  RightInputHubblepupTupleAppreffingeBuilderParent,
+} from './rightInputHubblepupTupleAppreffingeBuilder';
+import {
+  buildRightInputVoictentAppreffingeBuilder,
+  RightInputVoictentAppreffingeBuilderParent,
+} from './rightInputVoictentAppreffingeBuilder';
+import { hubblepupToHubblepup } from './tropoignantInputOutputModifier';
+
+type LeftVicken<TInputVoictent extends Voictent> =
+  LeftHubblepupVicken<TInputVoictent>;
+
+type RightInputVickenTuple = [];
+
+type PinbetunfInputTuple<TInputVoictent extends Voictent> = [
+  VoictentToHubblepup<TInputVoictent>,
+];
+
+type OutputVoictentTuple = [];
+
+type PinbetunfOutput = void;
+
+export type LeftAppreffinge<TInputVoictent extends Voictent> = {
+  gepp: TInputVoictent['gepp'];
+};
+
+export type LeftInputHubblepupAppreffingeBuilder = <
+  TInputVoictent extends Voictent,
+>(
+  leftAppreffinge: LeftAppreffinge<TInputVoictent>,
+) => RightInputGritionTupleAppreffingeBuilderParent<
+  LeftHubblepupVicken<TInputVoictent>,
+  RightInputVickenTuple,
+  PinbetunfInputTuple<TInputVoictent>
+> &
+  RightInputHubblepupTupleAppreffingeBuilderParent<
+    LeftHubblepupVicken<TInputVoictent>,
+    RightInputVickenTuple,
+    PinbetunfInputTuple<TInputVoictent>
+  > &
+  RightInputVoictentAppreffingeBuilderParent<
+    LeftVicken<TInputVoictent>,
+    RightInputVickenTuple,
+    PinbetunfInputTuple<TInputVoictent>
+  > &
+  PinbetunfBuilderParent<
+    LeftVicken<TInputVoictent>,
+    RightInputVickenTuple,
+    OutputVoictentTuple,
+    PinbetunfInputTuple<TInputVoictent>,
+    PinbetunfOutput
+  > &
+  OutputGritionAppreffingeBuilderParent<
+    LeftHubblepupVicken<TInputVoictent>,
+    RightInputVickenTuple,
+    PinbetunfInputTuple<TInputVoictent>
+  > &
+  OutputHubblepupAppreffingeBuilderParent<
+    LeftHubblepupVicken<TInputVoictent>,
+    RightInputVickenTuple,
+    PinbetunfInputTuple<TInputVoictent>
+  > &
+  OutputHubblepupTupleAppreffingeBuilderParent<
+    LeftHubblepupVicken<TInputVoictent>,
+    RightInputVickenTuple,
+    PinbetunfInputTuple<TInputVoictent>
+  >;
+
+export const buildLeftInputHubblepupAppreffingeBuilder =
+  (): LeftInputHubblepupAppreffingeBuilder => {
+    const buildLeftInputHubblepupAppreffinge: LeftInputHubblepupAppreffingeBuilder =
+      <TInputVoictent extends Voictent>(
+        leftAppreffinge: LeftAppreffinge<TInputVoictent>,
+      ) => {
+        const nextInputContext: InputContext = {
+          leftInputContext: {
+            gepp: leftAppreffinge.gepp,
+            isWibiz: false,
+            modifyTropoignantInput: hubblepupToHubblepup,
+          },
+          rightInputContextTuple: [],
+        };
+
+        const nextInputOutputContext: InputOutputContext = {
+          inputContext: nextInputContext,
+          outputContext: {
+            aggregatePinbetunfOutput: () => {
+              const aggregatedOutput: AggregatedOutput = {};
+              return aggregatedOutput;
+            },
+            constituentResultNormalizerList: [],
+          },
+        };
+
+        return {
+          andFromGritionTuple: buildRightInputGritionTupleAppreffingeBuilder<
+            LeftHubblepupVicken<TInputVoictent>,
+            RightInputVickenTuple,
+            PinbetunfInputTuple<TInputVoictent>
+          >(nextInputContext),
+          andFromHubblepupTuple:
+            buildRightInputHubblepupTupleAppreffingeBuilder<
+              LeftHubblepupVicken<TInputVoictent>,
+              RightInputVickenTuple,
+              PinbetunfInputTuple<TInputVoictent>
+            >(nextInputContext),
+          andFromVoictent: buildRightInputVoictentAppreffingeBuilder<
+            LeftHubblepupVicken<TInputVoictent>,
+            RightInputVickenTuple,
+            PinbetunfInputTuple<TInputVoictent>
+          >(nextInputContext),
+
+          onPinbe: buildPinbetunfBuilder<
+            LeftVicken<TInputVoictent>,
+            RightInputVickenTuple,
+            OutputVoictentTuple,
+            PinbetunfInputTuple<TInputVoictent>,
+            PinbetunfOutput
+          >(nextInputOutputContext),
+
+          toGrition: buildOutputGritionAppreffingeBuilder<
+            LeftHubblepupVicken<TInputVoictent>,
+            RightInputVickenTuple,
+            PinbetunfInputTuple<TInputVoictent>
+          >(nextInputContext),
+          toHubblepup: buildOutputHubblepupAppreffingeBuilder<
+            LeftHubblepupVicken<TInputVoictent>,
+            RightInputVickenTuple,
+            PinbetunfInputTuple<TInputVoictent>
+          >(nextInputContext),
+          toHubblepupTuple: buildOutputHubblepupTupleAppreffingeBuilder<
+            LeftHubblepupVicken<TInputVoictent>,
+            RightInputVickenTuple,
+            PinbetunfInputTuple<TInputVoictent>
+          >(nextInputContext),
+        };
+      };
+
+    return buildLeftInputHubblepupAppreffinge;
+  };
+
+export type LeftInputHubblepupAppreffingeBuilderParent = {
+  fromHubblepup: LeftInputHubblepupAppreffingeBuilder;
+};

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/leftInputOdeshinVoictentAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/leftInputOdeshinVoictentAppreffingeBuilder.ts
@@ -1,0 +1,91 @@
+import {
+  buildOutputHubblepupAppreffingeBuilder,
+  OutputHubblepupAppreffingeBuilderParent,
+} from './outputHubblepupAppreffingeBuilder';
+import { odeshinTupleToGritionTuple } from './tropoignantInputOutputModifier';
+import { LeftVoictentVicken } from '../../../type-script-adapter/vicken';
+import { InputContext } from './estinantBuilderContext';
+import {
+  buildRightInputVoictentAppreffingeBuilder,
+  RightInputVoictentAppreffingeBuilderParent,
+} from './rightInputVoictentAppreffingeBuilder';
+import { LeftAppreffinge } from './leftInputHubblepupAppreffingeBuilder';
+import { OdeshinVoictent } from '../odeshinVoictent';
+import { Tuple } from '../../../utilities/semantic-types/tuple';
+import {
+  buildRightInputOdeshinVoictentAppreffingeBuilder,
+  RightInputOdeshinVoictentAppreffingeBuilderParent,
+} from './rightInputOdeshinVoictentAppreffingeBuilder';
+
+type LeftVicken<TInputVoictent extends OdeshinVoictent> =
+  LeftVoictentVicken<TInputVoictent>;
+
+type RightVickenTuple = [];
+
+type PinbetunfInputTuple<TInputVoictent extends OdeshinVoictent> = [
+  // Note: don't use "OdeshinVoictentToGritionTuple" because it makes the final type harder to read :eyeroll:
+  Tuple<TInputVoictent['hubblepupTuple'][number]['grition']>,
+];
+
+export type LeftInputOdeshinVoictentAppreffingeBuilder = <
+  TInputVoictent extends OdeshinVoictent,
+>(
+  leftAppreffinge: LeftAppreffinge<TInputVoictent>,
+) => RightInputOdeshinVoictentAppreffingeBuilderParent<
+  LeftVicken<TInputVoictent>,
+  RightVickenTuple,
+  PinbetunfInputTuple<TInputVoictent>
+> &
+  RightInputVoictentAppreffingeBuilderParent<
+    LeftVicken<TInputVoictent>,
+    RightVickenTuple,
+    PinbetunfInputTuple<TInputVoictent>
+  > &
+  OutputHubblepupAppreffingeBuilderParent<
+    LeftVicken<TInputVoictent>,
+    RightVickenTuple,
+    PinbetunfInputTuple<TInputVoictent>
+  >;
+
+export const buildLeftInputOdeshinVoictentAppreffingeBuilder =
+  (): LeftInputOdeshinVoictentAppreffingeBuilder => {
+    const buildLeftInputOdeshinVoictentAppreffinge: LeftInputOdeshinVoictentAppreffingeBuilder =
+      <TInputVoictent extends OdeshinVoictent>(
+        leftAppreffinge: LeftAppreffinge<TInputVoictent>,
+      ) => {
+        const nextContext: InputContext = {
+          leftInputContext: {
+            gepp: leftAppreffinge.gepp,
+            isWibiz: true,
+            modifyTropoignantInput: odeshinTupleToGritionTuple,
+          },
+          rightInputContextTuple: [],
+        };
+
+        return {
+          andFromOdeshinVoictent:
+            buildRightInputOdeshinVoictentAppreffingeBuilder<
+              LeftVicken<TInputVoictent>,
+              RightVickenTuple,
+              PinbetunfInputTuple<TInputVoictent>
+            >(nextContext),
+          andFromVoictent: buildRightInputVoictentAppreffingeBuilder<
+            LeftVicken<TInputVoictent>,
+            RightVickenTuple,
+            PinbetunfInputTuple<TInputVoictent>
+          >(nextContext),
+
+          toHubblepup: buildOutputHubblepupAppreffingeBuilder<
+            LeftVicken<TInputVoictent>,
+            RightVickenTuple,
+            PinbetunfInputTuple<TInputVoictent>
+          >(nextContext),
+        };
+      };
+
+    return buildLeftInputOdeshinVoictentAppreffinge;
+  };
+
+export type LeftInputOdeshinVoictentAppreffingeBuilderParent = {
+  fromOdeshinVoictent: LeftInputOdeshinVoictentAppreffingeBuilder;
+};

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/leftInputVoictentAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/leftInputVoictentAppreffingeBuilder.ts
@@ -1,0 +1,89 @@
+import { Voictent } from '../voictent';
+import {
+  buildOutputHubblepupAppreffingeBuilder,
+  OutputHubblepupAppreffingeBuilderParent,
+} from './outputHubblepupAppreffingeBuilder';
+import { hubblepupTupleToHubblepupTuple } from './tropoignantInputOutputModifier';
+import { LeftVoictentVicken } from '../../../type-script-adapter/vicken';
+import { InputContext } from './estinantBuilderContext';
+import {
+  buildRightInputVoictentAppreffingeBuilder,
+  RightInputVoictentAppreffingeBuilderParent,
+} from './rightInputVoictentAppreffingeBuilder';
+import { LeftAppreffinge } from './leftInputHubblepupAppreffingeBuilder';
+import {
+  buildRightInputOdeshinVoictentAppreffingeBuilder,
+  RightInputOdeshinVoictentAppreffingeBuilderParent,
+} from './rightInputOdeshinVoictentAppreffingeBuilder';
+
+type LeftVicken<TInputVoictent extends Voictent> =
+  LeftVoictentVicken<TInputVoictent>;
+
+type RightVickenTuple = [];
+
+type PinbetunfInputTuple<TInputVoictent extends Voictent> = [
+  TInputVoictent['hubblepupTuple'],
+];
+
+export type LeftInputVoictentAppreffingeBuilder = <
+  TInputVoictent extends Voictent,
+>(
+  leftAppreffinge: LeftAppreffinge<TInputVoictent>,
+) => RightInputOdeshinVoictentAppreffingeBuilderParent<
+  LeftVicken<TInputVoictent>,
+  RightVickenTuple,
+  PinbetunfInputTuple<TInputVoictent>
+> &
+  RightInputVoictentAppreffingeBuilderParent<
+    LeftVicken<TInputVoictent>,
+    RightVickenTuple,
+    PinbetunfInputTuple<TInputVoictent>
+  > &
+  OutputHubblepupAppreffingeBuilderParent<
+    LeftVicken<TInputVoictent>,
+    RightVickenTuple,
+    PinbetunfInputTuple<TInputVoictent>
+  >;
+
+export const buildLeftInputVoictentAppreffingeBuilder =
+  (): LeftInputVoictentAppreffingeBuilder => {
+    const buildLeftInputVoictentAppreffinge: LeftInputVoictentAppreffingeBuilder =
+      <TInputVoictent extends Voictent>(
+        leftAppreffinge: LeftAppreffinge<TInputVoictent>,
+      ) => {
+        const nextContext: InputContext = {
+          leftInputContext: {
+            gepp: leftAppreffinge.gepp,
+            isWibiz: true,
+            modifyTropoignantInput: hubblepupTupleToHubblepupTuple,
+          },
+          rightInputContextTuple: [],
+        };
+
+        return {
+          andFromOdeshinVoictent:
+            buildRightInputOdeshinVoictentAppreffingeBuilder<
+              LeftVicken<TInputVoictent>,
+              RightVickenTuple,
+              PinbetunfInputTuple<TInputVoictent>
+            >(nextContext),
+          andFromVoictent: buildRightInputVoictentAppreffingeBuilder<
+            LeftVicken<TInputVoictent>,
+            RightVickenTuple,
+            PinbetunfInputTuple<TInputVoictent>
+          >(nextContext),
+
+          toHubblepup: buildOutputHubblepupAppreffingeBuilder<
+            LeftVicken<TInputVoictent>,
+            RightVickenTuple,
+            PinbetunfInputTuple<TInputVoictent>
+          >(nextContext),
+        };
+      };
+
+    return buildLeftInputVoictentAppreffinge;
+  };
+
+export type LeftInputVoictentAppreffingeBuilderParent = {
+  fromVoictent: LeftInputVoictentAppreffingeBuilder;
+};

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/outputGritionAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/outputGritionAppreffingeBuilder.ts
@@ -1,0 +1,104 @@
+import {
+  LeftVicken,
+  RightVickenTuple,
+} from '../../../type-script-adapter/vicken';
+import { StralineTuple } from '../../../utilities/semantic-types/straline';
+import { OdeshinVoictent } from '../odeshinVoictent';
+import { InputContext, InputOutputContext } from './estinantBuilderContext';
+import {
+  buildPinbetunfBuilder,
+  PinbetunfBuilderParent,
+} from './pinbetunfBuilder';
+import {
+  buildOutputGritionNormalizer,
+  buildPinbetunfOutputAggregator,
+  ZornAccessor,
+} from './tropoignantInputOutputModifier';
+
+type OutputAppreffinge<
+  TLeftVicken extends LeftVicken,
+  TOutputVoictent extends OdeshinVoictent,
+> = {
+  gepp: TOutputVoictent['gepp'];
+  getZorn: ZornAccessor<TLeftVicken['tropoignantInput']>;
+};
+
+type OutputVoictentTuple<TOutputVoictent extends OdeshinVoictent> = [
+  TOutputVoictent,
+];
+
+type PinbetunfOutput<TOutputVoictent extends OdeshinVoictent> =
+  TOutputVoictent['hubblepupTuple'][number]['grition'];
+
+export type OutputGritionAppreffingeBuilder<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+> = <TOutputVoictent extends OdeshinVoictent>(
+  outputAppreffinge: OutputAppreffinge<TLeftVicken, TOutputVoictent>,
+) => PinbetunfBuilderParent<
+  TLeftVicken,
+  TRightVickenTuple,
+  OutputVoictentTuple<TOutputVoictent>,
+  TPinbetunfInputTuple,
+  PinbetunfOutput<TOutputVoictent>
+>;
+
+export const buildOutputGritionAppreffingeBuilder = <
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+>(
+  inputContext: InputContext,
+): OutputGritionAppreffingeBuilder<
+  TLeftVicken,
+  TRightVickenTuple,
+  TPinbetunfInputTuple
+> => {
+  const buildoutputGritionAppreffinge: OutputGritionAppreffingeBuilder<
+    TLeftVicken,
+    TRightVickenTuple,
+    TPinbetunfInputTuple
+  > = <TOutputVoictent extends OdeshinVoictent>(
+    outputAppreffinge: OutputAppreffinge<TLeftVicken, TOutputVoictent>,
+  ) => {
+    const nextContext: InputOutputContext = {
+      inputContext,
+      outputContext: {
+        aggregatePinbetunfOutput: buildPinbetunfOutputAggregator(
+          outputAppreffinge.gepp,
+        ),
+        constituentResultNormalizerList: [
+          buildOutputGritionNormalizer(
+            outputAppreffinge.gepp,
+            outputAppreffinge.getZorn,
+          ),
+        ],
+      },
+    };
+
+    return {
+      onPinbe: buildPinbetunfBuilder<
+        TLeftVicken,
+        TRightVickenTuple,
+        OutputVoictentTuple<TOutputVoictent>,
+        TPinbetunfInputTuple,
+        PinbetunfOutput<TOutputVoictent>
+      >(nextContext),
+    };
+  };
+
+  return buildoutputGritionAppreffinge;
+};
+
+export type OutputGritionAppreffingeBuilderParent<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+> = {
+  toGrition: OutputGritionAppreffingeBuilder<
+    TLeftVicken,
+    TRightVickenTuple,
+    TPinbetunfInputTuple
+  >;
+};

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/outputHubblepupAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/outputHubblepupAppreffingeBuilder.ts
@@ -1,0 +1,132 @@
+import {
+  LeftVicken,
+  OutputHubblepupVicken,
+  RightVickenTuple,
+} from '../../../type-script-adapter/vicken';
+import { StralineTuple } from '../../../utilities/semantic-types/straline';
+import { Voictent } from '../voictent';
+import {
+  AdditionalOutputHubblepupAppreffingeBuilderParent,
+  buildAdditionalOutputHubblepupAppreffingeBuilder,
+} from './additionalOutputHubblepupAppreffingeBuilder';
+import {
+  AdditionalOutputHubblepupTupleAppreffingeBuilderParent,
+  buildAdditionalOutputHubblepupTupleAppreffingeBuilder,
+} from './additionalOutputHubblepupTupleAppreffingeBuilder';
+import { InputContext, InputOutputContext } from './estinantBuilderContext';
+import {
+  buildPinbetunfBuilder,
+  PinbetunfBuilderParent,
+} from './pinbetunfBuilder';
+import {
+  buildOutputHubblepupNormalizer,
+  buildPinbetunfOutputAggregator,
+} from './tropoignantInputOutputModifier';
+
+type OutputAppreffinge<TOutputVoictent extends Voictent> = {
+  gepp: TOutputVoictent['gepp'];
+};
+
+type OutputVoictentTuple<TOutputVoictent> = [TOutputVoictent];
+
+type OutputVickenTuple<TOutputVoictent extends Voictent> = [
+  OutputHubblepupVicken<TOutputVoictent>,
+];
+
+type PinbetunfOutput<TOutputVoictent extends Voictent> =
+  TOutputVoictent['hubblepupTuple'][number];
+
+export type OutputHubblepupAppreffingeBuilder<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+> = <TOutputVoictent extends Voictent>(
+  outputAppreffinge: OutputAppreffinge<TOutputVoictent>,
+) => AdditionalOutputHubblepupAppreffingeBuilderParent<
+  TLeftVicken,
+  TRightVickenTuple,
+  OutputVickenTuple<TOutputVoictent>,
+  TPinbetunfInputTuple
+> &
+  AdditionalOutputHubblepupTupleAppreffingeBuilderParent<
+    TLeftVicken,
+    TRightVickenTuple,
+    OutputVickenTuple<TOutputVoictent>,
+    TPinbetunfInputTuple
+  > &
+  PinbetunfBuilderParent<
+    TLeftVicken,
+    TRightVickenTuple,
+    OutputVoictentTuple<TOutputVoictent>,
+    TPinbetunfInputTuple,
+    PinbetunfOutput<TOutputVoictent>
+  >;
+
+export const buildOutputHubblepupAppreffingeBuilder = <
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+>(
+  inputContext: InputContext,
+): OutputHubblepupAppreffingeBuilder<
+  TLeftVicken,
+  TRightVickenTuple,
+  TPinbetunfInputTuple
+> => {
+  const buildOutputHubblepupAppreffinge: OutputHubblepupAppreffingeBuilder<
+    TLeftVicken,
+    TRightVickenTuple,
+    TPinbetunfInputTuple
+  > = <TOutputVoictent extends Voictent>(
+    outputAppreffinge: OutputAppreffinge<TOutputVoictent>,
+  ) => {
+    const nextContext: InputOutputContext = {
+      inputContext,
+      outputContext: {
+        aggregatePinbetunfOutput: buildPinbetunfOutputAggregator(
+          outputAppreffinge.gepp,
+        ),
+        constituentResultNormalizerList: [
+          buildOutputHubblepupNormalizer(outputAppreffinge.gepp),
+        ],
+      },
+    };
+
+    return {
+      toHubblepup: buildAdditionalOutputHubblepupAppreffingeBuilder<
+        TLeftVicken,
+        TRightVickenTuple,
+        OutputVickenTuple<TOutputVoictent>,
+        TPinbetunfInputTuple
+      >(nextContext),
+      andToHubblepupTuple:
+        buildAdditionalOutputHubblepupTupleAppreffingeBuilder<
+          TLeftVicken,
+          TRightVickenTuple,
+          OutputVickenTuple<TOutputVoictent>,
+          TPinbetunfInputTuple
+        >(nextContext),
+      onPinbe: buildPinbetunfBuilder<
+        TLeftVicken,
+        TRightVickenTuple,
+        OutputVoictentTuple<TOutputVoictent>,
+        TPinbetunfInputTuple,
+        PinbetunfOutput<TOutputVoictent>
+      >(nextContext),
+    };
+  };
+
+  return buildOutputHubblepupAppreffinge;
+};
+
+export type OutputHubblepupAppreffingeBuilderParent<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+> = {
+  toHubblepup: OutputHubblepupAppreffingeBuilder<
+    TLeftVicken,
+    TRightVickenTuple,
+    TPinbetunfInputTuple
+  >;
+};

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/outputHubblepupTupleAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/outputHubblepupTupleAppreffingeBuilder.ts
@@ -1,0 +1,138 @@
+import {
+  LeftVicken,
+  OutputVoictentVicken,
+  RightVickenTuple,
+} from '../../../type-script-adapter/vicken';
+import { StralineTuple } from '../../../utilities/semantic-types/straline';
+import { Voictent } from '../voictent';
+import {
+  AdditionalOutputHubblepupTupleAppreffingeBuilderParent,
+  buildAdditionalOutputHubblepupTupleAppreffingeBuilder,
+} from './additionalOutputHubblepupTupleAppreffingeBuilder';
+import { InputContext, InputOutputContext } from './estinantBuilderContext';
+import {
+  buildPinbetunfBuilder,
+  PinbetunfBuilderParent,
+} from './pinbetunfBuilder';
+import {
+  buildOutputHubblepupTupleNormalizer,
+  buildPinbetunfOutputAggregator,
+} from './tropoignantInputOutputModifier';
+
+type OutputAppreffinge<TOutputVoictent extends Voictent> = {
+  gepp: TOutputVoictent['gepp'];
+};
+
+type OutputVickenTuple<TOutputVoictent extends Voictent> = [
+  OutputVoictentVicken<TOutputVoictent>,
+];
+
+type OutputVoictentTuple<TOutputVoictent> = [TOutputVoictent];
+
+type PinbetunfOutput<TOutputVoictent extends Voictent> =
+  TOutputVoictent['hubblepupTuple'];
+
+export type OutputHubblepupTupleAppreffingeBuilder<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+> = <TOutputVoictent extends Voictent>(
+  outputAppreffinge: OutputAppreffinge<TOutputVoictent>,
+  // pinbe: Pinbetunf<[TInputVoictent['hubblepupTuple'][number]], unknown>,
+) => AdditionalOutputHubblepupTupleAppreffingeBuilderParent<
+  TLeftVicken,
+  TRightVickenTuple,
+  OutputVickenTuple<TOutputVoictent>,
+  TPinbetunfInputTuple
+> &
+  PinbetunfBuilderParent<
+    TLeftVicken,
+    TRightVickenTuple,
+    OutputVoictentTuple<TOutputVoictent>,
+    TPinbetunfInputTuple,
+    PinbetunfOutput<TOutputVoictent>
+  >;
+//   [TInputVoictent['hubblepupTuple'][number]]
+// > &
+// OutputVoictentBuilderParent<Virm<TInputVoictent, false>>;
+
+export const buildOutputHubblepupTupleAppreffingeBuilder = <
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+>(
+  inputContext: InputContext,
+): OutputHubblepupTupleAppreffingeBuilder<
+  TLeftVicken,
+  TRightVickenTuple,
+  TPinbetunfInputTuple
+> => {
+  const buildOutputHubblepupTupleAppreffinge: OutputHubblepupTupleAppreffingeBuilder<
+    TLeftVicken,
+    TRightVickenTuple,
+    TPinbetunfInputTuple
+  > = <TOutputVoictent extends Voictent>(
+    outputAppreffinge: OutputAppreffinge<TOutputVoictent>,
+    // pinbe: Pinbetunf<[TInputVoictent['hubblepupTuple'][number]], unknown>,
+  ) => {
+    const nextContext: InputOutputContext = {
+      inputContext,
+      outputContext: {
+        aggregatePinbetunfOutput: buildPinbetunfOutputAggregator(
+          outputAppreffinge.gepp,
+        ),
+        constituentResultNormalizerList: [
+          buildOutputHubblepupTupleNormalizer(outputAppreffinge.gepp),
+        ],
+      },
+    };
+
+    return {
+      // andFromVoictent: buildRightInputVoictentBuilder(),
+      // toVoictent: buildOutputVoictentBuilder({
+      //   gepp,
+      //   isWibiz: false,
+      // }),
+      // assemble: buildEstinantAssembler<Vition<TInputVoictent, []>, []>(
+      //   {
+      //     gepp,
+      //     isWibiz: false,
+      //     modifyTropoignantInput: hubblepupToHubblepup,
+      //   },
+      //   [],
+      //   {
+      //     normalizePinbetunfOutput: () => [],
+      //   },
+      //   pinbe,
+      // ),
+      andToHubblepupTuple:
+        buildAdditionalOutputHubblepupTupleAppreffingeBuilder<
+          TLeftVicken,
+          TRightVickenTuple,
+          OutputVickenTuple<TOutputVoictent>,
+          TPinbetunfInputTuple
+        >(nextContext),
+      onPinbe: buildPinbetunfBuilder<
+        TLeftVicken,
+        TRightVickenTuple,
+        OutputVoictentTuple<TOutputVoictent>,
+        TPinbetunfInputTuple,
+        PinbetunfOutput<TOutputVoictent>
+      >(nextContext),
+    };
+  };
+
+  return buildOutputHubblepupTupleAppreffinge;
+};
+
+export type OutputHubblepupTupleAppreffingeBuilderParent<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+> = {
+  toHubblepupTuple: OutputHubblepupTupleAppreffingeBuilder<
+    TLeftVicken,
+    TRightVickenTuple,
+    TPinbetunfInputTuple
+  >;
+};

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/pinbetunfBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/pinbetunfBuilder.ts
@@ -1,0 +1,86 @@
+import {
+  LeftVicken,
+  RightVickenTuple,
+} from '../../../type-script-adapter/vicken';
+import { VoictentTuple } from '../../../type-script-adapter/voictent';
+import {
+  Straline,
+  StralineTuple,
+} from '../../../utilities/semantic-types/straline';
+import {
+  buildEstinantAssembler,
+  EstinantAssemblerParent,
+} from './estinantAssembler';
+import {
+  AssemblerContext,
+  InputOutputContext,
+  Pinbetunf,
+} from './estinantBuilderContext';
+
+export type PinbetunfBuilder<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TOutputVoictentTuple extends VoictentTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+  TPinbeOutput extends Straline,
+> = (
+  pinbe: Pinbetunf<TPinbetunfInputTuple, TPinbeOutput>,
+) => EstinantAssemblerParent<
+  TLeftVicken,
+  TRightVickenTuple,
+  TOutputVoictentTuple
+>;
+
+export const buildPinbetunfBuilder = <
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TOutputVoictentTuple extends VoictentTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+  TPinbeOutput extends Straline,
+>(
+  inputOutputContext: InputOutputContext,
+): PinbetunfBuilder<
+  TLeftVicken,
+  TRightVickenTuple,
+  TOutputVoictentTuple,
+  TPinbetunfInputTuple,
+  TPinbeOutput
+> => {
+  const buildPinbetunf: PinbetunfBuilder<
+    TLeftVicken,
+    TRightVickenTuple,
+    TOutputVoictentTuple,
+    TPinbetunfInputTuple,
+    TPinbeOutput
+  > = (pinbe: Pinbetunf<TPinbetunfInputTuple, TPinbeOutput>) => {
+    const { inputContext, outputContext } = inputOutputContext;
+
+    const nextContext: AssemblerContext = {
+      inputContext,
+      outputContext,
+      pinbe,
+    };
+
+    return {
+      assemble: buildEstinantAssembler(nextContext),
+    };
+  };
+
+  return buildPinbetunf;
+};
+
+export type PinbetunfBuilderParent<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TOutputVoictentTuple extends VoictentTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+  TPinbeOutput extends Straline,
+> = {
+  onPinbe: PinbetunfBuilder<
+    TLeftVicken,
+    TRightVickenTuple,
+    TOutputVoictentTuple,
+    TPinbetunfInputTuple,
+    TPinbeOutput
+  >;
+};

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/rightInputGritionTupleAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/rightInputGritionTupleAppreffingeBuilder.ts
@@ -1,0 +1,299 @@
+import {
+  AppendRightVickenToTuple,
+  LeftVicken,
+  RightHubblepupVicken,
+  RightVickenTuple,
+  VickenVoictentTupleToZornTuple,
+} from '../../../type-script-adapter/vicken';
+import { VoictentToHubblepup } from '../../../type-script-adapter/voictent';
+import { StralineTuple } from '../../../utilities/semantic-types/straline';
+import { Tuple } from '../../../utilities/semantic-types/tuple';
+import { Zorn } from '../../../utilities/semantic-types/zorn';
+import { OdeshinVoictent } from '../odeshinVoictent';
+import {
+  AppendInputToPinbetunfInputTuple,
+  extendInputContext,
+  InputContext,
+  RightInputHubblepupContext,
+} from './estinantBuilderContext';
+import {
+  buildOutputGritionAppreffingeBuilder,
+  OutputGritionAppreffingeBuilderParent,
+} from './outputGritionAppreffingeBuilder';
+import {
+  buildOutputHubblepupAppreffingeBuilder,
+  OutputHubblepupAppreffingeBuilderParent,
+} from './outputHubblepupAppreffingeBuilder';
+import {
+  buildOutputHubblepupTupleAppreffingeBuilder,
+  OutputHubblepupTupleAppreffingeBuilderParent,
+} from './outputHubblepupTupleAppreffingeBuilder';
+import {
+  buildRightInputHubblepupTupleAppreffingeBuilder,
+  RightInputHubblepupTupleAppreffingeBuilderParent,
+} from './rightInputHubblepupTupleAppreffingeBuilder';
+import {
+  buildRightInputOdeshinVoictentAppreffingeBuilder,
+  RightInputOdeshinVoictentAppreffingeBuilderParent,
+} from './rightInputOdeshinVoictentAppreffingeBuilder';
+import {
+  buildRightInputVoictentAppreffingeBuilder,
+  RightInputVoictentAppreffingeBuilderParent,
+} from './rightInputVoictentAppreffingeBuilder';
+import { odeshinTupleToGritionTuple } from './tropoignantInputOutputModifier';
+
+type RightAppreffinge<
+  TLeftVicken extends LeftVicken,
+  TRightInputVoictent extends OdeshinVoictent,
+  TVoictentTuple extends Tuple<TRightInputVoictent>,
+  TZorn extends Zorn,
+> = {
+  gepp: TRightInputVoictent['gepp'];
+  framate: (
+    leftInput: TLeftVicken['tropoignantInput'],
+  ) => VickenVoictentTupleToZornTuple<TVoictentTuple, TZorn>;
+  croard: (rightInput: VoictentToHubblepup<TRightInputVoictent>) => TZorn;
+};
+
+type RightInputTuple<
+  TRightInputVoictent extends OdeshinVoictent,
+  TVoictentTuple extends Tuple<TRightInputVoictent>,
+> = {
+  [Index in keyof TVoictentTuple]: TVoictentTuple[Index]['hubblepupTuple'][number]['grition'];
+};
+
+type NextVickenTuple<
+  TRightVickenTuple extends RightVickenTuple,
+  TRightInputVoictent extends OdeshinVoictent,
+  TVoictentTuple extends Tuple<TRightInputVoictent>,
+  TZorn extends Zorn,
+> = AppendRightVickenToTuple<
+  TRightVickenTuple,
+  RightHubblepupVicken<TRightInputVoictent, TVoictentTuple, TZorn>
+>;
+
+type NextPinbetunfInputTuple<
+  TPinbetunfInputTuple extends StralineTuple,
+  TRightInputVoictent extends OdeshinVoictent,
+  TVoictentTuple extends Tuple<TRightInputVoictent>,
+> = AppendInputToPinbetunfInputTuple<
+  TPinbetunfInputTuple,
+  RightInputTuple<TRightInputVoictent, TVoictentTuple>
+>;
+
+export type RightInputGritionTupleAppreffingeBuilder<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+> = <
+  TRightInputVoictent extends OdeshinVoictent,
+  TVoictentTuple extends Tuple<TRightInputVoictent>,
+  TZorn extends Zorn,
+>(
+  rightAppreffinge: RightAppreffinge<
+    TLeftVicken,
+    TRightInputVoictent,
+    TVoictentTuple,
+    TZorn
+  >,
+) => RightInputGritionTupleAppreffingeBuilderParent<
+  TLeftVicken,
+  NextVickenTuple<
+    TRightVickenTuple,
+    TRightInputVoictent,
+    TVoictentTuple,
+    TZorn
+  >,
+  NextPinbetunfInputTuple<
+    TPinbetunfInputTuple,
+    TRightInputVoictent,
+    TVoictentTuple
+  >
+> &
+  RightInputHubblepupTupleAppreffingeBuilderParent<
+    TLeftVicken,
+    NextVickenTuple<
+      TRightVickenTuple,
+      TRightInputVoictent,
+      TVoictentTuple,
+      TZorn
+    >,
+    NextPinbetunfInputTuple<
+      TPinbetunfInputTuple,
+      TRightInputVoictent,
+      TVoictentTuple
+    >
+  > &
+  RightInputOdeshinVoictentAppreffingeBuilderParent<
+    TLeftVicken,
+    NextVickenTuple<
+      TRightVickenTuple,
+      TRightInputVoictent,
+      TVoictentTuple,
+      TZorn
+    >,
+    NextPinbetunfInputTuple<
+      TPinbetunfInputTuple,
+      TRightInputVoictent,
+      TVoictentTuple
+    >
+  > &
+  RightInputVoictentAppreffingeBuilderParent<
+    TLeftVicken,
+    NextVickenTuple<
+      TRightVickenTuple,
+      TRightInputVoictent,
+      TVoictentTuple,
+      TZorn
+    >,
+    NextPinbetunfInputTuple<
+      TPinbetunfInputTuple,
+      TRightInputVoictent,
+      TVoictentTuple
+    >
+  > &
+  OutputGritionAppreffingeBuilderParent<
+    TLeftVicken,
+    NextVickenTuple<
+      TRightVickenTuple,
+      TRightInputVoictent,
+      TVoictentTuple,
+      TZorn
+    >,
+    NextPinbetunfInputTuple<
+      TPinbetunfInputTuple,
+      TRightInputVoictent,
+      TVoictentTuple
+    >
+  > &
+  OutputHubblepupAppreffingeBuilderParent<
+    TLeftVicken,
+    NextVickenTuple<
+      TRightVickenTuple,
+      TRightInputVoictent,
+      TVoictentTuple,
+      TZorn
+    >,
+    NextPinbetunfInputTuple<
+      TPinbetunfInputTuple,
+      TRightInputVoictent,
+      TVoictentTuple
+    >
+  > &
+  OutputHubblepupTupleAppreffingeBuilderParent<
+    TLeftVicken,
+    NextVickenTuple<
+      TRightVickenTuple,
+      TRightInputVoictent,
+      TVoictentTuple,
+      TZorn
+    >,
+    NextPinbetunfInputTuple<
+      TPinbetunfInputTuple,
+      TRightInputVoictent,
+      TVoictentTuple
+    >
+  >;
+
+export const buildRightInputGritionTupleAppreffingeBuilder = <
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+>(
+  inputContext: InputContext,
+): RightInputGritionTupleAppreffingeBuilder<
+  TLeftVicken,
+  TRightVickenTuple,
+  TPinbetunfInputTuple
+> => {
+  const buildRightInputGritionTupleAppreffinge: RightInputGritionTupleAppreffingeBuilder<
+    TLeftVicken,
+    TRightVickenTuple,
+    TPinbetunfInputTuple
+  > = <
+    TRightInputVoictent extends OdeshinVoictent,
+    TVoictentTuple extends Tuple<TRightInputVoictent>,
+    TZorn extends Zorn,
+  >(
+    rightAppreffinge: RightAppreffinge<
+      TLeftVicken,
+      TRightInputVoictent,
+      TVoictentTuple,
+      TZorn
+    >,
+  ) => {
+    const nextContext = extendInputContext<RightInputHubblepupContext>({
+      inputContext,
+      nextRightInputContext: {
+        gepp: rightAppreffinge.gepp,
+        isWibiz: false,
+        framate: rightAppreffinge.framate,
+        croard: rightAppreffinge.croard,
+        modifyTropoignantInput: odeshinTupleToGritionTuple,
+      },
+    });
+
+    type TNextRightVickenTuple = AppendRightVickenToTuple<
+      TRightVickenTuple,
+      RightHubblepupVicken<TRightInputVoictent, TVoictentTuple, TZorn>
+    >;
+
+    type TNextPinbetunfInputTuple = AppendInputToPinbetunfInputTuple<
+      TPinbetunfInputTuple,
+      RightInputTuple<TRightInputVoictent, TVoictentTuple>
+    >;
+
+    return {
+      andFromGritionTuple: buildRightInputGritionTupleAppreffingeBuilder<
+        TLeftVicken,
+        TNextRightVickenTuple,
+        TNextPinbetunfInputTuple
+      >(nextContext),
+      andFromHubblepupTuple: buildRightInputHubblepupTupleAppreffingeBuilder<
+        TLeftVicken,
+        TNextRightVickenTuple,
+        TNextPinbetunfInputTuple
+      >(nextContext),
+      andFromOdeshinVoictent: buildRightInputOdeshinVoictentAppreffingeBuilder<
+        TLeftVicken,
+        TNextRightVickenTuple,
+        TNextPinbetunfInputTuple
+      >(nextContext),
+      andFromVoictent: buildRightInputVoictentAppreffingeBuilder<
+        TLeftVicken,
+        TNextRightVickenTuple,
+        TNextPinbetunfInputTuple
+      >(nextContext),
+
+      toGrition: buildOutputGritionAppreffingeBuilder<
+        TLeftVicken,
+        TNextRightVickenTuple,
+        TNextPinbetunfInputTuple
+      >(nextContext),
+      toHubblepup: buildOutputHubblepupAppreffingeBuilder<
+        TLeftVicken,
+        TNextRightVickenTuple,
+        TNextPinbetunfInputTuple
+      >(nextContext),
+      toHubblepupTuple: buildOutputHubblepupTupleAppreffingeBuilder<
+        TLeftVicken,
+        TNextRightVickenTuple,
+        TNextPinbetunfInputTuple
+      >(nextContext),
+    };
+  };
+
+  return buildRightInputGritionTupleAppreffinge;
+};
+
+export type RightInputGritionTupleAppreffingeBuilderParent<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+> = {
+  andFromGritionTuple: RightInputGritionTupleAppreffingeBuilder<
+    TLeftVicken,
+    TRightVickenTuple,
+    TPinbetunfInputTuple
+  >;
+};

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/rightInputHubblepupTupleAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/rightInputHubblepupTupleAppreffingeBuilder.ts
@@ -1,0 +1,276 @@
+import {
+  AppendRightVickenToTuple,
+  LeftVicken,
+  RightHubblepupVicken,
+  RightVickenTuple,
+  VickenVoictentTupleToZornTuple,
+} from '../../../type-script-adapter/vicken';
+import { VoictentToHubblepup } from '../../../type-script-adapter/voictent';
+import { StralineTuple } from '../../../utilities/semantic-types/straline';
+import { Tuple } from '../../../utilities/semantic-types/tuple';
+import { Zorn } from '../../../utilities/semantic-types/zorn';
+import { Voictent } from '../voictent';
+import {
+  AppendInputToPinbetunfInputTuple,
+  extendInputContext,
+  InputContext,
+  RightInputHubblepupContext,
+} from './estinantBuilderContext';
+import {
+  buildOutputGritionAppreffingeBuilder,
+  OutputGritionAppreffingeBuilderParent,
+} from './outputGritionAppreffingeBuilder';
+import {
+  buildOutputHubblepupAppreffingeBuilder,
+  OutputHubblepupAppreffingeBuilderParent,
+} from './outputHubblepupAppreffingeBuilder';
+import {
+  buildOutputHubblepupTupleAppreffingeBuilder,
+  OutputHubblepupTupleAppreffingeBuilderParent,
+} from './outputHubblepupTupleAppreffingeBuilder';
+import {
+  buildRightInputOdeshinVoictentAppreffingeBuilder,
+  RightInputOdeshinVoictentAppreffingeBuilderParent,
+} from './rightInputOdeshinVoictentAppreffingeBuilder';
+import {
+  buildRightInputVoictentAppreffingeBuilder,
+  RightInputVoictentAppreffingeBuilderParent,
+} from './rightInputVoictentAppreffingeBuilder';
+import { hubblepupTupleToHubblepupTuple } from './tropoignantInputOutputModifier';
+
+type RightAppreffinge<
+  TLeftVicken extends LeftVicken,
+  TRightInputVoictent extends Voictent,
+  TVoictentTuple extends Tuple<TRightInputVoictent>,
+  TZorn extends Zorn,
+> = {
+  gepp: TRightInputVoictent['gepp'];
+  framate: (
+    leftInput: TLeftVicken['tropoignantInput'],
+  ) => VickenVoictentTupleToZornTuple<TVoictentTuple, TZorn>;
+  croard: (rightInput: VoictentToHubblepup<TRightInputVoictent>) => TZorn;
+};
+
+type RightInputTuple<
+  TRightInputVoictent extends Voictent,
+  TVoictentTuple extends Tuple<TRightInputVoictent>,
+> = {
+  [Index in keyof TVoictentTuple]: TVoictentTuple[Index]['hubblepupTuple'][number];
+};
+
+type NextVickenTuple<
+  TRightVickenTuple extends RightVickenTuple,
+  TRightInputVoictent extends Voictent,
+  TVoictentTuple extends Tuple<TRightInputVoictent>,
+  TZorn extends Zorn,
+> = AppendRightVickenToTuple<
+  TRightVickenTuple,
+  RightHubblepupVicken<TRightInputVoictent, TVoictentTuple, TZorn>
+>;
+
+type NextPinbetunfInputTuple<
+  TPinbetunfInputTuple extends StralineTuple,
+  TRightInputVoictent extends Voictent,
+  TVoictentTuple extends Tuple<TRightInputVoictent>,
+> = AppendInputToPinbetunfInputTuple<
+  TPinbetunfInputTuple,
+  RightInputTuple<TRightInputVoictent, TVoictentTuple>
+>;
+
+export type RightInputHubblepupTupleAppreffingeBuilder<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+> = <
+  TRightInputVoictent extends Voictent,
+  TVoictentTuple extends Tuple<TRightInputVoictent>,
+  TZorn extends Zorn,
+>(
+  rightAppreffinge: RightAppreffinge<
+    TLeftVicken,
+    TRightInputVoictent,
+    TVoictentTuple,
+    TZorn
+  >,
+) => RightInputHubblepupTupleAppreffingeBuilderParent<
+  TLeftVicken,
+  NextVickenTuple<
+    TRightVickenTuple,
+    TRightInputVoictent,
+    TVoictentTuple,
+    TZorn
+  >,
+  NextPinbetunfInputTuple<
+    TPinbetunfInputTuple,
+    TRightInputVoictent,
+    TVoictentTuple
+  >
+> &
+  RightInputOdeshinVoictentAppreffingeBuilderParent<
+    TLeftVicken,
+    NextVickenTuple<
+      TRightVickenTuple,
+      TRightInputVoictent,
+      TVoictentTuple,
+      TZorn
+    >,
+    NextPinbetunfInputTuple<
+      TPinbetunfInputTuple,
+      TRightInputVoictent,
+      TVoictentTuple
+    >
+  > &
+  RightInputVoictentAppreffingeBuilderParent<
+    TLeftVicken,
+    NextVickenTuple<
+      TRightVickenTuple,
+      TRightInputVoictent,
+      TVoictentTuple,
+      TZorn
+    >,
+    NextPinbetunfInputTuple<
+      TPinbetunfInputTuple,
+      TRightInputVoictent,
+      TVoictentTuple
+    >
+  > &
+  OutputGritionAppreffingeBuilderParent<
+    TLeftVicken,
+    NextVickenTuple<
+      TRightVickenTuple,
+      TRightInputVoictent,
+      TVoictentTuple,
+      TZorn
+    >,
+    NextPinbetunfInputTuple<
+      TPinbetunfInputTuple,
+      TRightInputVoictent,
+      TVoictentTuple
+    >
+  > &
+  OutputHubblepupAppreffingeBuilderParent<
+    TLeftVicken,
+    NextVickenTuple<
+      TRightVickenTuple,
+      TRightInputVoictent,
+      TVoictentTuple,
+      TZorn
+    >,
+    NextPinbetunfInputTuple<
+      TPinbetunfInputTuple,
+      TRightInputVoictent,
+      TVoictentTuple
+    >
+  > &
+  OutputHubblepupTupleAppreffingeBuilderParent<
+    TLeftVicken,
+    NextVickenTuple<
+      TRightVickenTuple,
+      TRightInputVoictent,
+      TVoictentTuple,
+      TZorn
+    >,
+    NextPinbetunfInputTuple<
+      TPinbetunfInputTuple,
+      TRightInputVoictent,
+      TVoictentTuple
+    >
+  >;
+
+export const buildRightInputHubblepupTupleAppreffingeBuilder = <
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+>(
+  inputContext: InputContext,
+): RightInputHubblepupTupleAppreffingeBuilder<
+  TLeftVicken,
+  TRightVickenTuple,
+  TPinbetunfInputTuple
+> => {
+  const buildRightInputHubblepupTupleAppreffinge: RightInputHubblepupTupleAppreffingeBuilder<
+    TLeftVicken,
+    TRightVickenTuple,
+    TPinbetunfInputTuple
+  > = <
+    TRightInputVoictent extends Voictent,
+    TVoictentTuple extends Tuple<TRightInputVoictent>,
+    TZorn extends Zorn,
+  >(
+    rightAppreffinge: RightAppreffinge<
+      TLeftVicken,
+      TRightInputVoictent,
+      TVoictentTuple,
+      TZorn
+    >,
+  ) => {
+    const nextContext = extendInputContext<RightInputHubblepupContext>({
+      inputContext,
+      nextRightInputContext: {
+        gepp: rightAppreffinge.gepp,
+        isWibiz: false,
+        framate: rightAppreffinge.framate,
+        croard: rightAppreffinge.croard,
+        modifyTropoignantInput: hubblepupTupleToHubblepupTuple,
+      },
+    });
+
+    type TNextRightVickenTuple = AppendRightVickenToTuple<
+      TRightVickenTuple,
+      RightHubblepupVicken<TRightInputVoictent, TVoictentTuple, TZorn>
+    >;
+
+    type TNextPinbetunfInputTuple = AppendInputToPinbetunfInputTuple<
+      TPinbetunfInputTuple,
+      RightInputTuple<TRightInputVoictent, TVoictentTuple>
+    >;
+
+    return {
+      andFromHubblepupTuple: buildRightInputHubblepupTupleAppreffingeBuilder<
+        TLeftVicken,
+        TNextRightVickenTuple,
+        TNextPinbetunfInputTuple
+      >(nextContext),
+      andFromOdeshinVoictent: buildRightInputOdeshinVoictentAppreffingeBuilder<
+        TLeftVicken,
+        TNextRightVickenTuple,
+        TNextPinbetunfInputTuple
+      >(nextContext),
+      andFromVoictent: buildRightInputVoictentAppreffingeBuilder<
+        TLeftVicken,
+        TNextRightVickenTuple,
+        TNextPinbetunfInputTuple
+      >(nextContext),
+
+      toGrition: buildOutputGritionAppreffingeBuilder<
+        TLeftVicken,
+        TNextRightVickenTuple,
+        TNextPinbetunfInputTuple
+      >(nextContext),
+      toHubblepup: buildOutputHubblepupAppreffingeBuilder<
+        TLeftVicken,
+        TNextRightVickenTuple,
+        TNextPinbetunfInputTuple
+      >(nextContext),
+      toHubblepupTuple: buildOutputHubblepupTupleAppreffingeBuilder<
+        TLeftVicken,
+        TNextRightVickenTuple,
+        TNextPinbetunfInputTuple
+      >(nextContext),
+    };
+  };
+
+  return buildRightInputHubblepupTupleAppreffinge;
+};
+
+export type RightInputHubblepupTupleAppreffingeBuilderParent<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+> = {
+  andFromHubblepupTuple: RightInputHubblepupTupleAppreffingeBuilder<
+    TLeftVicken,
+    TRightVickenTuple,
+    TPinbetunfInputTuple
+  >;
+};

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/rightInputOdeshinVoictentAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/rightInputOdeshinVoictentAppreffingeBuilder.ts
@@ -1,0 +1,129 @@
+import {
+  AppendRightVickenToTuple,
+  LeftVicken,
+  RightHubblepupVicken,
+  RightVickenTuple,
+} from '../../../type-script-adapter/vicken';
+import { StralineTuple } from '../../../utilities/semantic-types/straline';
+import { Tuple } from '../../../utilities/semantic-types/tuple';
+import {
+  AppendInputToPinbetunfInputTuple,
+  extendInputContext,
+  InputContext,
+  RightInputVoictentContext,
+} from './estinantBuilderContext';
+import {
+  buildOutputHubblepupAppreffingeBuilder,
+  OutputHubblepupAppreffingeBuilderParent,
+} from './outputHubblepupAppreffingeBuilder';
+import { odeshinTupleToGritionTuple } from './tropoignantInputOutputModifier';
+import { OdeshinVoictent } from '../odeshinVoictent';
+import {
+  buildRightInputVoictentAppreffingeBuilder,
+  RightInputVoictentAppreffingeBuilderParent,
+} from './rightInputVoictentAppreffingeBuilder';
+
+type RightAppreffinge<TRightInputVoictent extends OdeshinVoictent> = {
+  gepp: TRightInputVoictent['gepp'];
+};
+
+type NextVickenTuple<
+  TRightVickenTuple extends RightVickenTuple,
+  TRightInputVoictent extends OdeshinVoictent,
+> = AppendRightVickenToTuple<
+  TRightVickenTuple,
+  RightHubblepupVicken<TRightInputVoictent>
+>;
+
+type NextPinbetunfInputTuple<
+  TPinbetunfInputTuple extends StralineTuple,
+  TRightInputVoictent extends OdeshinVoictent,
+> = AppendInputToPinbetunfInputTuple<
+  TPinbetunfInputTuple,
+  // Note: don't use "OdeshinVoictentToGritionTuple" because it makes the final type harder to read :eyeroll:
+  Tuple<TRightInputVoictent['hubblepupTuple'][number]['grition']>
+>;
+
+export type RightInputOdeshinVoictentAppreffingeBuilder<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+> = <TRightInputVoictent extends OdeshinVoictent>(
+  rightAppreffinge: RightAppreffinge<TRightInputVoictent>,
+) => RightInputOdeshinVoictentAppreffingeBuilderParent<
+  TLeftVicken,
+  NextVickenTuple<TRightVickenTuple, TRightInputVoictent>,
+  NextPinbetunfInputTuple<TPinbetunfInputTuple, TRightInputVoictent>
+> &
+  RightInputVoictentAppreffingeBuilderParent<
+    TLeftVicken,
+    NextVickenTuple<TRightVickenTuple, TRightInputVoictent>,
+    NextPinbetunfInputTuple<TPinbetunfInputTuple, TRightInputVoictent>
+  > &
+  OutputHubblepupAppreffingeBuilderParent<
+    TLeftVicken,
+    NextVickenTuple<TRightVickenTuple, TRightInputVoictent>,
+    NextPinbetunfInputTuple<TPinbetunfInputTuple, TRightInputVoictent>
+  >;
+
+export const buildRightInputOdeshinVoictentAppreffingeBuilder = <
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+>(
+  inputContext: InputContext,
+): RightInputOdeshinVoictentAppreffingeBuilder<
+  TLeftVicken,
+  TRightVickenTuple,
+  TPinbetunfInputTuple
+> => {
+  const buildRightInputOdeshinVoictentAppreffinge: RightInputOdeshinVoictentAppreffingeBuilder<
+    TLeftVicken,
+    TRightVickenTuple,
+    TPinbetunfInputTuple
+  > = <TRightInputVoictent extends OdeshinVoictent>(
+    rightAppreffinge: RightAppreffinge<TRightInputVoictent>,
+  ) => {
+    const nextContext = extendInputContext<RightInputVoictentContext>({
+      inputContext,
+      nextRightInputContext: {
+        gepp: rightAppreffinge.gepp,
+        isWibiz: true,
+        modifyTropoignantInput: odeshinTupleToGritionTuple,
+      },
+    });
+
+    return {
+      andFromOdeshinVoictent: buildRightInputOdeshinVoictentAppreffingeBuilder<
+        TLeftVicken,
+        NextVickenTuple<TRightVickenTuple, TRightInputVoictent>,
+        NextPinbetunfInputTuple<TPinbetunfInputTuple, TRightInputVoictent>
+      >(nextContext),
+      andFromVoictent: buildRightInputVoictentAppreffingeBuilder<
+        TLeftVicken,
+        NextVickenTuple<TRightVickenTuple, TRightInputVoictent>,
+        NextPinbetunfInputTuple<TPinbetunfInputTuple, TRightInputVoictent>
+      >(nextContext),
+
+      toHubblepup: buildOutputHubblepupAppreffingeBuilder<
+        TLeftVicken,
+        NextVickenTuple<TRightVickenTuple, TRightInputVoictent>,
+        NextPinbetunfInputTuple<TPinbetunfInputTuple, TRightInputVoictent>
+      >(nextContext),
+    };
+  };
+
+  return buildRightInputOdeshinVoictentAppreffinge;
+};
+
+export type RightInputOdeshinVoictentAppreffingeBuilderParent<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+> = {
+  andFromOdeshinVoictent: RightInputOdeshinVoictentAppreffingeBuilder<
+    TLeftVicken,
+    TRightVickenTuple,
+    TPinbetunfInputTuple
+  >;
+};

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/rightInputVoictentAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/rightInputVoictentAppreffingeBuilder.ts
@@ -1,0 +1,127 @@
+import {
+  AppendRightVickenToTuple,
+  LeftVicken,
+  RightHubblepupVicken,
+  RightVickenTuple,
+} from '../../../type-script-adapter/vicken';
+import { StralineTuple } from '../../../utilities/semantic-types/straline';
+import { Voictent } from '../voictent';
+import {
+  AppendInputToPinbetunfInputTuple,
+  extendInputContext,
+  InputContext,
+  RightInputVoictentContext,
+} from './estinantBuilderContext';
+import {
+  buildOutputHubblepupAppreffingeBuilder,
+  OutputHubblepupAppreffingeBuilderParent,
+} from './outputHubblepupAppreffingeBuilder';
+import {
+  buildOutputHubblepupTupleAppreffingeBuilder,
+  OutputHubblepupTupleAppreffingeBuilderParent,
+} from './outputHubblepupTupleAppreffingeBuilder';
+import { hubblepupTupleToHubblepupTuple } from './tropoignantInputOutputModifier';
+
+type RightAppreffinge<TRightInputVoictent extends Voictent> = {
+  gepp: TRightInputVoictent['gepp'];
+};
+
+type NextVickenTuple<
+  TRightVickenTuple extends RightVickenTuple,
+  TRightInputVoictent extends Voictent,
+> = AppendRightVickenToTuple<
+  TRightVickenTuple,
+  RightHubblepupVicken<TRightInputVoictent>
+>;
+
+type NextPinbetunfInputTuple<
+  TPinbetunfInputTuple extends StralineTuple,
+  TRightInputVoictent extends Voictent,
+> = AppendInputToPinbetunfInputTuple<
+  TPinbetunfInputTuple,
+  TRightInputVoictent['hubblepupTuple']
+>;
+
+export type RightInputVoictentAppreffingeBuilder<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+> = <TRightInputVoictent extends Voictent>(
+  rightAppreffinge: RightAppreffinge<TRightInputVoictent>,
+) => RightInputVoictentAppreffingeBuilderParent<
+  TLeftVicken,
+  NextVickenTuple<TRightVickenTuple, TRightInputVoictent>,
+  NextPinbetunfInputTuple<TPinbetunfInputTuple, TRightInputVoictent>
+> &
+  OutputHubblepupAppreffingeBuilderParent<
+    TLeftVicken,
+    NextVickenTuple<TRightVickenTuple, TRightInputVoictent>,
+    NextPinbetunfInputTuple<TPinbetunfInputTuple, TRightInputVoictent>
+  > &
+  OutputHubblepupTupleAppreffingeBuilderParent<
+    TLeftVicken,
+    NextVickenTuple<TRightVickenTuple, TRightInputVoictent>,
+    NextPinbetunfInputTuple<TPinbetunfInputTuple, TRightInputVoictent>
+  >;
+
+export const buildRightInputVoictentAppreffingeBuilder = <
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+>(
+  inputContext: InputContext,
+): RightInputVoictentAppreffingeBuilder<
+  TLeftVicken,
+  TRightVickenTuple,
+  TPinbetunfInputTuple
+> => {
+  const buildRightInputHubblepupAppreffinge: RightInputVoictentAppreffingeBuilder<
+    TLeftVicken,
+    TRightVickenTuple,
+    TPinbetunfInputTuple
+  > = <TRightInputVoictent extends Voictent>(
+    rightAppreffinge: RightAppreffinge<TRightInputVoictent>,
+  ) => {
+    const nextContext = extendInputContext<RightInputVoictentContext>({
+      inputContext,
+      nextRightInputContext: {
+        gepp: rightAppreffinge.gepp,
+        isWibiz: true,
+        modifyTropoignantInput: hubblepupTupleToHubblepupTuple,
+      },
+    });
+
+    return {
+      andFromVoictent: buildRightInputVoictentAppreffingeBuilder<
+        TLeftVicken,
+        NextVickenTuple<TRightVickenTuple, TRightInputVoictent>,
+        NextPinbetunfInputTuple<TPinbetunfInputTuple, TRightInputVoictent>
+      >(nextContext),
+
+      toHubblepup: buildOutputHubblepupAppreffingeBuilder<
+        TLeftVicken,
+        NextVickenTuple<TRightVickenTuple, TRightInputVoictent>,
+        NextPinbetunfInputTuple<TPinbetunfInputTuple, TRightInputVoictent>
+      >(nextContext),
+      toHubblepupTuple: buildOutputHubblepupTupleAppreffingeBuilder<
+        TLeftVicken,
+        NextVickenTuple<TRightVickenTuple, TRightInputVoictent>,
+        NextPinbetunfInputTuple<TPinbetunfInputTuple, TRightInputVoictent>
+      >(nextContext),
+    };
+  };
+
+  return buildRightInputHubblepupAppreffinge;
+};
+
+export type RightInputVoictentAppreffingeBuilderParent<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TPinbetunfInputTuple extends StralineTuple,
+> = {
+  andFromVoictent: RightInputVoictentAppreffingeBuilder<
+    TLeftVicken,
+    TRightVickenTuple,
+    TPinbetunfInputTuple
+  >;
+};

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/tropoignantInputOutputModifier.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/tropoignantInputOutputModifier.ts
@@ -1,0 +1,133 @@
+import { Hubblepup } from '../../../core/hubblepup';
+import { Quirm, QuirmList } from '../../../core/quirm';
+import { Gepp } from '../../../type-script-adapter/gepp';
+import { HubblepupTuple } from '../../../type-script-adapter/hubblepup';
+import { StringZorn } from '../../../utilities/semantic-types/zorn';
+import { Grition, GritionTuple } from '../grition';
+import { Odeshin, OdeshinTuple } from '../odeshin';
+import {
+  AggregatedOutput,
+  AggregatedOutputContext,
+  ConstituentResultNormalizer,
+  InputOutputContext,
+  PinbetunfOutputAggregator,
+} from './estinantBuilderContext';
+
+export const hubblepupTupleToHubblepupTuple = (
+  inputTuple: HubblepupTuple,
+): HubblepupTuple => inputTuple;
+
+export const odeshinTupleToGritionTuple = (
+  inputTuple: OdeshinTuple,
+): GritionTuple => inputTuple.map((odeshin) => odeshin.grition);
+
+export const hubblepupToHubblepup = (input: Hubblepup): Hubblepup => input;
+
+export const odeshinToGrition = (input: Odeshin): Grition => input.grition;
+
+export const voidToQuirmList = (): QuirmList => [];
+
+export const buildPinbetunfOutputAggregator = (
+  gepp: Gepp,
+): PinbetunfOutputAggregator => {
+  const aggregatePinbetunfOutput: PinbetunfOutputAggregator = (
+    modifiedOutput: unknown,
+  ) => {
+    return {
+      [gepp]: modifiedOutput,
+    };
+  };
+  return aggregatePinbetunfOutput;
+};
+
+export const buildOutputHubblepupTupleNormalizer = (
+  gepp: Gepp,
+): ConstituentResultNormalizer => {
+  const normalizeHubblepupTuple: ConstituentResultNormalizer = (
+    leftInput,
+    aggregatedOutput,
+  ) => {
+    const hubblepupTuple = aggregatedOutput[gepp] as HubblepupTuple;
+    const quirmList = hubblepupTuple.map<Quirm>((hubblepup) => {
+      return {
+        gepp,
+        hubblepup,
+      };
+    });
+
+    return quirmList;
+  };
+
+  return normalizeHubblepupTuple;
+};
+
+export const buildOutputHubblepupNormalizer = (
+  gepp: Gepp,
+): ConstituentResultNormalizer => {
+  const normalizeHubblepup: ConstituentResultNormalizer = (
+    leftInput,
+    aggregatedOutput,
+  ) => {
+    const hubblepup = aggregatedOutput[gepp] as Hubblepup;
+    const quirm: Quirm = {
+      gepp,
+      hubblepup,
+    };
+
+    return [quirm];
+  };
+
+  return normalizeHubblepup;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ZornAccessor<TLeftInput = any> = (
+  leftInput: TLeftInput,
+) => StringZorn;
+
+export const buildOutputGritionNormalizer = (
+  gepp: Gepp,
+  getZorn: ZornAccessor,
+): ConstituentResultNormalizer => {
+  const normalizeGrition: ConstituentResultNormalizer = (
+    leftInput,
+    aggregatedOutput,
+  ) => {
+    const zorn = getZorn(leftInput);
+    const grition = aggregatedOutput[gepp];
+    const hubblepup: Hubblepup = {
+      zorn,
+      grition,
+    };
+    const quirm: Quirm = {
+      gepp,
+      hubblepup,
+    };
+
+    return [quirm];
+  };
+
+  return normalizeGrition;
+};
+
+export const extendInputOutputContext = (
+  { inputContext, outputContext }: InputOutputContext,
+  normalizeNextConstituentResult: ConstituentResultNormalizer,
+): InputOutputContext => {
+  const nextOutputContext: AggregatedOutputContext = {
+    aggregatePinbetunfOutput: (aggregatedOutput: AggregatedOutput) => {
+      return aggregatedOutput;
+    },
+    constituentResultNormalizerList: [
+      ...outputContext.constituentResultNormalizerList,
+      normalizeNextConstituentResult,
+    ],
+  };
+
+  const nextInputOutputContext = {
+    inputContext,
+    outputContext: nextOutputContext,
+  };
+
+  return nextInputOutputContext;
+};

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/odeshin.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/odeshin.ts
@@ -1,6 +1,8 @@
 import { Hubblepup } from '../../type-script-adapter/hubblepup';
+import { Tuple } from '../../utilities/semantic-types/tuple';
 import { Grition } from './grition';
 
+// TODO: don't parametrize "zorn", so that this is way simpler to work with
 export type Odeshin<
   TZorn extends string = string,
   TGrition extends Grition = Grition,
@@ -8,6 +10,8 @@ export type Odeshin<
   zorn: TZorn;
   grition: TGrition;
 }>;
+
+export type OdeshinTuple = Tuple<Odeshin>;
 
 export type OdeshinFromGrition<TGrition extends Grition = Grition> = Odeshin<
   string,

--- a/packages/voictents-and-estinants-engine/src/custom/debugger/quirmDebugger.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/debugger/quirmDebugger.ts
@@ -68,7 +68,7 @@ export const buildQuirmDebugger = (
         ? escapePathSeparator(hubblepup.zorn)
         : uuid.v4();
 
-      writeHubblepupFile(gepp, fileName, '.yml', serialize(hubblepup));
+      writeHubblepupFile(gepp, fileName, 'yml', serialize(hubblepup));
     },
   };
 

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/engineProgramPartsCortmum.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/engineProgramPartsCortmum.ts
@@ -1,7 +1,4 @@
 import { TSESTree, AST_NODE_TYPES } from '@typescript-eslint/typescript-estree';
-import { buildCortmum } from '../../../type-script-adapter/estinant/cortmum';
-import { Vicken } from '../../../type-script-adapter/vicken';
-import { Vition } from '../../../type-script-adapter/vition';
 import { isArrayExpressionOfIdentifiers } from '../../../utilities/type-script-ast/isArrayExpressionOfIdentifiers';
 import {
   ObjectExpressionWithIdentifierProperties,
@@ -9,6 +6,7 @@ import {
   IdentifiableProperty,
 } from '../../../utilities/type-script-ast/isObjectLiteralExpressionWithIdentifierProperties';
 import { isSpecificExpressionStatement } from '../../../utilities/type-script-ast/isSpecificExpressionStatement';
+import { buildEstinant } from '../../adapter/estinant-builder/estinantBuilder';
 import {
   ParsedTypeScriptFileVoictent,
   PARSED_TYPE_SCRIPT_FILE_GEPP,
@@ -62,155 +60,149 @@ type ImportedEstinant = {
   fileImport: LocalTypeScriptFileImport;
 };
 
-export const engineProgramPartsCortmum = buildCortmum<
-  Vition<
-    ParsedTypeScriptFileVoictent,
-    [
-      Vicken<TypeScriptFileVoictent, [TypeScriptFileVoictent], string>,
-      Vicken<
-        TypeScriptFileImportListVoictent,
-        [TypeScriptFileImportListVoictent],
-        string
-      >,
-      Vicken<
-        EngineFunctionConfigurationVoictent,
-        [EngineFunctionConfigurationVoictent],
-        ''
-      >,
-    ]
-  >,
-  [EngineProgramVoictent, EngineEstinantVoictent]
->({
-  leftGepp: PARSED_TYPE_SCRIPT_FILE_GEPP,
-  rightAppreffingeTuple: [
-    {
-      gepp: TYPE_SCRIPT_FILE_GEPP,
-      croard: (rightInput): string => rightInput.zorn,
-      framate: (leftInput) => [leftInput.zorn] as const,
-    },
-    {
-      gepp: TYPE_SCRIPT_FILE_IMPORT_LIST_GEPP,
-      croard: (rightInput): string => rightInput.zorn,
-      framate: (leftInput) => [leftInput.zorn] as const,
-    },
-    {
-      gepp: ENGINE_FUNCTION_CONFIGURATION_GEPP,
-      croard: () => '' as const,
-      framate: () => [''] as const,
-    },
-  ],
-  outputGeppTuple: [ENGINE_PROGRAM_GEPP, ENGINE_ESTINANT_GEPP],
-  pinbe: (
-    leftInput,
-    [{ grition: typeScriptFile }],
-    [{ grition: importList }],
-    [engineFunctionConfiguration],
-  ) => {
-    const parsedFile = leftInput.grition;
+export const getEngineProgramParts = buildEstinant()
+  .fromHubblepup<ParsedTypeScriptFileVoictent>({
+    gepp: PARSED_TYPE_SCRIPT_FILE_GEPP,
+  })
+  .andFromGritionTuple<
+    TypeScriptFileVoictent,
+    [TypeScriptFileVoictent],
+    string
+  >({
+    gepp: TYPE_SCRIPT_FILE_GEPP,
+    framate: (leftInput) => [leftInput.zorn],
+    croard: (rightInput) => rightInput.zorn,
+  })
+  .andFromGritionTuple<
+    TypeScriptFileImportListVoictent,
+    [TypeScriptFileImportListVoictent],
+    string
+  >({
+    gepp: TYPE_SCRIPT_FILE_IMPORT_LIST_GEPP,
+    framate: (leftInput) => [leftInput.zorn],
+    croard: (rightInput) => rightInput.zorn,
+  })
+  .andFromVoictent<EngineFunctionConfigurationVoictent>({
+    gepp: ENGINE_FUNCTION_CONFIGURATION_GEPP,
+  })
+  .toHubblepupTuple<EngineProgramVoictent>({
+    gepp: ENGINE_PROGRAM_GEPP,
+  })
+  .andToHubblepupTuple<EngineEstinantVoictent>({
+    gepp: ENGINE_ESTINANT_GEPP,
+  })
+  .onPinbe(
+    (
+      leftInput,
+      [typeScriptFile],
+      [importList],
+      [engineFunctionConfiguration],
+    ) => {
+      const parsedFile = leftInput.grition;
 
-    const hasEngineFunctionImport = importList.some(
-      (fileImport) =>
-        fileImport.typeName === TypeScriptFileImportTypeName.Local &&
-        fileImport.filePath === engineFunctionConfiguration.filePath &&
-        fileImport.specifierList.some(
-          (specifier) =>
-            specifier === engineFunctionConfiguration.exportedIdentifier,
-        ),
-    );
-
-    if (!hasEngineFunctionImport) {
-      return {
-        [ENGINE_PROGRAM_GEPP]: [],
-        [ENGINE_ESTINANT_GEPP]: [],
-      };
-    }
-
-    const engineCallExpressionStatement = parsedFile.program.body.find(
-      (statement): statement is EngineCallExpressionStatement =>
-        isEngineCallExpressionStatement(
-          statement,
-          engineFunctionConfiguration.exportedIdentifier,
-        ),
-    );
-
-    const engineCallExpressionPropertyList: IdentifiableProperty[] =
-      engineCallExpressionStatement?.expression.arguments[0].properties ?? [];
-
-    const estinantListProperty = engineCallExpressionPropertyList.find(
-      (property) =>
-        property.key.name ===
-        engineFunctionConfiguration.estinantListKeyIdentifierName,
-    );
-
-    const estinantListValueNode = estinantListProperty?.value;
-
-    const estinantNodeList: TSESTree.Identifier[] =
-      isArrayExpressionOfIdentifiers(estinantListValueNode)
-        ? estinantListValueNode.elements
-        : [];
-
-    const estinantIdentifierList = estinantNodeList.map(
-      (identifier) => identifier.name,
-    );
-
-    const fileImportsByImportedIdentifier = new Map<
-      string,
-      TypeScriptFileImport
-    >();
-    importList
-      .flatMap((fileImport) => {
-        return fileImport.specifierList.map((specifier) => ({
-          fileImport,
-          specifier,
-        }));
-      })
-      .forEach(({ fileImport, specifier }) => {
-        fileImportsByImportedIdentifier.set(specifier, fileImport);
-      });
-
-    const importedEstinantList = estinantIdentifierList
-      .map((identifier) => {
-        const fileImport = fileImportsByImportedIdentifier.get(identifier);
-        return {
-          identifier,
-          fileImport,
-        };
-      })
-      .filter(
-        (importedEstinant): importedEstinant is ImportedEstinant =>
-          importedEstinant.fileImport !== undefined &&
-          importedEstinant.fileImport.typeName ===
-            TypeScriptFileImportTypeName.Local,
+      const hasEngineFunctionImport = importList.some(
+        (fileImport) =>
+          fileImport.typeName === TypeScriptFileImportTypeName.Local &&
+          fileImport.filePath === engineFunctionConfiguration.filePath &&
+          fileImport.specifierList.some(
+            (specifier) =>
+              specifier === engineFunctionConfiguration.exportedIdentifier,
+          ),
       );
 
-    const programName = typeScriptFile.inMemoryFileName.kebabCase;
+      if (!hasEngineFunctionImport) {
+        return {
+          [ENGINE_PROGRAM_GEPP]: [],
+          [ENGINE_ESTINANT_GEPP]: [],
+        };
+      }
 
-    const outputEstinantList = importedEstinantList.map<EngineEstinantOdeshin>(
-      (importedEstinant) => ({
-        zorn: getEngineEstinantIdentifier(
-          programName,
-          importedEstinant.identifier,
-        ),
+      const engineCallExpressionStatement = parsedFile.program.body.find(
+        (statement): statement is EngineCallExpressionStatement =>
+          isEngineCallExpressionStatement(
+            statement,
+            engineFunctionConfiguration.exportedIdentifier,
+          ),
+      );
+
+      const engineCallExpressionPropertyList: IdentifiableProperty[] =
+        engineCallExpressionStatement?.expression.arguments[0].properties ?? [];
+
+      const estinantListProperty = engineCallExpressionPropertyList.find(
+        (property) =>
+          property.key.name ===
+          engineFunctionConfiguration.estinantListKeyIdentifierName,
+      );
+
+      const estinantListValueNode = estinantListProperty?.value;
+
+      const estinantNodeList: TSESTree.Identifier[] =
+        isArrayExpressionOfIdentifiers(estinantListValueNode)
+          ? estinantListValueNode.elements
+          : [];
+
+      const estinantIdentifierList = estinantNodeList.map(
+        (identifier) => identifier.name,
+      );
+
+      const fileImportsByImportedIdentifier = new Map<
+        string,
+        TypeScriptFileImport
+      >();
+      importList
+        .flatMap((fileImport) => {
+          return fileImport.specifierList.map((specifier) => ({
+            fileImport,
+            specifier,
+          }));
+        })
+        .forEach(({ fileImport, specifier }) => {
+          fileImportsByImportedIdentifier.set(specifier, fileImport);
+        });
+
+      const importedEstinantList = estinantIdentifierList
+        .map((identifier) => {
+          const fileImport = fileImportsByImportedIdentifier.get(identifier);
+          return {
+            identifier,
+            fileImport,
+          };
+        })
+        .filter(
+          (importedEstinant): importedEstinant is ImportedEstinant =>
+            importedEstinant.fileImport !== undefined &&
+            importedEstinant.fileImport.typeName ===
+              TypeScriptFileImportTypeName.Local,
+        );
+
+      const programName = typeScriptFile.inMemoryFileName.kebabCase;
+
+      const outputEstinantList =
+        importedEstinantList.map<EngineEstinantOdeshin>((importedEstinant) => ({
+          zorn: getEngineEstinantIdentifier(
+            programName,
+            importedEstinant.identifier,
+          ),
+          grition: {
+            programName,
+            estinantName: importedEstinant.identifier,
+            estinantFilePath: importedEstinant.fileImport.filePath,
+            exportedIdentifierName: importedEstinant.identifier,
+          },
+        }));
+
+      const outputProgram: EngineProgramOdeshin = {
+        zorn: leftInput.zorn,
         grition: {
           programName,
-          estinantName: importedEstinant.identifier,
-          estinantFilePath: importedEstinant.fileImport.filePath,
-          exportedIdentifierName: importedEstinant.identifier,
+          estinantIdentifierList: outputEstinantList.map(({ zorn }) => zorn),
         },
-      }),
-    );
+      };
 
-    const outputProgram: EngineProgramOdeshin = {
-      zorn: leftInput.zorn,
-      grition: {
-        programName,
-        estinantIdentifierList: outputEstinantList.map(({ zorn }) => zorn),
-      },
-    };
-
-    return {
-      [ENGINE_PROGRAM_GEPP]: [outputProgram],
-      [ENGINE_ESTINANT_GEPP]: outputEstinantList,
-    };
-  },
-});
+      return {
+        [ENGINE_PROGRAM_GEPP]: [outputProgram],
+        [ENGINE_ESTINANT_GEPP]: outputEstinantList,
+      };
+    },
+  )
+  .assemble();

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/engineProgramRendererWortinator.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/engineProgramRendererWortinator.ts
@@ -1,5 +1,5 @@
 import * as uuid from 'uuid';
-import { buildOnama } from '../../../type-script-adapter/estinant/onama';
+import { buildEstinant } from '../../adapter/estinant-builder/estinantBuilder';
 import {
   OutputFile,
   OutputFileVoictent,
@@ -36,13 +36,14 @@ type IdentifiableRenderableNode = {
   right: IdentifiableEntityNode;
 };
 
-export const engineProgramTreeToOutputFile = buildOnama<
-  EngineProgramTreeNodeVoictent,
-  OutputFileVoictent
->({
-  inputGepp: ENGINE_PROGRAM_TREE_NODE_GEPP,
-  outputGepp: OUTPUT_FILE_GEPP,
-  pinbe: ({ grition: input }) => {
+export const constructEngineProgramTreeOutputFile = buildEstinant()
+  .fromGrition<EngineProgramTreeNodeVoictent>({
+    gepp: ENGINE_PROGRAM_TREE_NODE_GEPP,
+  })
+  .toHubblepup<OutputFileVoictent>({
+    gepp: OUTPUT_FILE_GEPP,
+  })
+  .onPinbe((input) => {
     const endEntityNode: EntityNode = {
       typeName: EntityNodeTypeName.VOICTENT,
       name: 'END',
@@ -178,5 +179,5 @@ ${allLineList.join('\n')}
     };
 
     return outputFile;
-  },
-});
+  })
+  .assemble();

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/estinant-call-expression-parameter/estinantCallExpressionParameterCortmum.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/estinant-call-expression-parameter/estinantCallExpressionParameterCortmum.ts
@@ -1,8 +1,20 @@
-import { AST_NODE_TYPES } from '@typescript-eslint/typescript-estree';
-import { buildCortmum } from '../../../../type-script-adapter/estinant/cortmum';
-import { Vicken } from '../../../../type-script-adapter/vicken';
-import { Vition } from '../../../../type-script-adapter/vition';
-import { isIdentifiableCallExpression } from '../../../../utilities/type-script-ast/isIdentifiableCallExpression';
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/typescript-estree';
+import { splitList } from '../../../../utilities/splitList';
+import {
+  flattenCallExpressionChain,
+  FlattenedCallExpressionOrError,
+} from '../../../../utilities/type-script-ast/flattenIdentifiableCallExpressionChain';
+import { isCallExpression } from '../../../../utilities/type-script-ast/isCallExpression';
+import {
+  IdentifiableCallExpression,
+  isIdentifiableCallExpression,
+} from '../../../../utilities/type-script-ast/isIdentifiableCallExpression';
+import {
+  IdentifiableTypeScriptTypeReference,
+  isIdentifiableTypeScriptTypeReference,
+} from '../../../../utilities/type-script-ast/isIdentifiableTypeScriptTypeReference';
+import { IdentifiableMemberExpressionCallExpression } from '../../../../utilities/type-script-ast/isMemberExpressionCallExpression';
+import { buildEstinant } from '../../../adapter/estinant-builder/estinantBuilder';
 import { ErrorVoictent, ERROR_GEPP } from '../../error/error';
 import {
   ProgramBodyDeclarationsByIdentifierVoictent,
@@ -20,6 +32,16 @@ import { isOnamaCallExpression } from '../estinant-call-expression/onamaCallExpr
 import { isWattlectionCallExpression } from '../estinant-call-expression/wattlectionCallExpression';
 import { isWortinatorCallExpression } from '../estinant-call-expression/wortinatorCallExpression';
 import {
+  EstinantInput,
+  EstinantInputListVoictent,
+  ESTINANT_INPUT_LIST_GEPP,
+} from '../estinant-input-output/estinantInputList';
+import {
+  EstinantOutput,
+  EstinantOutputListVoictent,
+  ESTINANT_OUTPUT_LIST_GEPP,
+} from '../estinant-input-output/estinantOutputList';
+import {
   EstinantCallExpressionInputParameterVoictent,
   ESTINANT_CALL_EXPRESSION_INPUT_PARAMETER_GEPP,
 } from './estinantCallExpressionInputParameter';
@@ -32,65 +54,371 @@ import {
   ESTINANT_INPUT_OUTPUT_PARENT_GEPP,
 } from './estinantInputOutputParent';
 
-export const estinantCallExpressionParameterCortmum = buildCortmum<
-  Vition<
-    EngineEstinantVoictent,
-    [
-      Vicken<
-        ProgramBodyDeclarationsByIdentifierVoictent,
-        [ProgramBodyDeclarationsByIdentifierVoictent],
-        string
-      >,
-    ]
-  >,
-  [
-    EstinantInputOutputParentVoictent,
-    EstinantCallExpressionInputParameterVoictent,
-    EstinantCallExpressionOutputParameterVoictent,
-    ErrorVoictent,
-  ]
->({
-  leftGepp: ENGINE_ESTINANT_GEPP,
-  rightAppreffingeTuple: [
-    {
-      gepp: PROGRAM_BODY_STATEMENTS_BY_IDENTIFIER_GEPP,
-      croard: (rightInput): string => rightInput.zorn,
-      framate: (leftInput) => [leftInput.grition.estinantFilePath] as const,
-    },
-  ],
-  outputGeppTuple: [
-    ESTINANT_INPUT_OUTPUT_PARENT_GEPP,
-    ESTINANT_CALL_EXPRESSION_INPUT_PARAMETER_GEPP,
-    ESTINANT_CALL_EXPRESSION_OUTPUT_PARAMETER_GEPP,
-    ERROR_GEPP,
-  ],
-  pinbe: (engineEstinantInput, [{ grition: bodyDeclarationsByIdentifier }]) => {
-    const engineEstinant = engineEstinantInput.grition;
+export const getEstinantCallExpressionParts = buildEstinant()
+  .fromHubblepup<EngineEstinantVoictent>({
+    gepp: ENGINE_ESTINANT_GEPP,
+  })
+  .andFromHubblepupTuple<
+    ProgramBodyDeclarationsByIdentifierVoictent,
+    [ProgramBodyDeclarationsByIdentifierVoictent],
+    string
+  >({
+    gepp: PROGRAM_BODY_STATEMENTS_BY_IDENTIFIER_GEPP,
+    croard: (rightInput) => rightInput.zorn,
+    framate: (leftInput) => [leftInput.grition.estinantFilePath],
+  })
+  .toHubblepupTuple<EstinantInputOutputParentVoictent>({
+    gepp: ESTINANT_INPUT_OUTPUT_PARENT_GEPP,
+  })
+  .andToHubblepupTuple<EstinantCallExpressionInputParameterVoictent>({
+    gepp: ESTINANT_CALL_EXPRESSION_INPUT_PARAMETER_GEPP,
+  })
+  .andToHubblepupTuple<EstinantCallExpressionOutputParameterVoictent>({
+    gepp: ESTINANT_CALL_EXPRESSION_OUTPUT_PARAMETER_GEPP,
+  })
+  .andToHubblepupTuple<EstinantInputListVoictent>({
+    gepp: ESTINANT_INPUT_LIST_GEPP,
+  })
+  .andToHubblepupTuple<EstinantOutputListVoictent>({
+    gepp: ESTINANT_OUTPUT_LIST_GEPP,
+  })
+  .andToHubblepupTuple<ErrorVoictent>({
+    gepp: ERROR_GEPP,
+  })
+  .onPinbe(
+    (engineEstinantInput, [{ grition: bodyDeclarationsByIdentifier }]) => {
+      const errorZorn = `estinantCallExpressionParameterCortmum/${engineEstinantInput.zorn}`;
 
-    const node = bodyDeclarationsByIdentifier.get(
-      engineEstinant.exportedIdentifierName,
-    );
-
-    const initExpression =
-      node?.type === AST_NODE_TYPES.VariableDeclarator ? node.init : null;
-
-    const callExpression = isIdentifiableCallExpression(initExpression)
-      ? initExpression
-      : null;
-
-    if (
-      isCortmumCallExpression(callExpression) ||
-      isMentursectionCallExpression(callExpression) ||
-      isOnamaCallExpression(callExpression) ||
-      isMattomerCallExpression(callExpression) ||
-      isWattlectionCallExpression(callExpression) ||
-      isWortinatorCallExpression(callExpression) ||
-      isDisatingerCallExpression(callExpression)
-    ) {
+      const engineEstinant = engineEstinantInput.grition;
       const { programName, estinantName } = engineEstinant;
 
-      const inputListIdentifier = `${engineEstinantInput.zorn}/input`;
-      const outputListIdentifier = `${engineEstinantInput.zorn}/output`;
+      const node = bodyDeclarationsByIdentifier.get(
+        engineEstinant.exportedIdentifierName,
+      );
+
+      const initExpression =
+        node?.type === AST_NODE_TYPES.VariableDeclarator ? node.init : null;
+
+      const callExpression = isCallExpression(initExpression)
+        ? initExpression
+        : null;
+
+      if (callExpression === null) {
+        return {
+          [ESTINANT_INPUT_OUTPUT_PARENT_GEPP]: [],
+          [ESTINANT_CALL_EXPRESSION_INPUT_PARAMETER_GEPP]: [],
+          [ESTINANT_CALL_EXPRESSION_OUTPUT_PARAMETER_GEPP]: [],
+          [ESTINANT_INPUT_LIST_GEPP]: [],
+          [ESTINANT_OUTPUT_LIST_GEPP]: [],
+          [ERROR_GEPP]: [
+            {
+              zorn: errorZorn,
+              grition: {
+                message: 'Export declaration is missing a call expression',
+                hasNode: node !== undefined,
+                hasInitExpression: initExpression !== null,
+                hasCallExpression: callExpression !== null,
+                initExpression,
+              },
+            },
+          ],
+        };
+      }
+
+      if (
+        isIdentifiableCallExpression(callExpression) &&
+        (isCortmumCallExpression(callExpression) ||
+          isMentursectionCallExpression(callExpression) ||
+          isOnamaCallExpression(callExpression) ||
+          isMattomerCallExpression(callExpression) ||
+          isWattlectionCallExpression(callExpression) ||
+          isWortinatorCallExpression(callExpression) ||
+          isDisatingerCallExpression(callExpression))
+      ) {
+        const inputListIdentifier = `${engineEstinantInput.zorn}/input`;
+        const outputListIdentifier = `${engineEstinantInput.zorn}/output`;
+
+        return {
+          [ESTINANT_INPUT_OUTPUT_PARENT_GEPP]: [
+            {
+              zorn: engineEstinantInput.zorn,
+              grition: {
+                programName,
+                estinantName,
+                inputListIdentifier,
+                outputListIdentifier,
+              },
+            },
+          ],
+          [ESTINANT_CALL_EXPRESSION_INPUT_PARAMETER_GEPP]: [
+            {
+              zorn: inputListIdentifier,
+              grition: {
+                programName,
+                estinantName,
+                isInput: true,
+                node: callExpression.typeParameters.params[0],
+              },
+            },
+          ],
+          [ESTINANT_CALL_EXPRESSION_OUTPUT_PARAMETER_GEPP]: [
+            {
+              zorn: outputListIdentifier,
+              grition: {
+                programName,
+                estinantName,
+                isInput: false,
+                node: callExpression.typeParameters.params[1],
+              },
+            },
+          ],
+          [ESTINANT_INPUT_LIST_GEPP]: [],
+          [ESTINANT_OUTPUT_LIST_GEPP]: [],
+          [ERROR_GEPP]: [],
+        };
+      }
+
+      // const estinantBuilderCallExpression = isSpecificIdentifiableCallExpression(
+      //   callExpression,
+      //   // TODO:
+      //   'assemble',
+      // )
+      //   ? callExpression
+      //   : null;
+
+      const flattenedCallExpressionAndErrorList =
+        flattenCallExpressionChain(callExpression);
+
+      const errorList: Error[] = [];
+
+      const flattenedCallExpressionList: Exclude<
+        FlattenedCallExpressionOrError,
+        Error
+      >[] = [];
+
+      splitList({
+        list: flattenedCallExpressionAndErrorList,
+        isElementA: (element): element is Error => element instanceof Error,
+        accumulatorA: errorList,
+        accumulatorB: flattenedCallExpressionList,
+      });
+
+      if (errorList.length > 0) {
+        return {
+          [ESTINANT_INPUT_OUTPUT_PARENT_GEPP]: [],
+          [ESTINANT_CALL_EXPRESSION_INPUT_PARAMETER_GEPP]: [],
+          [ESTINANT_CALL_EXPRESSION_OUTPUT_PARAMETER_GEPP]: [],
+          [ESTINANT_INPUT_LIST_GEPP]: [],
+          [ESTINANT_OUTPUT_LIST_GEPP]: [],
+          [ERROR_GEPP]: errorList.map((error, index) => {
+            return {
+              zorn: `${errorZorn}/${index}`,
+              grition: error,
+            };
+          }),
+        };
+      }
+
+      // const functionNameList = flattenedCallExpressionList.map((expression) => {
+      //   if (expression.type === AST_NODE_TYPES.CallExpression) {
+      //     return expression.callee.name;
+      //   }
+
+      //   return expression.property.name;
+      // });
+
+      // const inputOutputCallExpressionList = flattenedCallExpressionList.slice(
+      //   1,
+      //   -2,
+      // );
+
+      type ParsedExpression1 = {
+        functionName: string;
+        isInput: boolean | null;
+        typeNode: TSESTree.TypeNode | null;
+      };
+
+      type ParsedExpression2 = {
+        functionName: string;
+        isInput: boolean;
+        typeNode: IdentifiableTypeScriptTypeReference;
+      };
+
+      const getTypeParameterList = (
+        expression:
+          | IdentifiableCallExpression
+          | IdentifiableMemberExpressionCallExpression
+          | undefined,
+      ): TSESTree.TypeNode[] | undefined => {
+        if (expression === undefined) {
+          return undefined;
+        }
+
+        if (expression.type === AST_NODE_TYPES.CallExpression) {
+          return expression.typeParameters?.params;
+        }
+
+        return expression.object.typeParameters?.params;
+      };
+
+      const parsedFlattenedCallExpressionList =
+        flattenedCallExpressionList.map<ParsedExpression1>(
+          (expression, index) => {
+            // TODO: clean up the logic for a flattened call expression list. The type parameters are on the next element's node which is confusing
+            const typeParameterNodeList = getTypeParameterList(
+              flattenedCallExpressionList[index + 1],
+            );
+
+            const typeNode: TSESTree.TypeNode | null =
+              (typeParameterNodeList ?? [])[0] ?? null;
+
+            let functionName: string;
+            if (expression.type === AST_NODE_TYPES.CallExpression) {
+              functionName = expression.callee.name;
+            } else {
+              functionName = expression.property.name;
+            }
+
+            let isInput: boolean | null;
+            if (
+              functionName.startsWith('from') ||
+              functionName.startsWith('andFrom')
+            ) {
+              isInput = true;
+            } else if (
+              functionName.startsWith('to') ||
+              functionName.startsWith('andTo')
+            ) {
+              isInput = false;
+            } else {
+              isInput = null;
+            }
+
+            return {
+              functionName,
+              isInput,
+              typeNode,
+            };
+          },
+        );
+
+      if (
+        parsedFlattenedCallExpressionList[0].functionName !== buildEstinant.name
+      ) {
+        return {
+          [ESTINANT_INPUT_OUTPUT_PARENT_GEPP]: [],
+          [ESTINANT_CALL_EXPRESSION_INPUT_PARAMETER_GEPP]: [],
+          [ESTINANT_CALL_EXPRESSION_OUTPUT_PARAMETER_GEPP]: [],
+          [ESTINANT_INPUT_LIST_GEPP]: [],
+          [ESTINANT_OUTPUT_LIST_GEPP]: [],
+          [ERROR_GEPP]: [
+            {
+              zorn: errorZorn,
+              grition: {
+                message: `Call expression chain does not start with "${buildEstinant.name}"`,
+                parsedFlattenedCallExpressionList,
+              },
+            },
+          ],
+        };
+      }
+
+      // TODO: tie these function names back to the estinant builder function names
+      if (
+        parsedFlattenedCallExpressionList[
+          parsedFlattenedCallExpressionList.length - 2
+        ]?.functionName !== 'onPinbe' ||
+        parsedFlattenedCallExpressionList[
+          parsedFlattenedCallExpressionList.length - 1
+        ]?.functionName !== 'assemble'
+      ) {
+        return {
+          [ESTINANT_INPUT_OUTPUT_PARENT_GEPP]: [],
+          [ESTINANT_CALL_EXPRESSION_INPUT_PARAMETER_GEPP]: [],
+          [ESTINANT_CALL_EXPRESSION_OUTPUT_PARAMETER_GEPP]: [],
+          [ESTINANT_INPUT_LIST_GEPP]: [],
+          [ESTINANT_OUTPUT_LIST_GEPP]: [],
+          [ERROR_GEPP]: [
+            {
+              zorn: errorZorn,
+              grition: {
+                message:
+                  'Estinant builder call expression chain does not end in "onPinbe" and on "assemble"',
+                parsedFlattenedCallExpressionList,
+              },
+            },
+          ],
+        };
+      }
+
+      const inputOutputCallExpressionList: ParsedExpression2[] = [];
+      const errorParsedExpressionList: ParsedExpression1[] = [];
+      splitList({
+        list: parsedFlattenedCallExpressionList.slice(1, -2),
+        isElementA: (element): element is ParsedExpression2 =>
+          element.isInput !== null &&
+          isIdentifiableTypeScriptTypeReference(element.typeNode),
+        accumulatorA: inputOutputCallExpressionList,
+        accumulatorB: errorParsedExpressionList,
+      });
+
+      if (errorParsedExpressionList.length > 0) {
+        return {
+          [ESTINANT_INPUT_OUTPUT_PARENT_GEPP]: [],
+          [ESTINANT_CALL_EXPRESSION_INPUT_PARAMETER_GEPP]: [],
+          [ESTINANT_CALL_EXPRESSION_OUTPUT_PARAMETER_GEPP]: [],
+          [ESTINANT_INPUT_LIST_GEPP]: [],
+          [ESTINANT_OUTPUT_LIST_GEPP]: [],
+          [ERROR_GEPP]: errorParsedExpressionList.map(
+            (parsedExpression, index) => {
+              return {
+                zorn: `${errorZorn}/${index}`,
+                grition: {
+                  message: `Estinant builder expression "${parsedExpression.functionName}" is missing a type parameter`,
+                  parsedExpression,
+                },
+              };
+            },
+          ),
+        };
+      }
+
+      const inputListZorn = `${engineEstinantInput.zorn}/input`;
+      const outputListZorn = `${engineEstinantInput.zorn}/output`;
+
+      const estinantInputOutputList = inputOutputCallExpressionList.map<
+        EstinantInput | EstinantOutput
+      >(({ isInput, typeNode }, index) => {
+        // TODO: make the convention where we chop off the suffix more discoverable
+        const voictentName = typeNode.typeName.name.replace(/Voictent$/, '');
+
+        if (isInput) {
+          return {
+            programName,
+            estinantName,
+            voictentName,
+            isInput,
+            index,
+          } satisfies EstinantInput;
+        }
+
+        return {
+          programName,
+          estinantName,
+          voictentName,
+          isInput,
+          index: null,
+        } satisfies EstinantOutput;
+      });
+
+      const inputList = estinantInputOutputList.filter<EstinantInput>(
+        (inputOrOutput): inputOrOutput is EstinantInput =>
+          inputOrOutput.isInput,
+      );
+      const outputList = estinantInputOutputList.filter<EstinantOutput>(
+        (inputOrOutput): inputOrOutput is EstinantOutput =>
+          !inputOrOutput.isInput,
+      );
 
       return {
         [ESTINANT_INPUT_OUTPUT_PARENT_GEPP]: [
@@ -99,52 +427,27 @@ export const estinantCallExpressionParameterCortmum = buildCortmum<
             grition: {
               programName,
               estinantName,
-              inputListIdentifier,
-              outputListIdentifier,
+              inputListIdentifier: inputListZorn,
+              outputListIdentifier: outputListZorn,
             },
           },
         ],
-        [ESTINANT_CALL_EXPRESSION_INPUT_PARAMETER_GEPP]: [
+        [ESTINANT_CALL_EXPRESSION_INPUT_PARAMETER_GEPP]: [],
+        [ESTINANT_CALL_EXPRESSION_OUTPUT_PARAMETER_GEPP]: [],
+        [ESTINANT_INPUT_LIST_GEPP]: [
           {
-            zorn: inputListIdentifier,
-            grition: {
-              programName,
-              estinantName,
-              isInput: true,
-              node: callExpression.typeParameters.params[0],
-            },
+            zorn: inputListZorn,
+            grition: inputList,
           },
         ],
-        [ESTINANT_CALL_EXPRESSION_OUTPUT_PARAMETER_GEPP]: [
+        [ESTINANT_OUTPUT_LIST_GEPP]: [
           {
-            zorn: outputListIdentifier,
-            grition: {
-              programName,
-              estinantName,
-              isInput: false,
-              node: callExpression.typeParameters.params[1],
-            },
+            zorn: outputListZorn,
+            grition: outputList,
           },
         ],
         [ERROR_GEPP]: [],
       };
-    }
-
-    return {
-      [ESTINANT_INPUT_OUTPUT_PARENT_GEPP]: [],
-      [ESTINANT_CALL_EXPRESSION_INPUT_PARAMETER_GEPP]: [],
-      [ESTINANT_CALL_EXPRESSION_OUTPUT_PARAMETER_GEPP]: [],
-      [ERROR_GEPP]: [
-        {
-          zorn: engineEstinantInput.zorn,
-          grition: {
-            hasNode: node !== undefined,
-            hasInitExpression: initExpression !== null,
-            hasCallExpression: callExpression !== null,
-            callExpression,
-          },
-        },
-      ],
-    };
-  },
-});
+    },
+  )
+  .assemble();

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/estinant-call-expression/baseEstinantCallExpression.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/estinant-call-expression/baseEstinantCallExpression.ts
@@ -1,4 +1,4 @@
-import { isSpecificCallExpression } from '../../../../utilities/type-script-ast/isCallExpression';
+import { isSpecificIdentifiableCallExpression } from '../../../../utilities/type-script-ast/isCallExpression';
 import { IdentifiableCallExpression } from '../../../../utilities/type-script-ast/isIdentifiableCallExpression';
 import {
   isNode,
@@ -48,7 +48,7 @@ export const buildIsEstinantCallExpression = <
   > => {
     return (
       isNode(node) &&
-      isSpecificCallExpression(node, calleeName) &&
+      isSpecificIdentifiableCallExpression(node, calleeName) &&
       isTypeScriptTypeParameterInstantiationWithParameterTuple(
         node.typeParameters,
         parameterNodeTypeTuple,

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/estinant-input-output/estinantInputList.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/estinant-input-output/estinantInputList.ts
@@ -10,7 +10,7 @@ import {
   isTypeScriptTypeParameterInstantiation,
   TypeScriptTypeParameterInstantiation,
 } from '../../../../utilities/type-script-ast/isTypeScriptTypeParameterInstantiation';
-import { buildMentursection } from '../../../adapter/estinant/mentursection';
+import { buildEstinant } from '../../../adapter/estinant-builder/estinantBuilder';
 import { Grition } from '../../../adapter/grition';
 import { OdeshinFromGrition } from '../../../adapter/odeshin';
 import { Voictent } from '../../../adapter/voictent';
@@ -79,15 +79,23 @@ const isVitionInstantiation = (
       isIdentifiableTypeScriptTypeReference(subNode.typeParameters.params[0]),
   );
 
-export const estinantInputMentursection = buildMentursection<
-  EstinantCallExpressionInputParameterVoictent,
-  [EstinantInputListVoictent, ErrorVoictent]
->({
-  inputGepp: ESTINANT_CALL_EXPRESSION_INPUT_PARAMETER_GEPP,
-  outputGeppTuple: [ESTINANT_INPUT_LIST_GEPP, ERROR_GEPP],
-  pinbe: (input) => {
-    const identifiableNode = isIdentifiableTypeScriptTypeReference(input.node)
-      ? input.node
+export const getEstinantInputList = buildEstinant()
+  .fromHubblepup<EstinantCallExpressionInputParameterVoictent>({
+    gepp: ESTINANT_CALL_EXPRESSION_INPUT_PARAMETER_GEPP,
+  })
+  .toHubblepup<EstinantInputListVoictent>({
+    gepp: ESTINANT_INPUT_LIST_GEPP,
+  })
+  .andToHubblepupTuple<ErrorVoictent>({
+    gepp: ERROR_GEPP,
+  })
+  .onPinbe((input) => {
+    const callExpressionInputParameter = input.grition;
+
+    const identifiableNode = isIdentifiableTypeScriptTypeReference(
+      callExpressionInputParameter.node,
+    )
+      ? callExpressionInputParameter.node
       : null;
 
     let voictentNameList: string[] | [];
@@ -119,11 +127,11 @@ export const estinantInputMentursection = buildMentursection<
           ]
         : [];
 
-    const outputList = voictentNameList.map<EstinantInput>(
+    const inputList = voictentNameList.map<EstinantInput>(
       (voictentName, index) => {
         return {
-          programName: input.programName,
-          estinantName: input.estinantName,
+          programName: callExpressionInputParameter.programName,
+          estinantName: callExpressionInputParameter.estinantName,
           voictentName,
           isInput: true,
           index,
@@ -132,8 +140,16 @@ export const estinantInputMentursection = buildMentursection<
     );
 
     return {
-      [ESTINANT_INPUT_LIST_GEPP]: [outputList],
-      [ERROR_GEPP]: errorList,
+      [ESTINANT_INPUT_LIST_GEPP]: {
+        zorn: input.zorn,
+        grition: inputList,
+      },
+      [ERROR_GEPP]: errorList.map((error, index) => {
+        return {
+          zorn: `${input.zorn}/${index}`,
+          grition: error,
+        };
+      }),
     };
-  },
-});
+  })
+  .assemble();

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/tree/engineProgramTreeNode.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/tree/engineProgramTreeNode.ts
@@ -1,7 +1,5 @@
-import { buildWattlection } from '../../../../type-script-adapter/estinant/wattlection';
-import { Vicken } from '../../../../type-script-adapter/vicken';
-import { Vition } from '../../../../type-script-adapter/vition';
 import { Tuple } from '../../../../utilities/semantic-types/tuple';
+import { buildEstinant } from '../../../adapter/estinant-builder/estinantBuilder';
 import { Grition } from '../../../adapter/grition';
 import { OdeshinFromGrition } from '../../../adapter/odeshin';
 import { Voictent } from '../../../adapter/voictent';
@@ -36,40 +34,35 @@ export type EngineProgramTreeNodeVoictent = Voictent<
   EngineProgramTreeNodeOdeshin
 >;
 
-export const engineProgramTreeNodeWattlection = buildWattlection<
-  Vition<
-    EngineProgramVoictent,
-    [Vicken<EstinantTreeNodeVoictent, Tuple<EstinantTreeNodeVoictent>, string>]
-  >,
-  EngineProgramTreeNodeVoictent
->({
-  leftGepp: ENGINE_PROGRAM_GEPP,
-  rightAppreffingeTuple: [
-    {
-      gepp: ESTINANT_TREE_NODE_GEPP,
-      croard: (rightInput): string => rightInput.zorn,
-      framate: (leftInput): string[] =>
-        leftInput.grition.estinantIdentifierList,
-    },
-  ],
-  outputGepp: ENGINE_PROGRAM_TREE_NODE_GEPP,
-  pinbe: (leftInput, rightInputList) => {
-    const engineProgram = leftInput.grition;
-
+export const constructEngineProgramTree = buildEstinant()
+  .fromGrition<EngineProgramVoictent>({
+    gepp: ENGINE_PROGRAM_GEPP,
+  })
+  .andFromHubblepupTuple<
+    EstinantTreeNodeVoictent,
+    Tuple<EstinantTreeNodeVoictent>,
+    string
+  >({
+    gepp: ESTINANT_TREE_NODE_GEPP,
+    framate: (leftInput) => leftInput.grition.estinantIdentifierList,
+    croard: (rightInput) => rightInput.zorn,
+  })
+  .toGrition<EngineProgramTreeNodeVoictent>({
+    gepp: ENGINE_PROGRAM_TREE_NODE_GEPP,
+    getZorn: (leftInput) => leftInput.zorn,
+  })
+  .onPinbe((engineProgram, rightInputList) => {
     const estinantTreeNodeList = rightInputList.map(({ grition }) => grition);
 
     return {
-      zorn: leftInput.zorn,
-      grition: {
-        programName: engineProgram.programName,
-        estinantList: estinantTreeNodeList.map<EngineProgramEstinantTreeNode>(
-          ({ estinantName, inputList, outputList }) => ({
-            estinantName,
-            inputList,
-            outputList,
-          }),
-        ),
-      },
+      programName: engineProgram.programName,
+      estinantList: estinantTreeNodeList.map<EngineProgramEstinantTreeNode>(
+        ({ estinantName, inputList, outputList }) => ({
+          estinantName,
+          inputList,
+          outputList,
+        }),
+      ),
     };
-  },
-});
+  })
+  .assemble();

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/tree/estinantTreeNode.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/tree/estinantTreeNode.ts
@@ -1,7 +1,4 @@
-// TODO: make a custom adapter wattlection
-import { buildWattlection } from '../../../../type-script-adapter/estinant/wattlection';
-import { Vicken } from '../../../../type-script-adapter/vicken';
-import { Vition } from '../../../../type-script-adapter/vition';
+import { buildEstinant } from '../../../adapter/estinant-builder/estinantBuilder';
 import { Grition } from '../../../adapter/grition';
 import { OdeshinFromGrition } from '../../../adapter/odeshin';
 import { Voictent } from '../../../adapter/voictent';
@@ -48,36 +45,35 @@ export type EstinantTreeNodeVoictent = Voictent<
   EstinantTreeNodeOdeshin
 >;
 
-export const estinantTreeNodeWattlection = buildWattlection<
-  Vition<
-    EstinantInputOutputParentVoictent,
-    [
-      Vicken<EstinantInputListVoictent, [EstinantInputListVoictent], string>,
-      Vicken<EstinantOutputListVoictent, [EstinantOutputListVoictent], string>,
-    ]
-  >,
-  EstinantTreeNodeVoictent
->({
-  leftGepp: ESTINANT_INPUT_OUTPUT_PARENT_GEPP,
-  rightAppreffingeTuple: [
-    {
-      gepp: ESTINANT_INPUT_LIST_GEPP,
-      croard: (rightInput): string => rightInput.zorn,
-      framate: (leftInput) => [leftInput.grition.inputListIdentifier] as const,
-    },
-    {
-      gepp: ESTINANT_OUTPUT_LIST_GEPP,
-      croard: (rightInput): string => rightInput.zorn,
-      framate: (leftInput) => [leftInput.grition.outputListIdentifier] as const,
-    },
-  ],
-  outputGepp: ESTINANT_TREE_NODE_GEPP,
-  pinbe: (leftInput, [{ grition: inputList }], [{ grition: outputList }]) => {
-    const estinantParent = leftInput.grition;
-
-    return {
-      zorn: leftInput.zorn,
-      grition: {
+export const constructEstinantTreeNode = buildEstinant()
+  .fromGrition<EstinantInputOutputParentVoictent>({
+    gepp: ESTINANT_INPUT_OUTPUT_PARENT_GEPP,
+  })
+  .andFromHubblepupTuple<
+    EstinantInputListVoictent,
+    [EstinantInputListVoictent],
+    string
+  >({
+    gepp: ESTINANT_INPUT_LIST_GEPP,
+    framate: (leftInput) => [leftInput.grition.inputListIdentifier],
+    croard: (rightInput) => rightInput.zorn,
+  })
+  .andFromHubblepupTuple<
+    EstinantOutputListVoictent,
+    [EstinantOutputListVoictent],
+    string
+  >({
+    gepp: ESTINANT_OUTPUT_LIST_GEPP,
+    framate: (leftInput) => [leftInput.grition.outputListIdentifier],
+    croard: (rightInput) => rightInput.zorn,
+  })
+  .toGrition<EstinantTreeNodeVoictent>({
+    gepp: ESTINANT_TREE_NODE_GEPP,
+    getZorn: (leftInput) => leftInput.zorn,
+  })
+  .onPinbe(
+    (estinantParent, [{ grition: inputList }], [{ grition: outputList }]) => {
+      return {
         programName: estinantParent.programName,
         estinantName: estinantParent.estinantName,
         inputList: inputList.map(({ voictentName, index }) => ({
@@ -87,7 +83,7 @@ export const estinantTreeNodeWattlection = buildWattlection<
         outputList: outputList.map(({ voictentName }) => ({
           voictentName,
         })),
-      },
-    };
-  },
-});
+      };
+    },
+  )
+  .assemble();

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/file/fileMattomer.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/file/fileMattomer.ts
@@ -17,7 +17,7 @@ import {
   HTML_FILE_GEPP,
 } from '../html-file/htmlFile';
 
-export const fileMattomer = buildMattomer<
+export const categorizeFiles = buildMattomer<
   FileVoictent,
   [TypeScriptFileVoictent, YamlFileVoictent, HtmlFileVoictent]
 >({

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/file/fileMentursection.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/file/fileMentursection.ts
@@ -1,9 +1,9 @@
-import { buildMentursection } from '../../../type-script-adapter/estinant/mentursection';
 import {
   FileSystemNodeMetadata,
   getNestedFileSystemNodeMetadataList,
 } from '../../../utilities/file/getNestedFilePaths';
 import { splitList } from '../../../utilities/splitList';
+import { buildEstinant } from '../../adapter/estinant-builder/estinantBuilder';
 import {
   DirectoryOdeshin,
   DirectoryVoictent,
@@ -12,7 +12,7 @@ import {
 import { FileVoictent, FILE_GEPP, FileOdeshin, FileGrition } from './file';
 import { getFileExtensionSuffixIdentifier } from './fileExtensionSuffixIdentifier';
 import {
-  FileMentursectionConfigurationVoictent,
+  FileSystemObjectEnumeratorConfigurationVoictent,
   FILE_MENTURSECTION_CONFIGURATION_GEPP,
 } from './fileMentursectionConfiguration';
 import { getFileMetadata } from './getFileMetadata';
@@ -49,13 +49,17 @@ const partsToKebabCase = (x: string[]): string => {
   return x.join('-');
 };
 
-export const fileMentursection = buildMentursection<
-  FileMentursectionConfigurationVoictent,
-  [DirectoryVoictent, FileVoictent]
->({
-  inputGepp: FILE_MENTURSECTION_CONFIGURATION_GEPP,
-  outputGeppTuple: [DIRECTORY_GEPP, FILE_GEPP],
-  pinbe: (input) => {
+export const enumerateFileSystemObjects = buildEstinant()
+  .fromHubblepup<FileSystemObjectEnumeratorConfigurationVoictent>({
+    gepp: FILE_MENTURSECTION_CONFIGURATION_GEPP,
+  })
+  .toHubblepupTuple<DirectoryVoictent>({
+    gepp: DIRECTORY_GEPP,
+  })
+  .andToHubblepupTuple<FileVoictent>({
+    gepp: FILE_GEPP,
+  })
+  .onPinbe((input) => {
     const nodeMetadataList = getNestedFileSystemNodeMetadataList(input);
 
     const directoryMetadataList: FileSystemNodeMetadata[] = [];
@@ -126,5 +130,5 @@ export const fileMentursection = buildMentursection<
       [DIRECTORY_GEPP]: directoryOutputTuple,
       [FILE_GEPP]: fileOutputTuple,
     };
-  },
-});
+  })
+  .assemble();

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/file/fileMentursectionConfiguration.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/file/fileMentursectionConfiguration.ts
@@ -20,7 +20,7 @@ export const FILE_MENTURSECTION_CONFIGURATION_GEPP =
 export type FileMentursectionConfigurationGepp =
   typeof FILE_MENTURSECTION_CONFIGURATION_GEPP;
 
-export type FileMentursectionConfigurationVoictent = Voictent<
+export type FileSystemObjectEnumeratorConfigurationVoictent = Voictent<
   FileMentursectionConfigurationGepp,
   FileMentursectionConfigurationHubblepup
 >;

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/directedGraphToGraphvizCode.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/directedGraphToGraphvizCode.ts
@@ -1,4 +1,4 @@
-import { buildOnama } from '../../adapter/estinant/onama';
+import { buildEstinant } from '../../adapter/estinant-builder/estinantBuilder';
 import {
   DirectedGraphVoictent,
   DIRECTED_GRAPH_GEPP,
@@ -6,14 +6,16 @@ import {
 import { getGraphvizCode } from './directed-graph/getGraphvizCode';
 import { GraphvizCodeVoictent, GRAPHVIZ_CODE_GEPP } from './graphvizCode';
 
-export const directedGraphToGraphvizCode = buildOnama<
-  DirectedGraphVoictent,
-  GraphvizCodeVoictent
->({
-  inputGepp: DIRECTED_GRAPH_GEPP,
-  outputGepp: GRAPHVIZ_CODE_GEPP,
-  pinbe: (input) => {
+export const encodeDirectedGraphAsGraphvizCode = buildEstinant()
+  .fromGrition<DirectedGraphVoictent>({
+    gepp: DIRECTED_GRAPH_GEPP,
+  })
+  .toGrition<GraphvizCodeVoictent>({
+    gepp: GRAPHVIZ_CODE_GEPP,
+    getZorn: (leftInput) => leftInput.zorn,
+  })
+  .onPinbe((input) => {
     const code = getGraphvizCode(input);
     return code;
-  },
-});
+  })
+  .assemble();

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/graphvizCodeToSvgDocument.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/graphvizCodeToSvgDocument.ts
@@ -1,16 +1,17 @@
 import childProcessUtilities from 'child_process';
 import * as cheerio from 'cheerio';
-import { buildMentursection } from '../../../type-script-adapter/estinant/mentursection';
 import { GraphvizCodeVoictent, GRAPHVIZ_CODE_GEPP } from './graphvizCode';
 import { SvgDocumentVoictent, SVG_DOCUMENT_GEPP } from './svgDocument';
+import { buildEstinant } from '../../adapter/estinant-builder/estinantBuilder';
 
-export const graphvizCodeToSvgDocument = buildMentursection<
-  GraphvizCodeVoictent,
-  [SvgDocumentVoictent]
->({
-  inputGepp: GRAPHVIZ_CODE_GEPP,
-  outputGeppTuple: [SVG_DOCUMENT_GEPP],
-  pinbe: ({ zorn, grition }) => {
+export const renderGraphvizCodeToSvgDocument = buildEstinant()
+  .fromHubblepup<GraphvizCodeVoictent>({
+    gepp: GRAPHVIZ_CODE_GEPP,
+  })
+  .toHubblepupTuple<SvgDocumentVoictent>({
+    gepp: SVG_DOCUMENT_GEPP,
+  })
+  .onPinbe(({ zorn, grition }) => {
     const result = childProcessUtilities.spawnSync('dot', ['-Tsvg'], {
       encoding: 'utf8',
       input: grition,
@@ -54,17 +55,15 @@ export const graphvizCodeToSvgDocument = buildMentursection<
 
     const modifiedDocument = $svg.toString() ?? '';
 
-    return {
-      [SVG_DOCUMENT_GEPP]: [
-        {
-          zorn: `${zorn}/original`,
-          grition: originalDocument,
-        },
-        {
-          zorn: `${zorn}/modified`,
-          grition: modifiedDocument,
-        },
-      ],
-    };
-  },
-});
+    return [
+      {
+        zorn: `${zorn}/original`,
+        grition: originalDocument,
+      },
+      {
+        zorn: `${zorn}/modified`,
+        grition: modifiedDocument,
+      },
+    ];
+  })
+  .assemble();

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/svgDocumentToInteractivePage.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/svgDocumentToInteractivePage.ts
@@ -1,7 +1,5 @@
 import fs from 'fs';
-import { buildWattlection } from '../../../type-script-adapter/estinant/wattlection';
-import { Vicken } from '../../../type-script-adapter/vicken';
-import { Vition } from '../../../type-script-adapter/vition';
+import { buildEstinant } from '../../adapter/estinant-builder/estinantBuilder';
 import { HtmlFileVoictent, HTML_FILE_GEPP } from '../html-file/htmlFile';
 import {
   OutputFileVoictent,
@@ -12,23 +10,19 @@ import { SvgDocumentVoictent, SVG_DOCUMENT_GEPP } from './svgDocument';
 const INTERACTIVE_HTML_FILE_PATH =
   'packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/interactiveSvg.html';
 
-export const svgDocumentToInteractivePage = buildWattlection<
-  Vition<
-    SvgDocumentVoictent,
-    [Vicken<HtmlFileVoictent, [HtmlFileVoictent], string>]
-  >,
-  OutputFileVoictent
->({
-  leftGepp: SVG_DOCUMENT_GEPP,
-  outputGepp: OUTPUT_FILE_GEPP,
-  rightAppreffingeTuple: [
-    {
-      gepp: HTML_FILE_GEPP,
-      framate: (): [string] => [INTERACTIVE_HTML_FILE_PATH],
-      croard: (rightInput): string => rightInput.zorn,
-    },
-  ],
-  pinbe: (leftInput, [rightInput]) => {
+export const addInteractivityToSvgDocument = buildEstinant()
+  .fromHubblepup<SvgDocumentVoictent>({
+    gepp: SVG_DOCUMENT_GEPP,
+  })
+  .andFromHubblepupTuple<HtmlFileVoictent, [HtmlFileVoictent], string>({
+    gepp: HTML_FILE_GEPP,
+    framate: () => [INTERACTIVE_HTML_FILE_PATH],
+    croard: (rightInput) => rightInput.zorn,
+  })
+  .toHubblepup<OutputFileVoictent>({
+    gepp: OUTPUT_FILE_GEPP,
+  })
+  .onPinbe((leftInput, [rightInput]) => {
     const svgText = leftInput.grition;
     const templateFile = rightInput.grition;
 
@@ -46,5 +40,5 @@ export const svgDocumentToInteractivePage = buildWattlection<
       fileExtensionSuffix: 'html',
       text: outputTemplate,
     };
-  },
-});
+  })
+  .assemble();

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file-relationships/typeScriptFileRelationshipList.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file-relationships/typeScriptFileRelationshipList.ts
@@ -1,6 +1,4 @@
-import { buildWattlection } from '../../../type-script-adapter/estinant/wattlection';
-import { Vicken } from '../../../type-script-adapter/vicken';
-import { Vition } from '../../../type-script-adapter/vition';
+import { buildEstinant } from '../../adapter/estinant-builder/estinantBuilder';
 import { Grition } from '../../adapter/grition';
 import { OdeshinFromGrition } from '../../adapter/odeshin';
 import { Voictent } from '../../adapter/voictent';
@@ -54,34 +52,27 @@ export type TypeScriptFileRelationshipListVoictent = Voictent<
   TypeScriptFileRelationshipListOdeshin
 >;
 
-export const typeScriptFileRelationshipWattlection = buildWattlection<
-  Vition<
-    TypeScriptFileVoictent,
-    [
-      Vicken<
-        TypeScriptFileImportListVoictent,
-        [TypeScriptFileImportListVoictent],
-        string
-      >,
-    ]
-  >,
-  TypeScriptFileRelationshipListVoictent
->({
-  leftGepp: TYPE_SCRIPT_FILE_GEPP,
-  rightAppreffingeTuple: [
-    {
-      gepp: TYPE_SCRIPT_FILE_IMPORT_LIST_GEPP,
-      framate: (leftInput): [string] => [leftInput.zorn],
-      croard: (rightInput): string => rightInput.zorn,
-    },
-  ],
-  outputGepp: TYPE_SCRIPT_FILE_RELATIONSHIP_LIST_GEPP,
-  pinbe: (leftInput, [{ grition: importList }]) => {
-    const typeScriptFile = leftInput.grition;
-
-    return {
-      zorn: leftInput.zorn,
-      grition: importList.map<TypeScriptFileRelationship>((importedItem) => {
+export const getTypeScriptFileRelationshipList = buildEstinant()
+  .fromGrition<TypeScriptFileVoictent>({
+    gepp: TYPE_SCRIPT_FILE_GEPP,
+  })
+  // TODO: change to "andFromOdeshinTuple"
+  .andFromHubblepupTuple<
+    TypeScriptFileImportListVoictent,
+    [TypeScriptFileImportListVoictent],
+    string
+  >({
+    gepp: TYPE_SCRIPT_FILE_IMPORT_LIST_GEPP,
+    framate: (leftInput): [string] => [leftInput.zorn],
+    croard: (rightInput): string => rightInput.zorn,
+  })
+  .toGrition<TypeScriptFileRelationshipListVoictent>({
+    gepp: TYPE_SCRIPT_FILE_RELATIONSHIP_LIST_GEPP,
+    getZorn: (leftInput) => leftInput.zorn,
+  })
+  .onPinbe((typeScriptFile, [{ grition: importList }]) => {
+    const relationshipList = importList.map<TypeScriptFileRelationship>(
+      (importedItem) => {
         return {
           node: {
             typeName: TypeScriptFileImportTypeName.Local,
@@ -93,7 +84,9 @@ export const typeScriptFileRelationshipWattlection = buildWattlection<
             nodePath: getSourcePath(importedItem),
           },
         };
-      }),
-    };
-  },
-});
+      },
+    );
+
+    return relationshipList;
+  })
+  .assemble();

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file-relationships/typeScriptFileRelationshipListToDirectedGraph.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file-relationships/typeScriptFileRelationshipListToDirectedGraph.ts
@@ -1,13 +1,6 @@
 import { posix } from 'path';
-import { buildCortmum } from '../../../type-script-adapter/estinant/cortmum';
-import { Vicken } from '../../../type-script-adapter/vicken';
-import { Vition } from '../../../type-script-adapter/vition';
-import {
-  Directory,
-  DirectoryOdeshin,
-  DirectoryVoictent,
-  DIRECTORY_GEPP,
-} from '../file/directory';
+import { buildEstinant } from '../../adapter/estinant-builder/estinantBuilder';
+import { DirectoryVoictent, DIRECTORY_GEPP } from '../file/directory';
 import { Shape } from '../graph-visualization/directed-graph/attribute';
 import {
   DirectedGraph,
@@ -19,65 +12,35 @@ import {
 import { DirectedGraphEdge } from '../graph-visualization/directed-graph/directedGraphEdge';
 import { DirectedGraphNode } from '../graph-visualization/directed-graph/directedGraphNode';
 import {
-  TypeScriptFileOdeshin,
   TypeScriptFileVoictent,
   TYPE_SCRIPT_FILE_GEPP,
 } from '../type-script-file/typeScriptFile';
 import { TypeScriptFileImportTypeName } from '../type-script-file/typeScriptFileImportList';
 import {
   RelationshipNodeMetadata,
-  TypeScriptFileRelationship,
-  TypeScriptFileRelationshipListOdeshin,
   TypeScriptFileRelationshipListVoictent,
   TYPE_SCRIPT_FILE_RELATIONSHIP_LIST_GEPP,
 } from './typeScriptFileRelationshipList';
 
-export const typeScriptFileRelationshipListToDirectedGraph = buildCortmum<
-  Vition<
-    TypeScriptFileRelationshipListVoictent,
-    [
-      Vicken<DirectoryVoictent, [DirectoryVoictent], string>,
-      Vicken<TypeScriptFileVoictent, [TypeScriptFileVoictent], string>,
-    ]
-  >,
-  [DirectedGraphVoictent]
->({
-  leftGepp: TYPE_SCRIPT_FILE_RELATIONSHIP_LIST_GEPP,
-  isWibiz: true,
-  rightAppreffingeTuple: [
-    {
-      gepp: DIRECTORY_GEPP,
-      isWibiz: true,
-      framate: (): [string] => [''],
-      croard: (): string => '',
-    },
-    {
-      gepp: TYPE_SCRIPT_FILE_GEPP,
-      isWibiz: true,
-      framate: (): [string] => [''],
-      croard: (): string => '',
-    },
-  ],
-  outputGeppTuple: [DIRECTED_GRAPH_GEPP],
-  pinbe: (leftInput, rightInput1, rightInput2) => {
-    // TODO: update the type adapter layer to provide type safety for "isWibiz"
-    const typedLeftInput =
-      leftInput as unknown as TypeScriptFileRelationshipListOdeshin[];
-    const typedRightInput1 = rightInput1 as unknown as DirectoryOdeshin[];
-    const typedRightInput2 = rightInput2 as unknown as TypeScriptFileOdeshin[];
-
-    const directoryList = typedRightInput1.map<Directory>(
-      ({ grition }) => grition,
-    );
-
-    const typeScriptFileList = typedRightInput2.map(({ grition }) => grition);
-
-    const relationshipList = typedLeftInput.flatMap<TypeScriptFileRelationship>(
-      ({ grition }) => grition,
-    );
+export const digraphificateTypeScriptFileRelationshipList = buildEstinant()
+  .fromOdeshinVoictent<TypeScriptFileRelationshipListVoictent>({
+    gepp: TYPE_SCRIPT_FILE_RELATIONSHIP_LIST_GEPP,
+  })
+  // TODO: make these odeshin voictents
+  .andFromOdeshinVoictent<DirectoryVoictent>({
+    gepp: DIRECTORY_GEPP,
+  })
+  .andFromOdeshinVoictent<TypeScriptFileVoictent>({
+    gepp: TYPE_SCRIPT_FILE_GEPP,
+  })
+  .toHubblepup<DirectedGraphVoictent>({
+    gepp: DIRECTED_GRAPH_GEPP,
+  })
+  .onPinbe((relationshipListTuple, directoryTuple, typeScriptFileTuple) => {
+    const allRelationshipList = relationshipListTuple.flat();
 
     let rootDirectoryPathPartList: string[] = [];
-    directoryList.forEach((directory) => {
+    directoryTuple.forEach((directory) => {
       rootDirectoryPathPartList =
         directory.directoryPathPartList.length <
           rootDirectoryPathPartList.length ||
@@ -118,7 +81,7 @@ export const typeScriptFileRelationshipListToDirectedGraph = buildCortmum<
       return subgraph;
     };
 
-    directoryList.forEach((directory) => {
+    directoryTuple.forEach((directory) => {
       // TODO: move these insights to the "File" type
       const { directoryPath } = directory;
       const parentDirectoryPath = posix.dirname(directoryPath);
@@ -131,7 +94,7 @@ export const typeScriptFileRelationshipListToDirectedGraph = buildCortmum<
       }
     });
 
-    typeScriptFileList.forEach((file) => {
+    typeScriptFileTuple.forEach((file) => {
       const node: DirectedGraphNode = {
         attributeByKey: {
           id: file.filePath,
@@ -163,7 +126,7 @@ export const typeScriptFileRelationshipListToDirectedGraph = buildCortmum<
       subgraphList: [rootDirectoryGraph],
     };
 
-    relationshipList.forEach(({ node, importedNode }) => {
+    allRelationshipList.forEach(({ node, importedNode }) => {
       const tailId = importedNode.nodePath;
       const headId = node.nodePath;
       const edgeId = `${tailId}:${headId}`;
@@ -180,7 +143,7 @@ export const typeScriptFileRelationshipListToDirectedGraph = buildCortmum<
     });
 
     const externalNodeByNodePath = new Map<string, RelationshipNodeMetadata>();
-    relationshipList
+    allRelationshipList
       .map(({ importedNode }) => importedNode)
       .filter(
         (importedNode) =>
@@ -215,12 +178,8 @@ export const typeScriptFileRelationshipListToDirectedGraph = buildCortmum<
     rootGraph.subgraphList.unshift(externalSubgraph);
 
     return {
-      [DIRECTED_GRAPH_GEPP]: [
-        {
-          zorn: 'type-script-file-relationship-graph',
-          grition: rootGraph,
-        },
-      ],
+      zorn: 'type-script-file-relationship-graph',
+      grition: rootGraph,
     };
-  },
-});
+  })
+  .assemble();

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file/parsedTypeScriptFile.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file/parsedTypeScriptFile.ts
@@ -9,7 +9,7 @@ import {
 } from './typeScriptFileConfiguration';
 import { ErrorVoictent, ERROR_GEPP } from '../error/error';
 import { Voictent } from '../../adapter/voictent';
-import { buildMentursection } from '../../adapter/estinant/mentursection';
+import { buildEstinant } from '../../adapter/estinant-builder/estinantBuilder';
 
 export type ParsedTypeScriptFile = {
   filePath: string;
@@ -30,27 +30,36 @@ export type ParsedTypeScriptFileVoictent = Voictent<
   ParsedTypeScriptFileOdeshin
 >;
 
-export const parsedTypeScriptFileMentursection = buildMentursection<
-  TypeScriptFileConfigurationVoictent,
-  [ParsedTypeScriptFileVoictent, ErrorVoictent]
->({
-  inputGepp: TYPE_SCRIPT_FILE_CONFIGURATION_GEPP,
-  outputGeppTuple: [PARSED_TYPE_SCRIPT_FILE_GEPP, ERROR_GEPP],
-  pinbe: (input) => {
-    const fileContents = fs.readFileSync(input.sourceFilePath, 'utf8');
+export const parseTypeScriptFile = buildEstinant()
+  .fromHubblepup<TypeScriptFileConfigurationVoictent>({
+    gepp: TYPE_SCRIPT_FILE_CONFIGURATION_GEPP,
+  })
+  .toHubblepupTuple<ParsedTypeScriptFileVoictent>({
+    gepp: PARSED_TYPE_SCRIPT_FILE_GEPP,
+  })
+  .andToHubblepupTuple<ErrorVoictent>({
+    gepp: ERROR_GEPP,
+  })
+  .onPinbe((input) => {
+    const inputGrition = input.grition;
+
+    const fileContents = fs.readFileSync(inputGrition.sourceFilePath, 'utf8');
 
     try {
       const program: TSESTree.Program = parser.parse(fileContents, {
         project: './tsconfig.json',
-        tsconfigRootDir: input.rootDirectory,
+        tsconfigRootDir: inputGrition.rootDirectory,
         comment: true,
       });
 
       return {
         [PARSED_TYPE_SCRIPT_FILE_GEPP]: [
           {
-            filePath: input.sourceFilePath,
-            program,
+            zorn: input.zorn,
+            grition: {
+              filePath: inputGrition.sourceFilePath,
+              program,
+            },
           },
         ],
         [ERROR_GEPP]: [],
@@ -58,8 +67,13 @@ export const parsedTypeScriptFileMentursection = buildMentursection<
     } catch (error) {
       return {
         [PARSED_TYPE_SCRIPT_FILE_GEPP]: [],
-        [ERROR_GEPP]: [error],
+        [ERROR_GEPP]: [
+          {
+            zorn: input.zorn,
+            grition: error,
+          },
+        ],
       };
     }
-  },
-});
+  })
+  .assemble();

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file/programBodyDeclarationsByIdentifier.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file/programBodyDeclarationsByIdentifier.ts
@@ -8,7 +8,6 @@ import {
   isIdentifiableTypeDeclaration,
   IdentifiableTypeDeclaration,
 } from '../../../utilities/type-script-ast/isIdentifiableTypeDeclaration';
-import { buildOnama } from '../../adapter/estinant/onama';
 import { Grition } from '../../adapter/grition';
 import { OdeshinFromGrition } from '../../adapter/odeshin';
 import { Voictent } from '../../adapter/voictent';
@@ -16,6 +15,7 @@ import {
   ParsedTypeScriptFileVoictent,
   PARSED_TYPE_SCRIPT_FILE_GEPP,
 } from './parsedTypeScriptFile';
+import { buildEstinant } from '../../adapter/estinant-builder/estinantBuilder';
 
 export type ProgramBodyDeclarationsByIdentifier = Map<
   string,
@@ -39,13 +39,15 @@ export type ProgramBodyDeclarationsByIdentifierVoictent = Voictent<
   ProgramBodyDeclarationsByIdentifierOdeshin
 >;
 
-export const programBodyDeclarationsByIdentifierOnama = buildOnama<
-  ParsedTypeScriptFileVoictent,
-  ProgramBodyDeclarationsByIdentifierVoictent
->({
-  inputGepp: PARSED_TYPE_SCRIPT_FILE_GEPP,
-  outputGepp: PROGRAM_BODY_STATEMENTS_BY_IDENTIFIER_GEPP,
-  pinbe: (input) => {
+export const getProgramBodyDeclarationsByIdentifier = buildEstinant()
+  .fromGrition<ParsedTypeScriptFileVoictent>({
+    gepp: PARSED_TYPE_SCRIPT_FILE_GEPP,
+  })
+  .toGrition<ProgramBodyDeclarationsByIdentifierVoictent>({
+    gepp: PROGRAM_BODY_STATEMENTS_BY_IDENTIFIER_GEPP,
+    getZorn: (leftInput) => leftInput.zorn,
+  })
+  .onPinbe((input) => {
     const output: ProgramBodyDeclarationsByIdentifier = new Map();
 
     input.program.body.forEach((statement) => {
@@ -67,5 +69,5 @@ export const programBodyDeclarationsByIdentifierOnama = buildOnama<
     });
 
     return output;
-  },
-});
+  })
+  .assemble();

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file/typeScriptFileConfiguration.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file/typeScriptFileConfiguration.ts
@@ -6,8 +6,8 @@ import {
   TypeScriptFileVoictent,
   TYPE_SCRIPT_FILE_GEPP,
 } from './typeScriptFile';
-import { buildOnama } from '../../adapter/estinant/onama';
 import { Voictent } from '../../adapter/voictent';
+import { buildEstinant } from '../../adapter/estinant-builder/estinantBuilder';
 
 export type TypeScriptFileConfiguration = {
   sourceFilePath: string;
@@ -53,13 +53,15 @@ const getConfigurationFilePath = (filePath: string): string => {
   return configFilePath;
 };
 
-export const typeScriptFileConfigurationOnama = buildOnama<
-  TypeScriptFileVoictent,
-  TypeScriptFileConfigurationVoictent
->({
-  inputGepp: TYPE_SCRIPT_FILE_GEPP,
-  outputGepp: TYPE_SCRIPT_FILE_CONFIGURATION_GEPP,
-  pinbe: (input) => {
+export const associateTypeScriptFileToTypescriptConfiguration = buildEstinant()
+  .fromGrition<TypeScriptFileVoictent>({
+    gepp: TYPE_SCRIPT_FILE_GEPP,
+  })
+  .toGrition<TypeScriptFileConfigurationVoictent>({
+    gepp: TYPE_SCRIPT_FILE_CONFIGURATION_GEPP,
+    getZorn: (input) => input.zorn,
+  })
+  .onPinbe((input) => {
     const configurationFilePath = getConfigurationFilePath(input.filePath);
     const configurationRootDirectory = posix.dirname(configurationFilePath);
 
@@ -70,5 +72,5 @@ export const typeScriptFileConfigurationOnama = buildOnama<
     };
 
     return configuration;
-  },
-});
+  })
+  .assemble();

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file/typeScriptFileExportList.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file/typeScriptFileExportList.ts
@@ -7,7 +7,7 @@ import {
   ExportNamedVariableDeclaration,
   isExportNamedVariableDeclaration,
 } from '../../../utilities/type-script-ast/isExportNamedVariableDeclaration';
-import { buildOnama } from '../../adapter/estinant/onama';
+import { buildEstinant } from '../../adapter/estinant-builder/estinantBuilder';
 import { Grition } from '../../adapter/grition';
 import { OdeshinFromGrition } from '../../adapter/odeshin';
 import { Voictent } from '../../adapter/voictent';
@@ -43,13 +43,15 @@ export type TypeScriptFileExportListVoictent = Voictent<
   TypeScriptFileExportListOdeshin
 >;
 
-export const typeScriptFileExportListOnama = buildOnama<
-  ParsedTypeScriptFileVoictent,
-  TypeScriptFileExportListVoictent
->({
-  inputGepp: PARSED_TYPE_SCRIPT_FILE_GEPP,
-  outputGepp: TYPE_SCRIPT_FILE_EXPORT_LIST_GEPP,
-  pinbe: (input) => {
+export const getTypeScriptFileExportList = buildEstinant()
+  .fromGrition<ParsedTypeScriptFileVoictent>({
+    gepp: PARSED_TYPE_SCRIPT_FILE_GEPP,
+  })
+  .toGrition<TypeScriptFileExportListVoictent>({
+    gepp: TYPE_SCRIPT_FILE_EXPORT_LIST_GEPP,
+    getZorn: (leftInput) => leftInput.zorn,
+  })
+  .onPinbe((input) => {
     const exportList = input.program.body
       .filter(
         (
@@ -75,5 +77,5 @@ export const typeScriptFileExportListOnama = buildOnama<
       });
 
     return exportList;
-  },
-});
+  })
+  .assemble();

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file/typeScriptFileImportList.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file/typeScriptFileImportList.ts
@@ -2,7 +2,7 @@ import { posix } from 'path';
 import { resolveModuleFilePath } from '../../../utilities/file/resolveModuleFilePath';
 import { Merge } from '../../../utilities/merge';
 import { isImportDeclaration } from '../../../utilities/type-script-ast/isImportDeclaration';
-import { buildOnama } from '../../adapter/estinant/onama';
+import { buildEstinant } from '../../adapter/estinant-builder/estinantBuilder';
 import { Grition } from '../../adapter/grition';
 import { OdeshinFromGrition } from '../../adapter/odeshin';
 import { Voictent } from '../../adapter/voictent';
@@ -57,13 +57,15 @@ export type TypeScriptFileImportListVoictent = Voictent<
   TypeScriptFileImportListOdeshin
 >;
 
-export const typeScriptFileImportListOnama = buildOnama<
-  ParsedTypeScriptFileVoictent,
-  TypeScriptFileImportListVoictent
->({
-  inputGepp: PARSED_TYPE_SCRIPT_FILE_GEPP,
-  outputGepp: TYPE_SCRIPT_FILE_IMPORT_LIST_GEPP,
-  pinbe: (input) => {
+export const getTypeScriptFileImportList = buildEstinant()
+  .fromGrition<ParsedTypeScriptFileVoictent>({
+    gepp: PARSED_TYPE_SCRIPT_FILE_GEPP,
+  })
+  .toGrition<TypeScriptFileImportListVoictent>({
+    gepp: TYPE_SCRIPT_FILE_IMPORT_LIST_GEPP,
+    getZorn: (leftInput) => leftInput.zorn,
+  })
+  .onPinbe((input) => {
     const importList = input.program.body
       .filter(isImportDeclaration)
       .map<TypeScriptFileImport>((inputImportDeclaration) => {
@@ -101,5 +103,5 @@ export const typeScriptFileImportListOnama = buildOnama<
       });
 
     return importList;
-  },
-});
+  })
+  .assemble();

--- a/packages/voictents-and-estinants-engine/src/custom/programs/categorizeFiles.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/categorizeFiles.ts
@@ -3,8 +3,8 @@ import {
   FILE_MENTURSECTION_CONFIGURATION_GEPP,
   VOICTENTS_AND_ESTINANTS_FILE_MENTURSECTION_CONFIGURATION,
 } from '../programmable-units/file/fileMentursectionConfiguration';
-import { fileMattomer } from '../programmable-units/file/fileMattomer';
-import { fileMentursection } from '../programmable-units/file/fileMentursection';
+import { categorizeFiles } from '../programmable-units/file/fileMattomer';
+import { enumerateFileSystemObjects } from '../programmable-units/file/fileMentursection';
 import { buildBasicQuirmDebugger } from '../debugger/quirmDebugger';
 
 digikikify({
@@ -13,6 +13,6 @@ digikikify({
       VOICTENTS_AND_ESTINANTS_FILE_MENTURSECTION_CONFIGURATION,
     ],
   },
-  estinantTuple: [fileMentursection, fileMattomer],
+  estinantTuple: [enumerateFileSystemObjects, categorizeFiles],
   quirmDebugger: buildBasicQuirmDebugger('categorizeFiles'),
 });

--- a/packages/voictents-and-estinants-engine/src/custom/programs/estinant-builder-example/exampleProgram.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/estinant-builder-example/exampleProgram.ts
@@ -1,0 +1,193 @@
+import { digikikify } from '../../../type-script-adapter/digikikify';
+import { buildBasicQuirmDebugger } from '../../debugger/quirmDebugger';
+import { buildEstinant } from '../../adapter/estinant-builder/estinantBuilder';
+import { InputAVoictent, INPUT_A_GEPP } from './inputA';
+import { OutputVoictent, OUTPUT_GEPP } from './output';
+import { InputBVoictent, INPUT_B_GEPP } from './inputB';
+import { InputCVoictent, INPUT_C_GEPP } from './inputC';
+import { InputDVoictent, INPUT_D_GEPP } from './inputD';
+
+const inputVoictentToOutputHubblepup = buildEstinant()
+  .fromVoictent<InputAVoictent>({
+    gepp: INPUT_A_GEPP,
+  })
+  .toHubblepup<OutputVoictent>({
+    gepp: OUTPUT_GEPP,
+  })
+  .onPinbe((inputTuple) => {
+    return {
+      zorn: '01/inputVoictentToOutputHubblepup',
+      grition: inputTuple.map((input) => input.number).join(', '),
+    };
+  })
+  .assemble();
+
+const inputHubblepupToOutputHubblepup = buildEstinant()
+  .fromHubblepup<InputAVoictent>({
+    gepp: INPUT_A_GEPP,
+  })
+  .toHubblepup<OutputVoictent>({
+    gepp: OUTPUT_GEPP,
+  })
+  .onPinbe((input) => {
+    return {
+      zorn: `02/inputHubblepupToOutputHubblepup/${input.number}`,
+      grition: input.number,
+    };
+  })
+  .assemble();
+
+const inputGritionToOutputHubblepup = buildEstinant()
+  .fromGrition<InputBVoictent>({
+    gepp: INPUT_B_GEPP,
+  })
+  .toHubblepup<OutputVoictent>({
+    gepp: OUTPUT_GEPP,
+  })
+  .onPinbe((input) => {
+    return {
+      zorn: `03/inputGritionToOutputHubblepup/${input}`,
+      grition: input,
+    };
+  })
+  .assemble();
+
+const inputHubblepupAndInputHubblepupTupleToOutputHubblepup = buildEstinant()
+  .fromHubblepup<InputAVoictent>({
+    gepp: INPUT_A_GEPP,
+  })
+  .andFromHubblepupTuple<
+    InputBVoictent,
+    [InputBVoictent, InputBVoictent],
+    string
+  >({
+    gepp: INPUT_B_GEPP,
+    framate: (leftInput) => [`b-${leftInput.number}`, `b-${leftInput.number}`],
+    croard: (rightInput) => rightInput.zorn,
+  })
+  .toHubblepup<OutputVoictent>({
+    gepp: OUTPUT_GEPP,
+  })
+  .onPinbe((leftInput, [rightInput1, rightInput2]) => {
+    return {
+      zorn: `04/inputHubblepupAndInputHubblepupTupleToOutputHubblepup/${leftInput.number}`,
+      grition: [
+        leftInput.number,
+        rightInput1.grition,
+        rightInput2.grition,
+      ].join(', '),
+    };
+  })
+  .assemble();
+
+const inputHubblepupAndInputHubblepupTupleAndInputHubblepupTupleToOutputHubblepup =
+  buildEstinant()
+    .fromHubblepup<InputAVoictent>({
+      gepp: INPUT_A_GEPP,
+    })
+    .andFromHubblepupTuple<
+      InputBVoictent,
+      [InputBVoictent, InputBVoictent],
+      string
+    >({
+      gepp: INPUT_B_GEPP,
+      framate: (leftInput) => [
+        `b-${leftInput.number}`,
+        `b-${leftInput.number}`,
+      ],
+      croard: (rightInput) => rightInput.zorn,
+    })
+    .andFromHubblepupTuple<
+      InputCVoictent,
+      [InputCVoictent, InputCVoictent, InputCVoictent],
+      string
+    >({
+      gepp: INPUT_C_GEPP,
+      framate: (leftInput) => [
+        `c-${leftInput.number}`,
+        `c-${leftInput.number}`,
+        `c-${leftInput.number}`,
+      ],
+      croard: (rightInput) => rightInput.zorn,
+    })
+    .toHubblepup<OutputVoictent>({
+      gepp: OUTPUT_GEPP,
+    })
+    .onPinbe(
+      (
+        leftInput,
+        [rightInputB1, rightInputB2],
+        [rightInputC1, rightInputC2, rightInputC3],
+      ) => {
+        return {
+          zorn: `05/inputHubblepupAndInputHubblepupTupleAndInputHubblepupTupleToOutputHubblepup/${leftInput.number}`,
+          grition: [
+            leftInput.number,
+            rightInputB1.grition,
+            rightInputB2.grition,
+            rightInputC1.grition,
+            rightInputC2.grition,
+            rightInputC3.grition,
+          ].join(', '),
+        };
+      },
+    )
+    .assemble();
+
+const inputGritionToOutputGrition = buildEstinant()
+  .fromGrition<InputBVoictent>({
+    gepp: INPUT_B_GEPP,
+  })
+  .toGrition<OutputVoictent>({
+    gepp: OUTPUT_GEPP,
+    getZorn: (leftInput) => `06/inputGritionToOutputGrition/${leftInput.zorn}`,
+  })
+  .onPinbe((input) => {
+    return input;
+  })
+  .assemble();
+
+const inputHubblepupAndInputVoictentToOutputHubblepup = buildEstinant()
+  .fromHubblepup<InputAVoictent>({
+    gepp: INPUT_A_GEPP,
+  })
+  .andFromVoictent<InputDVoictent>({
+    gepp: INPUT_D_GEPP,
+  })
+  .toHubblepup({
+    gepp: OUTPUT_GEPP,
+  })
+  .onPinbe((leftInput, rightInputTuple) => {
+    return {
+      zorn: `07/inputHubblepupAndInputVoictentToOutputHubblepup/${leftInput.number}`,
+      grition: [leftInput, ...rightInputTuple]
+        .map((input) => input.number)
+        .join(', '),
+    };
+  })
+  .assemble();
+
+digikikify({
+  initialVoictentsByGepp: {
+    [INPUT_A_GEPP]: [{ number: '1' }, { number: '2' }],
+    [INPUT_B_GEPP]: [
+      { zorn: 'b-1', grition: 'bx' },
+      { zorn: 'b-2', grition: 'by' },
+    ],
+    [INPUT_C_GEPP]: [
+      { zorn: 'c-1', grition: 'cx' },
+      { zorn: 'c-2', grition: 'cy' },
+    ],
+    [INPUT_D_GEPP]: [{ number: '3' }, { number: '4' }],
+  },
+  estinantTuple: [
+    inputVoictentToOutputHubblepup,
+    inputHubblepupToOutputHubblepup,
+    inputGritionToOutputHubblepup,
+    inputHubblepupAndInputHubblepupTupleToOutputHubblepup,
+    inputHubblepupAndInputHubblepupTupleAndInputHubblepupTupleToOutputHubblepup,
+    inputGritionToOutputGrition,
+    inputHubblepupAndInputVoictentToOutputHubblepup,
+  ],
+  quirmDebugger: buildBasicQuirmDebugger('exampleProgram'),
+});

--- a/packages/voictents-and-estinants-engine/src/custom/programs/estinant-builder-example/inputA.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/estinant-builder-example/inputA.ts
@@ -1,0 +1,14 @@
+import { Hubblepup } from '../../adapter/hubblepup';
+import { Voictent } from '../../adapter/voictent';
+
+export type InputA = {
+  number: string;
+};
+
+export type InputAHubblepup = Hubblepup<InputA>;
+
+export const INPUT_A_GEPP = 'input-a';
+
+export type InputAGepp = typeof INPUT_A_GEPP;
+
+export type InputAVoictent = Voictent<InputAGepp, InputAHubblepup>;

--- a/packages/voictents-and-estinants-engine/src/custom/programs/estinant-builder-example/inputB.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/estinant-builder-example/inputB.ts
@@ -1,0 +1,15 @@
+import { Grition } from '../../adapter/grition';
+import { OdeshinFromGrition } from '../../adapter/odeshin';
+import { Voictent } from '../../adapter/voictent';
+
+export type InputB = string;
+
+export type InputBGrition = Grition<InputB>;
+
+export type InputBOdeshin = OdeshinFromGrition<InputBGrition>;
+
+export const INPUT_B_GEPP = 'input-b';
+
+export type InputBGepp = typeof INPUT_B_GEPP;
+
+export type InputBVoictent = Voictent<InputBGepp, InputBOdeshin>;

--- a/packages/voictents-and-estinants-engine/src/custom/programs/estinant-builder-example/inputC.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/estinant-builder-example/inputC.ts
@@ -1,0 +1,15 @@
+import { Grition } from '../../adapter/grition';
+import { OdeshinFromGrition } from '../../adapter/odeshin';
+import { Voictent } from '../../adapter/voictent';
+
+export type InputC = unknown;
+
+export type InputCGrition = Grition<InputC>;
+
+export type InputCOdeshin = OdeshinFromGrition<InputCGrition>;
+
+export const INPUT_C_GEPP = 'input-c';
+
+export type InputCGepp = typeof INPUT_C_GEPP;
+
+export type InputCVoictent = Voictent<InputCGepp, InputCOdeshin>;

--- a/packages/voictents-and-estinants-engine/src/custom/programs/estinant-builder-example/inputD.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/estinant-builder-example/inputD.ts
@@ -1,0 +1,14 @@
+import { Hubblepup } from '../../adapter/hubblepup';
+import { Voictent } from '../../adapter/voictent';
+
+export type InputD = {
+  number: string;
+};
+
+export type InputDHubblepup = Hubblepup<InputD>;
+
+export const INPUT_D_GEPP = 'input-d';
+
+export type InputDGepp = typeof INPUT_D_GEPP;
+
+export type InputDVoictent = Voictent<InputDGepp, InputDHubblepup>;

--- a/packages/voictents-and-estinants-engine/src/custom/programs/estinant-builder-example/output.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/estinant-builder-example/output.ts
@@ -1,0 +1,15 @@
+import { Grition } from '../../adapter/grition';
+import { OdeshinFromGrition } from '../../adapter/odeshin';
+import { Voictent } from '../../adapter/voictent';
+
+export type Output = string;
+
+export type OutputGrition = Grition<Output>;
+
+export type OutputOdeshin = OdeshinFromGrition<OutputGrition>;
+
+export const OUTPUT_GEPP = 'output';
+
+export type OutputBGepp = typeof OUTPUT_GEPP;
+
+export type OutputVoictent = Voictent<OutputBGepp, OutputOdeshin>;

--- a/packages/voictents-and-estinants-engine/src/custom/programs/modelPrograms.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/modelPrograms.ts
@@ -3,25 +3,25 @@ import {
   FILE_MENTURSECTION_CONFIGURATION_GEPP,
   VOICTENTS_AND_ESTINANTS_FILE_MENTURSECTION_CONFIGURATION,
 } from '../programmable-units/file/fileMentursectionConfiguration';
-import { fileMattomer } from '../programmable-units/file/fileMattomer';
-import { fileMentursection } from '../programmable-units/file/fileMentursection';
-import { typeScriptFileConfigurationOnama } from '../programmable-units/type-script-file/typeScriptFileConfiguration';
-import { parsedTypeScriptFileMentursection } from '../programmable-units/type-script-file/parsedTypeScriptFile';
-import { typeScriptFileExportListOnama } from '../programmable-units/type-script-file/typeScriptFileExportList';
+import { categorizeFiles } from '../programmable-units/file/fileMattomer';
+import { enumerateFileSystemObjects } from '../programmable-units/file/fileMentursection';
+import { associateTypeScriptFileToTypescriptConfiguration } from '../programmable-units/type-script-file/typeScriptFileConfiguration';
+import { parseTypeScriptFile } from '../programmable-units/type-script-file/parsedTypeScriptFile';
+import { getTypeScriptFileExportList } from '../programmable-units/type-script-file/typeScriptFileExportList';
 
-import { typeScriptFileImportListOnama } from '../programmable-units/type-script-file/typeScriptFileImportList';
+import { getTypeScriptFileImportList } from '../programmable-units/type-script-file/typeScriptFileImportList';
 import {
   ENGINE_FUNCTION_CONFIGURATION,
   ENGINE_FUNCTION_CONFIGURATION_GEPP,
 } from '../programmable-units/engine-program/engineFunctionConfiguration';
-import { engineProgramPartsCortmum } from '../programmable-units/engine-program/engineProgramPartsCortmum';
-import { programBodyDeclarationsByIdentifierOnama } from '../programmable-units/type-script-file/programBodyDeclarationsByIdentifier';
-import { estinantCallExpressionParameterCortmum } from '../programmable-units/engine-program/estinant-call-expression-parameter/estinantCallExpressionParameterCortmum';
-import { estinantOutputMentursection } from '../programmable-units/engine-program/estinant-input-output/estinantOutputList';
-import { estinantInputMentursection } from '../programmable-units/engine-program/estinant-input-output/estinantInputList';
-import { estinantTreeNodeWattlection } from '../programmable-units/engine-program/tree/estinantTreeNode';
-import { engineProgramTreeNodeWattlection } from '../programmable-units/engine-program/tree/engineProgramTreeNode';
-import { engineProgramTreeToOutputFile } from '../programmable-units/engine-program/engineProgramRendererWortinator';
+import { getEngineProgramParts } from '../programmable-units/engine-program/engineProgramPartsCortmum';
+import { getProgramBodyDeclarationsByIdentifier } from '../programmable-units/type-script-file/programBodyDeclarationsByIdentifier';
+import { getEstinantCallExpressionParts } from '../programmable-units/engine-program/estinant-call-expression-parameter/estinantCallExpressionParameterCortmum';
+import { getEstinantOutputList } from '../programmable-units/engine-program/estinant-input-output/estinantOutputList';
+import { getEstinantInputList } from '../programmable-units/engine-program/estinant-input-output/estinantInputList';
+import { constructEstinantTreeNode } from '../programmable-units/engine-program/tree/estinantTreeNode';
+import { constructEngineProgramTree } from '../programmable-units/engine-program/tree/engineProgramTreeNode';
+import { constructEngineProgramTreeOutputFile } from '../programmable-units/engine-program/engineProgramRendererWortinator';
 import { buildQuirmDebugger } from '../debugger/quirmDebugger';
 
 digikikify({
@@ -32,22 +32,22 @@ digikikify({
     [ENGINE_FUNCTION_CONFIGURATION_GEPP]: [ENGINE_FUNCTION_CONFIGURATION],
   },
   estinantTuple: [
-    fileMentursection,
-    fileMattomer,
+    enumerateFileSystemObjects,
+    categorizeFiles,
 
-    typeScriptFileConfigurationOnama,
-    parsedTypeScriptFileMentursection,
-    programBodyDeclarationsByIdentifierOnama,
-    typeScriptFileExportListOnama,
-    typeScriptFileImportListOnama,
+    associateTypeScriptFileToTypescriptConfiguration,
+    parseTypeScriptFile,
+    getProgramBodyDeclarationsByIdentifier,
+    getTypeScriptFileExportList,
+    getTypeScriptFileImportList,
 
-    engineProgramPartsCortmum,
-    estinantCallExpressionParameterCortmum,
-    estinantInputMentursection,
-    estinantOutputMentursection,
-    estinantTreeNodeWattlection,
-    engineProgramTreeNodeWattlection,
-    engineProgramTreeToOutputFile,
+    getEngineProgramParts,
+    getEstinantCallExpressionParts,
+    getEstinantInputList,
+    getEstinantOutputList,
+    constructEstinantTreeNode,
+    constructEngineProgramTree,
+    constructEngineProgramTreeOutputFile,
   ],
   quirmDebugger: buildQuirmDebugger('modelPrograms'),
 });

--- a/packages/voictents-and-estinants-engine/src/custom/programs/renderTypeScriptFileRelationships.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/renderTypeScriptFileRelationships.ts
@@ -1,19 +1,19 @@
 import { digikikify } from '../../type-script-adapter/digikikify';
 import { buildQuirmDebugger } from '../debugger/quirmDebugger';
-import { fileMattomer } from '../programmable-units/file/fileMattomer';
-import { fileMentursection } from '../programmable-units/file/fileMentursection';
+import { categorizeFiles } from '../programmable-units/file/fileMattomer';
+import { enumerateFileSystemObjects } from '../programmable-units/file/fileMentursection';
 import {
   FILE_MENTURSECTION_CONFIGURATION_GEPP,
   VOICTENTS_AND_ESTINANTS_FILE_MENTURSECTION_CONFIGURATION,
 } from '../programmable-units/file/fileMentursectionConfiguration';
-import { directedGraphToGraphvizCode } from '../programmable-units/graph-visualization/directedGraphToGraphvizCode';
-import { graphvizCodeToSvgDocument } from '../programmable-units/graph-visualization/graphvizCodeToSvgDocument';
-import { svgDocumentToInteractivePage } from '../programmable-units/graph-visualization/svgDocumentToInteractivePage';
-import { typeScriptFileRelationshipWattlection } from '../programmable-units/type-script-file-relationships/typeScriptFileRelationshipList';
-import { typeScriptFileRelationshipListToDirectedGraph } from '../programmable-units/type-script-file-relationships/typeScriptFileRelationshipListToDirectedGraph';
-import { parsedTypeScriptFileMentursection } from '../programmable-units/type-script-file/parsedTypeScriptFile';
-import { typeScriptFileConfigurationOnama } from '../programmable-units/type-script-file/typeScriptFileConfiguration';
-import { typeScriptFileImportListOnama } from '../programmable-units/type-script-file/typeScriptFileImportList';
+import { encodeDirectedGraphAsGraphvizCode } from '../programmable-units/graph-visualization/directedGraphToGraphvizCode';
+import { renderGraphvizCodeToSvgDocument } from '../programmable-units/graph-visualization/graphvizCodeToSvgDocument';
+import { addInteractivityToSvgDocument } from '../programmable-units/graph-visualization/svgDocumentToInteractivePage';
+import { getTypeScriptFileRelationshipList } from '../programmable-units/type-script-file-relationships/typeScriptFileRelationshipList';
+import { digraphificateTypeScriptFileRelationshipList } from '../programmable-units/type-script-file-relationships/typeScriptFileRelationshipListToDirectedGraph';
+import { parseTypeScriptFile } from '../programmable-units/type-script-file/parsedTypeScriptFile';
+import { associateTypeScriptFileToTypescriptConfiguration } from '../programmable-units/type-script-file/typeScriptFileConfiguration';
+import { getTypeScriptFileImportList } from '../programmable-units/type-script-file/typeScriptFileImportList';
 
 digikikify({
   initialVoictentsByGepp: {
@@ -22,19 +22,19 @@ digikikify({
     ],
   },
   estinantTuple: [
-    fileMentursection,
-    fileMattomer,
+    enumerateFileSystemObjects,
+    categorizeFiles,
 
-    typeScriptFileConfigurationOnama,
-    parsedTypeScriptFileMentursection,
-    typeScriptFileImportListOnama,
+    associateTypeScriptFileToTypescriptConfiguration,
+    parseTypeScriptFile,
+    getTypeScriptFileImportList,
 
-    typeScriptFileRelationshipWattlection,
-    typeScriptFileRelationshipListToDirectedGraph,
+    getTypeScriptFileRelationshipList,
+    digraphificateTypeScriptFileRelationshipList,
 
-    directedGraphToGraphvizCode,
-    graphvizCodeToSvgDocument,
-    svgDocumentToInteractivePage,
+    encodeDirectedGraphAsGraphvizCode,
+    renderGraphvizCodeToSvgDocument,
+    addInteractivityToSvgDocument,
   ],
   quirmDebugger: buildQuirmDebugger('renderTypeScriptFileRelationships'),
 });

--- a/packages/voictents-and-estinants-engine/src/custom/programs/testGraphRender.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/testGraphRender.ts
@@ -1,12 +1,12 @@
 import { digikikify } from '../../type-script-adapter/digikikify';
 import { buildQuirmDebugger } from '../debugger/quirmDebugger';
-import { fileMattomer } from '../programmable-units/file/fileMattomer';
-import { fileMentursection } from '../programmable-units/file/fileMentursection';
+import { categorizeFiles } from '../programmable-units/file/fileMattomer';
+import { enumerateFileSystemObjects } from '../programmable-units/file/fileMentursection';
 import { FILE_MENTURSECTION_CONFIGURATION_GEPP } from '../programmable-units/file/fileMentursectionConfiguration';
 import { DIRECTED_GRAPH_GEPP } from '../programmable-units/graph-visualization/directed-graph/directedGraph';
-import { directedGraphToGraphvizCode } from '../programmable-units/graph-visualization/directedGraphToGraphvizCode';
-import { graphvizCodeToSvgDocument } from '../programmable-units/graph-visualization/graphvizCodeToSvgDocument';
-import { svgDocumentToInteractivePage } from '../programmable-units/graph-visualization/svgDocumentToInteractivePage';
+import { encodeDirectedGraphAsGraphvizCode } from '../programmable-units/graph-visualization/directedGraphToGraphvizCode';
+import { renderGraphvizCodeToSvgDocument } from '../programmable-units/graph-visualization/graphvizCodeToSvgDocument';
+import { addInteractivityToSvgDocument } from '../programmable-units/graph-visualization/svgDocumentToInteractivePage';
 
 digikikify({
   initialVoictentsByGepp: {
@@ -94,12 +94,12 @@ digikikify({
     ],
   },
   estinantTuple: [
-    fileMentursection,
-    fileMattomer,
+    enumerateFileSystemObjects,
+    categorizeFiles,
 
-    directedGraphToGraphvizCode,
-    graphvizCodeToSvgDocument,
-    svgDocumentToInteractivePage,
+    encodeDirectedGraphAsGraphvizCode,
+    renderGraphvizCodeToSvgDocument,
+    addInteractivityToSvgDocument,
   ],
   quirmDebugger: buildQuirmDebugger('testGraphRender'),
 });

--- a/packages/voictents-and-estinants-engine/src/example-programs/adapter/entities/exampleMentursection.ts
+++ b/packages/voictents-and-estinants-engine/src/example-programs/adapter/entities/exampleMentursection.ts
@@ -1,22 +1,29 @@
-import { buildMentursection } from '../../../type-script-adapter/estinant/mentursection';
+import { buildEstinant } from '../../../custom/adapter/estinant-builder/estinantBuilder';
 import { Voictent } from '../../../type-script-adapter/voictent';
-import { InitialInputVoictent } from './initialInputVoictent';
+import {
+  InitialInputVoictent,
+  INITIAL_INPUT_GEPP,
+} from './initialInputVoictent';
 
 type ValueHubblepup<T> = {
   value: T;
 };
 
-type VoictentLetter = Voictent<'letter', ValueHubblepup<string>>;
+type LetterVoictent = Voictent<'letter', ValueHubblepup<string>>;
 
-type VoictentNumber = Voictent<'number', ValueHubblepup<number>>;
+type NumberVoictent = Voictent<'number', ValueHubblepup<number>>;
 
-export const exampleMentursection = buildMentursection<
-  InitialInputVoictent,
-  [VoictentLetter, VoictentNumber]
->({
-  inputGepp: 'initial-input',
-  outputGeppTuple: ['letter', 'number'],
-  pinbe: (input) => {
+export const exampleMentursection = buildEstinant()
+  .fromHubblepup<InitialInputVoictent>({
+    gepp: INITIAL_INPUT_GEPP,
+  })
+  .toHubblepup<LetterVoictent>({
+    gepp: 'letter',
+  })
+  .toHubblepup<NumberVoictent>({
+    gepp: 'number',
+  })
+  .onPinbe((input) => {
     const letterHubblepup: ValueHubblepup<string> = {
       value: input.key,
     };
@@ -26,8 +33,8 @@ export const exampleMentursection = buildMentursection<
     };
 
     return {
-      letter: [letterHubblepup],
-      number: [numberHubblepup],
+      letter: letterHubblepup,
+      number: numberHubblepup,
     };
-  },
-});
+  })
+  .assemble();

--- a/packages/voictents-and-estinants-engine/src/example-programs/adapter/entities/exampleWortinator.ts
+++ b/packages/voictents-and-estinants-engine/src/example-programs/adapter/entities/exampleWortinator.ts
@@ -1,10 +1,12 @@
-import { buildWortinator } from '../../../type-script-adapter/estinant/wortinator';
+import { buildEstinant } from '../../../custom/adapter/estinant-builder/estinantBuilder';
 import { SerializedVoictent } from './exampleOnama';
 
-export const exampleWortinator = buildWortinator<SerializedVoictent>({
-  inputGepp: 'serialized',
-  pinbe: (input) => {
+export const exampleWortinator = buildEstinant()
+  .fromHubblepup<SerializedVoictent>({
+    gepp: 'serialized',
+  })
+  .onPinbe((input) => {
     // eslint-disable-next-line no-console
     console.log(`Wort wort wort: ${input.serialized}`);
-  },
-});
+  })
+  .assemble();

--- a/packages/voictents-and-estinants-engine/src/example-programs/adapter/exampleAdapter.ts
+++ b/packages/voictents-and-estinants-engine/src/example-programs/adapter/exampleAdapter.ts
@@ -24,6 +24,6 @@ digikikify({
     exampleCortmum,
     exampleDisatinger,
     exampleMentursection,
-  ] as const,
+  ],
   quirmDebugger: buildBasicQuirmDebugger('exampleAdapter'),
 });

--- a/packages/voictents-and-estinants-engine/src/type-script-adapter/digikikify.ts
+++ b/packages/voictents-and-estinants-engine/src/type-script-adapter/digikikify.ts
@@ -2,8 +2,8 @@ import { digikikify as coreDigikikify } from '../core/digikikify';
 import { EstinantTuple as CoreEstinantTuple } from '../core/estinant';
 import { Quirm } from '../core/quirm';
 import { StralineTuple } from '../utilities/semantic-types/straline';
-import { Estinant } from './estinant/estinant';
-import { VickenTupleToVoictentTuple } from './vicken';
+import { Estinant, Estinant2 } from './estinant/estinant';
+import { RightVickenTuple, VickenTupleToVoictentTuple } from './vicken';
 import {
   Voictent,
   VoictentArrayToVoictentItem,
@@ -15,9 +15,13 @@ import { Gepp } from './gepp';
 import { HubblepupTuple } from './hubblepup';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyEstinant = Estinant<any, any>;
+export type AnyEstinant = Estinant<any, any> | Estinant2<any, any, any>;
 
 type AnyEstinantTuple = readonly AnyEstinant[];
+
+type IDK<TRightVickenTuple extends RightVickenTuple> = {
+  [Index in keyof TRightVickenTuple]: TRightVickenTuple[Index]['voictent'];
+};
 
 /**
  * Combines the input and output VoictentTuple types for each each estinant individually
@@ -32,6 +36,15 @@ type EstinantTupleToCombinedVoictentTuple<
     ?
         | TInputVition['leftVoictent']
         | VickenTupleToVoictentTuple<TInputVition['rightVickenTuple']>[number]
+        | TOutputVoictentTuple[number]
+    : TEstinantTuple[Index] extends Estinant2<
+        infer TLeftVicken,
+        infer TRightVickenTuple,
+        infer TOutputVoictentTuple
+      >
+    ?
+        | TLeftVicken['voictent']
+        | IDK<TRightVickenTuple>[number]
         | TOutputVoictentTuple[number]
     : never;
 };

--- a/packages/voictents-and-estinants-engine/src/type-script-adapter/estinant/estinant.ts
+++ b/packages/voictents-and-estinants-engine/src/type-script-adapter/estinant/estinant.ts
@@ -1,5 +1,12 @@
+import { Tuple } from '../../utilities/semantic-types/tuple';
 import { LeftAppreffinge, RightAppreffingeTuple } from '../appreffinge';
-import { Tropoignant } from '../tropoignant';
+import { Tropoignant, Tropoignant2 } from '../tropoignant';
+import {
+  LeftVicken,
+  RightHubblepupVicken,
+  RightVicken,
+  RightVickenTuple,
+} from '../vicken';
 import { Vition } from '../vition';
 import { VoictentTuple } from '../voictent';
 
@@ -10,4 +17,54 @@ export type Estinant<
   leftAppreffinge: LeftAppreffinge<TInputVition>;
   rightAppreffingeTuple: RightAppreffingeTuple<TInputVition>;
   tropoig: Tropoignant<TInputVition, TOutputVoictentTuple>;
+};
+
+// TODO: a voictent right appreffinge does not nead a framation or croarder anymore
+type RightVickenToAppreffinge<
+  TLeftVicken extends LeftVicken,
+  TRightVicken extends RightVicken,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+> = TRightVicken extends RightHubblepupVicken<any, any, any>
+  ? {
+      gepp: TRightVicken['voictent']['gepp'];
+      isWibiz: boolean;
+      framate: (
+        leftInput: TLeftVicken['tropoignantInput'],
+      ) => Tuple<TRightVicken['zorn']>;
+      croard: (
+        rightInput: TRightVicken['tropoignantInput'],
+      ) => TRightVicken['zorn'];
+    }
+  : {
+      gepp: TRightVicken['voictent']['gepp'];
+      isWibiz: boolean;
+      // TODO: remove these as they are not used
+      framate: (leftInput: TLeftVicken['tropoignantInput']) => [''];
+      croard: (rightInput: TRightVicken['tropoignantInput']) => '';
+    };
+
+export type RightVickenTupleToAppreffingeTuple<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+> = {
+  [Index in keyof TRightVickenTuple]: RightVickenToAppreffinge<
+    TLeftVicken,
+    TRightVickenTuple[Index]
+  >;
+};
+
+export type Estinant2<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TOutputVoictentTuple extends VoictentTuple,
+> = {
+  leftAppreffinge: {
+    gepp: TLeftVicken['voictent']['gepp'];
+    isWibiz: boolean;
+  };
+  rightAppreffingeTuple: RightVickenTupleToAppreffingeTuple<
+    TLeftVicken,
+    TRightVickenTuple
+  >;
+  tropoig: Tropoignant2<TLeftVicken, TRightVickenTuple, TOutputVoictentTuple>;
 };

--- a/packages/voictents-and-estinants-engine/src/type-script-adapter/tropoignant.ts
+++ b/packages/voictents-and-estinants-engine/src/type-script-adapter/tropoignant.ts
@@ -1,3 +1,4 @@
+import { LeftVicken, RightVickenTuple } from './vicken';
 import { Vition, VitionToHubblepupInputList } from './vition';
 import { VoictentTuple, VoictentTupleToQuirmList } from './voictent';
 
@@ -6,4 +7,29 @@ export type Tropoignant<
   TOutputVoictentTuple extends VoictentTuple,
 > = (
   ...inputTuple: VitionToHubblepupInputList<TInputVition>
+) => VoictentTupleToQuirmList<TOutputVoictentTuple>;
+
+type RightVickenTupleToRightTropoignantInputTuple<
+  TRightVickenTuple extends RightVickenTuple,
+> = {
+  [Index in keyof TRightVickenTuple]: TRightVickenTuple[Index]['tropoignantInput'];
+};
+
+type LeftVickenAndRightVickenTupleToTropoignantInputTuple<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+> = [
+  TLeftVicken['tropoignantInput'],
+  ...RightVickenTupleToRightTropoignantInputTuple<TRightVickenTuple>,
+];
+
+export type Tropoignant2<
+  TLeftVicken extends LeftVicken,
+  TRightVickenTuple extends RightVickenTuple,
+  TOutputVoictentTuple extends VoictentTuple,
+> = (
+  ...inputTuple: LeftVickenAndRightVickenTupleToTropoignantInputTuple<
+    TLeftVicken,
+    TRightVickenTuple
+  >
 ) => VoictentTupleToQuirmList<TOutputVoictentTuple>;

--- a/packages/voictents-and-estinants-engine/src/type-script-adapter/vicken.ts
+++ b/packages/voictents-and-estinants-engine/src/type-script-adapter/vicken.ts
@@ -1,3 +1,4 @@
+import { OdeshinVoictent } from '../custom/adapter/odeshinVoictent';
 import { Tuple } from '../utilities/semantic-types/tuple';
 import { Zorn } from '../utilities/semantic-types/zorn';
 import {
@@ -28,7 +29,7 @@ export type VickenTupleToVoictentTuple<TVickenTuple extends VickenTuple> = {
   [Index in keyof TVickenTuple]: TVickenTuple[Index]['voictent'];
 };
 
-type VickenVoictentTupleToZornTuple<
+export type VickenVoictentTupleToZornTuple<
   TVoictentTuple extends VoictentTuple,
   TZorn extends Zorn,
 > = {
@@ -38,3 +39,78 @@ type VickenVoictentTupleToZornTuple<
 export type VickenZornTuple<TVicken extends Vicken> = Readonly<
   VickenVoictentTupleToZornTuple<TVicken['voictentTuple'], TVicken['zorn']>
 >;
+
+export type LeftVoictentVicken<TVoictent extends Voictent = Voictent> = {
+  voictent: TVoictent;
+  tropoignantInput: TVoictent['hubblepupTuple'];
+};
+
+export type LeftHubblepupVicken<TVoictent extends Voictent = Voictent> = {
+  voictent: TVoictent;
+  tropoignantInput: TVoictent['hubblepupTuple'][number];
+};
+
+export type LeftVicken = LeftVoictentVicken | LeftHubblepupVicken;
+
+export type RightVoictentVicken<TVoictent extends Voictent = Voictent> = {
+  voictent: TVoictent;
+  tropoignantInput: TVoictent['hubblepupTuple'];
+};
+
+export type RightHubblepupVicken<
+  TVoictent extends Voictent = Voictent,
+  TVoictentTuple extends Tuple<TVoictent> = Tuple<TVoictent>,
+  TZorn extends Zorn = Zorn,
+> = {
+  voictent: TVoictent;
+  voictentTuple: TVoictentTuple;
+  zorn: TZorn;
+  tropoignantInput: TVoictent['hubblepupTuple'][number];
+};
+
+export type RightVicken = RightVoictentVicken | RightHubblepupVicken;
+
+export type RightVickenTuple = Tuple<RightVicken>;
+
+export type AppendRightVickenToTuple<
+  TRightVickenTuple extends RightVickenTuple,
+  TNextRightVicken extends RightVicken,
+> = [...TRightVickenTuple, TNextRightVicken];
+
+// I DONT THINK VICKEN IS THE RIGHT TERM HERE, BUT WE'LL DEAL WITH THAT LATER(tm)
+export type OutputVoictentVicken<TVoictent extends Voictent = Voictent> = {
+  voictent: TVoictent;
+  pinbeOutput: TVoictent['hubblepupTuple'];
+};
+
+export type OutputOdeshinVoictentVicken<
+  TVoictent extends OdeshinVoictent = OdeshinVoictent,
+> = {
+  voictent: TVoictent;
+  pinbeOutput: TVoictent['hubblepupTuple'][number]['grition'][];
+};
+
+export type OutputHubblepupVicken<TVoictent extends Voictent = Voictent> = {
+  voictent: TVoictent;
+  pinbeOutput: TVoictent['hubblepupTuple'][number];
+};
+
+export type OutputGritionVicken<
+  TVoictent extends OdeshinVoictent = OdeshinVoictent,
+> = {
+  voictent: TVoictent;
+  pinbeOutput: TVoictent['hubblepupTuple'][number]['grition'];
+};
+
+export type OutputVicken =
+  | OutputVoictentVicken
+  | OutputOdeshinVoictentVicken
+  | OutputHubblepupVicken
+  | OutputGritionVicken;
+
+export type OutputVickenTuple = Tuple<OutputVicken>;
+
+export type AppendOutputVickenToTuple<
+  TOutputVickenTuple extends OutputVickenTuple,
+  TNextOutputVicken extends OutputVicken,
+> = [...TOutputVickenTuple, TNextOutputVicken];

--- a/packages/voictents-and-estinants-engine/src/utilities/semantic-types/zorn.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/semantic-types/zorn.ts
@@ -5,6 +5,8 @@ import { Straline } from './straline';
  */
 export type Zorn = Straline;
 
+export type StringZorn = string;
+
 export type ZornTuple = readonly Zorn[];
 
 export type ZornTupleTuple = readonly ZornTuple[];

--- a/packages/voictents-and-estinants-engine/src/utilities/type-script-ast/flattenIdentifiableCallExpressionChain.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/type-script-ast/flattenIdentifiableCallExpressionChain.ts
@@ -1,0 +1,54 @@
+import { TSESTree } from '@typescript-eslint/typescript-estree';
+import {
+  IdentifiableCallExpression,
+  isIdentifiableCallExpression,
+} from './isIdentifiableCallExpression';
+import {
+  IdentifiableMemberExpressionCallExpression,
+  isIdentifiableMemberExpressionCallExpression,
+} from './isMemberExpressionCallExpression';
+
+export type FlattenedCallExpressionOrError =
+  | IdentifiableCallExpression
+  | IdentifiableMemberExpressionCallExpression
+  | Error;
+
+export type FlattenedCallExpressionAndErrorList =
+  FlattenedCallExpressionOrError[];
+
+const recursivlyFlattenCallExpressionChain = (
+  callExpression: TSESTree.CallExpression,
+  flattenedCallExpressionAndErrorList: FlattenedCallExpressionAndErrorList,
+): void => {
+  if (isIdentifiableCallExpression(callExpression)) {
+    flattenedCallExpressionAndErrorList.push(callExpression);
+    return;
+  }
+
+  if (isIdentifiableMemberExpressionCallExpression(callExpression.callee)) {
+    const memberExpression = callExpression.callee;
+
+    recursivlyFlattenCallExpressionChain(
+      memberExpression.object,
+      flattenedCallExpressionAndErrorList,
+    );
+    flattenedCallExpressionAndErrorList.push(memberExpression);
+    return;
+  }
+
+  flattenedCallExpressionAndErrorList.push(
+    new Error(`Unhandled call expression callee type "${callExpression.type}"`),
+  );
+};
+
+export const flattenCallExpressionChain = (
+  callExpression: TSESTree.CallExpression,
+): FlattenedCallExpressionAndErrorList => {
+  const flattenedCallExpressionAndErrorList: FlattenedCallExpressionAndErrorList =
+    [];
+  recursivlyFlattenCallExpressionChain(
+    callExpression,
+    flattenedCallExpressionAndErrorList,
+  );
+  return flattenedCallExpressionAndErrorList;
+};

--- a/packages/voictents-and-estinants-engine/src/utilities/type-script-ast/isCallExpression.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/type-script-ast/isCallExpression.ts
@@ -1,13 +1,14 @@
 import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/typescript-estree';
 import { isSpecificIdentifier } from './isIdentifier';
+import { isNode, TypeScriptNode } from './isNode';
 
 export const isCallExpression = (
-  node: TSESTree.Node,
+  node: TypeScriptNode,
 ): node is TSESTree.CallExpression =>
-  node.type === AST_NODE_TYPES.CallExpression;
+  isNode(node) && node.type === AST_NODE_TYPES.CallExpression;
 
-export const isSpecificCallExpression = (
-  node: TSESTree.Node,
+export const isSpecificIdentifiableCallExpression = (
+  node: TypeScriptNode,
   identifierName: string,
 ): node is TSESTree.CallExpression =>
   isCallExpression(node) && isSpecificIdentifier(node.callee, identifierName);

--- a/packages/voictents-and-estinants-engine/src/utilities/type-script-ast/isIdentifiableTypeScriptTypeReference.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/type-script-ast/isIdentifiableTypeScriptTypeReference.ts
@@ -1,5 +1,6 @@
 import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/typescript-estree';
 import { Identifier, isIdentifier } from './isIdentifier';
+import { isNode, TypeScriptNode } from './isNode';
 
 export type IdentifiableTypeScriptTypeReference<TName extends string = string> =
   TSESTree.TSTypeReference & {
@@ -7,9 +8,11 @@ export type IdentifiableTypeScriptTypeReference<TName extends string = string> =
   };
 
 export const isIdentifiableTypeScriptTypeReference = (
-  node: TSESTree.Node,
+  node: TypeScriptNode,
 ): node is IdentifiableTypeScriptTypeReference =>
-  node.type === AST_NODE_TYPES.TSTypeReference && isIdentifier(node.typeName);
+  isNode(node) &&
+  node.type === AST_NODE_TYPES.TSTypeReference &&
+  isIdentifier(node.typeName);
 
 export const isSpecificIdentifiableTypeScriptTypeReference = <
   TName extends string,

--- a/packages/voictents-and-estinants-engine/src/utilities/type-script-ast/isMemberExpression.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/type-script-ast/isMemberExpression.ts
@@ -1,0 +1,7 @@
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/typescript-estree';
+import { isNode, TypeScriptNode } from './isNode';
+
+export const isMemberExpression = (
+  node: TypeScriptNode,
+): node is TSESTree.MemberExpression =>
+  isNode(node) && node.type === AST_NODE_TYPES.MemberExpression;

--- a/packages/voictents-and-estinants-engine/src/utilities/type-script-ast/isMemberExpressionCallExpression.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/type-script-ast/isMemberExpressionCallExpression.ts
@@ -1,0 +1,24 @@
+import { TSESTree } from '@typescript-eslint/typescript-estree';
+import { isCallExpression } from './isCallExpression';
+import { isIdentifier } from './isIdentifier';
+import { isMemberExpression } from './isMemberExpression';
+import { isNode, TypeScriptNode } from './isNode';
+
+export type MemberExpressionCallExpression = TSESTree.MemberExpression & {
+  object: TSESTree.CallExpression;
+};
+
+export const isMemberExpressionCallExpression = (
+  node: TypeScriptNode,
+): node is MemberExpressionCallExpression =>
+  isNode(node) && isMemberExpression(node) && isCallExpression(node.object);
+
+export type IdentifiableMemberExpressionCallExpression =
+  MemberExpressionCallExpression & {
+    property: TSESTree.Identifier;
+  };
+
+export const isIdentifiableMemberExpressionCallExpression = (
+  node: TypeScriptNode,
+): node is IdentifiableMemberExpressionCallExpression =>
+  isMemberExpressionCallExpression(node) && isIdentifier(node.property);


### PR DESCRIPTION
Use the builder pattern to make estinants. Estinants can have one or many inputs, zero, one or many outputs, each input can read from a collection or the items of a collection and collections can have a concept of an inner and outer datum. This creates many variations of estinants, and so the builder pattern allows us to address these concerns individually and have a transform with the correct TypeScript types.