### PR TITLE
Consolidate shared logic in building the builder context

### DIFF
--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/leftInputGritionAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/leftInputGritionAppreffingeBuilder.ts
@@ -1,10 +1,6 @@
 import { LeftGritionVicken } from '../../../type-script-adapter/vicken';
 import { OdeshinVoictent } from '../odeshinVoictent';
-import {
-  AggregatedOutput,
-  InputContext,
-  InputOutputContext,
-} from './estinantBuilderContext';
+import { buildInputOutputContextFromLeftInputContext } from './estinantBuilderContext';
 import { LeftAppreffinge } from './leftInputHubblepupAppreffingeBuilder';
 import {
   buildOutputGritionAppreffingeBuilder,
@@ -76,56 +72,42 @@ export const buildLeftInputGritionAppreffingeBuilder =
       <TInputVoictent extends OdeshinVoictent>(
         leftAppreffinge: LeftAppreffinge<TInputVoictent>,
       ) => {
-        const nextInputContext: InputContext = {
-          leftInputContext: {
-            gepp: leftAppreffinge.gepp,
-            isWibiz: false,
-            modifyTropoignantInput: odeshinToGrition,
-          },
-          rightInputContextTuple: [],
-        };
-
-        const nextInputOutputContext: InputOutputContext = {
-          inputContext: nextInputContext,
-          outputContext: {
-            aggregatePinbetunfOutput: () => {
-              const aggregatedOutput: AggregatedOutput = {};
-              return aggregatedOutput;
-            },
-            constituentResultNormalizerList: [],
-          },
-        };
+        const nextContext = buildInputOutputContextFromLeftInputContext({
+          gepp: leftAppreffinge.gepp,
+          isWibiz: false,
+          modifyTropoignantInput: odeshinToGrition,
+        });
 
         return {
           andFromHubblepupTuple:
             buildRightInputHubblepupTupleAppreffingeBuilder<
               LeftVicken<TInputVoictent>,
               RightInputVickenTuple
-            >(nextInputContext),
+            >(nextContext),
           andFromOdeshinVoictent:
             buildRightInputOdeshinVoictentAppreffingeBuilder<
               LeftVicken<TInputVoictent>,
               RightInputVickenTuple
-            >(nextInputContext),
+            >(nextContext),
           andFromVoictent: buildRightInputVoictentAppreffingeBuilder<
             LeftVicken<TInputVoictent>,
             RightInputVickenTuple
-          >(nextInputContext),
+          >(nextContext),
 
           toGrition: buildOutputGritionAppreffingeBuilder<
             LeftVicken<TInputVoictent>,
             RightInputVickenTuple
-          >(nextInputContext),
+          >(nextContext),
           toHubblepup: buildOutputHubblepupAppreffingeBuilder<
             LeftVicken<TInputVoictent>,
             RightInputVickenTuple,
             OutputVickenTuple
-          >(nextInputOutputContext),
+          >(nextContext),
           toHubblepupTuple: buildOutputHubblepupTupleAppreffingeBuilder<
             LeftVicken<TInputVoictent>,
             RightInputVickenTuple,
             OutputVickenTuple
-          >(nextInputOutputContext),
+          >(nextContext),
         };
       };
 

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/leftInputHubblepupAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/leftInputHubblepupAppreffingeBuilder.ts
@@ -1,10 +1,6 @@
 import { LeftHubblepupVicken } from '../../../type-script-adapter/vicken';
 import { Voictent } from '../voictent';
-import {
-  AggregatedOutput,
-  InputContext,
-  InputOutputContext,
-} from './estinantBuilderContext';
+import { buildInputOutputContextFromLeftInputContext } from './estinantBuilderContext';
 import {
   buildOutputGritionAppreffingeBuilder,
   OutputGritionAppreffingeBuilderParent,
@@ -88,61 +84,47 @@ export const buildLeftInputHubblepupAppreffingeBuilder =
       <TInputVoictent extends Voictent>(
         leftAppreffinge: LeftAppreffinge<TInputVoictent>,
       ) => {
-        const nextInputContext: InputContext = {
-          leftInputContext: {
-            gepp: leftAppreffinge.gepp,
-            isWibiz: false,
-            modifyTropoignantInput: hubblepupToHubblepup,
-          },
-          rightInputContextTuple: [],
-        };
-
-        const nextInputOutputContext: InputOutputContext = {
-          inputContext: nextInputContext,
-          outputContext: {
-            aggregatePinbetunfOutput: () => {
-              const aggregatedOutput: AggregatedOutput = {};
-              return aggregatedOutput;
-            },
-            constituentResultNormalizerList: [],
-          },
-        };
+        const nextContext = buildInputOutputContextFromLeftInputContext({
+          gepp: leftAppreffinge.gepp,
+          isWibiz: false,
+          modifyTropoignantInput: hubblepupToHubblepup,
+        });
 
         return {
           andFromGritionTuple: buildRightInputGritionTupleAppreffingeBuilder<
             LeftHubblepupVicken<TInputVoictent>,
             RightInputVickenTuple
-          >(nextInputContext),
+          >(nextContext),
           andFromHubblepupTuple:
             buildRightInputHubblepupTupleAppreffingeBuilder<
               LeftHubblepupVicken<TInputVoictent>,
               RightInputVickenTuple
-            >(nextInputContext),
+            >(nextContext),
           andFromVoictent: buildRightInputVoictentAppreffingeBuilder<
             LeftHubblepupVicken<TInputVoictent>,
             RightInputVickenTuple
-          >(nextInputContext),
+          >(nextContext),
 
           onPinbe: buildPinbetunfBuilder<
             LeftVicken<TInputVoictent>,
             RightInputVickenTuple,
             OutputVickenTuple
-          >(nextInputOutputContext),
+          >(nextContext),
 
           toGrition: buildOutputGritionAppreffingeBuilder<
             LeftHubblepupVicken<TInputVoictent>,
             RightInputVickenTuple
-          >(nextInputContext),
+          >(nextContext),
           toHubblepup: buildOutputHubblepupAppreffingeBuilder<
             LeftHubblepupVicken<TInputVoictent>,
             RightInputVickenTuple,
             OutputVickenTuple
-          >(nextInputOutputContext),
+          >(nextContext),
           toHubblepupTuple: buildOutputHubblepupTupleAppreffingeBuilder<
             LeftHubblepupVicken<TInputVoictent>,
             RightInputVickenTuple,
             OutputVickenTuple
-          >(nextInputOutputContext),
+          >(nextContext),
         };
       };
 

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/leftInputOdeshinVoictentAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/leftInputOdeshinVoictentAppreffingeBuilder.ts
@@ -4,11 +4,7 @@ import {
 } from './outputHubblepupAppreffingeBuilder';
 import { odeshinTupleToGritionTuple } from './tropoignantInputOutputModifier';
 import { LeftOdeshinVoictentVicken } from '../../../type-script-adapter/vicken';
-import {
-  AggregatedOutput,
-  InputContext,
-  InputOutputContext,
-} from './estinantBuilderContext';
+import { buildInputOutputContextFromLeftInputContext } from './estinantBuilderContext';
 import {
   buildRightInputVoictentAppreffingeBuilder,
   RightInputVoictentAppreffingeBuilderParent,
@@ -51,42 +47,28 @@ export const buildLeftInputOdeshinVoictentAppreffingeBuilder =
       <TInputVoictent extends OdeshinVoictent>(
         leftAppreffinge: LeftAppreffinge<TInputVoictent>,
       ) => {
-        const nextInputContext: InputContext = {
-          leftInputContext: {
-            gepp: leftAppreffinge.gepp,
-            isWibiz: true,
-            modifyTropoignantInput: odeshinTupleToGritionTuple,
-          },
-          rightInputContextTuple: [],
-        };
-
-        const nextInputOutputContext: InputOutputContext = {
-          inputContext: nextInputContext,
-          outputContext: {
-            aggregatePinbetunfOutput: () => {
-              const aggregatedOutput: AggregatedOutput = {};
-              return aggregatedOutput;
-            },
-            constituentResultNormalizerList: [],
-          },
-        };
+        const nextContext = buildInputOutputContextFromLeftInputContext({
+          gepp: leftAppreffinge.gepp,
+          isWibiz: true,
+          modifyTropoignantInput: odeshinTupleToGritionTuple,
+        });
 
         return {
           andFromOdeshinVoictent:
             buildRightInputOdeshinVoictentAppreffingeBuilder<
               LeftVicken<TInputVoictent>,
               RightVickenTuple
-            >(nextInputContext),
+            >(nextContext),
           andFromVoictent: buildRightInputVoictentAppreffingeBuilder<
             LeftVicken<TInputVoictent>,
             RightVickenTuple
-          >(nextInputContext),
+          >(nextContext),
 
           toHubblepup: buildOutputHubblepupAppreffingeBuilder<
             LeftVicken<TInputVoictent>,
             RightVickenTuple,
             OutputVickenTuple
-          >(nextInputOutputContext),
+          >(nextContext),
         };
       };
 

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/leftInputVoictentAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/leftInputVoictentAppreffingeBuilder.ts
@@ -5,11 +5,7 @@ import {
 } from './outputHubblepupAppreffingeBuilder';
 import { hubblepupTupleToHubblepupTuple } from './tropoignantInputOutputModifier';
 import { LeftVoictentVicken } from '../../../type-script-adapter/vicken';
-import {
-  AggregatedOutput,
-  InputContext,
-  InputOutputContext,
-} from './estinantBuilderContext';
+import { buildInputOutputContextFromLeftInputContext } from './estinantBuilderContext';
 import {
   buildRightInputVoictentAppreffingeBuilder,
   RightInputVoictentAppreffingeBuilderParent,
@@ -51,42 +47,28 @@ export const buildLeftInputVoictentAppreffingeBuilder =
       <TInputVoictent extends Voictent>(
         leftAppreffinge: LeftAppreffinge<TInputVoictent>,
       ) => {
-        const nextInputContext: InputContext = {
-          leftInputContext: {
-            gepp: leftAppreffinge.gepp,
-            isWibiz: true,
-            modifyTropoignantInput: hubblepupTupleToHubblepupTuple,
-          },
-          rightInputContextTuple: [],
-        };
-
-        const nextInputOutputContext: InputOutputContext = {
-          inputContext: nextInputContext,
-          outputContext: {
-            aggregatePinbetunfOutput: () => {
-              const aggregatedOutput: AggregatedOutput = {};
-              return aggregatedOutput;
-            },
-            constituentResultNormalizerList: [],
-          },
-        };
+        const nextContext = buildInputOutputContextFromLeftInputContext({
+          gepp: leftAppreffinge.gepp,
+          isWibiz: true,
+          modifyTropoignantInput: hubblepupTupleToHubblepupTuple,
+        });
 
         return {
           andFromOdeshinVoictent:
             buildRightInputOdeshinVoictentAppreffingeBuilder<
               LeftVicken<TInputVoictent>,
               RightVickenTuple
-            >(nextInputContext),
+            >(nextContext),
           andFromVoictent: buildRightInputVoictentAppreffingeBuilder<
             LeftVicken<TInputVoictent>,
             RightVickenTuple
-          >(nextInputContext),
+          >(nextContext),
 
           toHubblepup: buildOutputHubblepupAppreffingeBuilder<
             LeftVicken<TInputVoictent>,
             RightVickenTuple,
             OutputVickenTuple
-          >(nextInputOutputContext),
+          >(nextContext),
         };
       };
 

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/outputGritionAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/outputGritionAppreffingeBuilder.ts
@@ -4,14 +4,16 @@ import {
   RightVickenTuple,
 } from '../../../type-script-adapter/vicken';
 import { OdeshinVoictent } from '../odeshinVoictent';
-import { InputContext, InputOutputContext } from './estinantBuilderContext';
+import {
+  buildInputOutputContextFromConstituentResultNormalizer,
+  InputOutputContext,
+} from './estinantBuilderContext';
 import {
   buildPinbetunfBuilder,
   PinbetunfBuilderParent,
 } from './pinbetunfBuilder';
 import {
   buildOutputGritionNormalizer,
-  buildPinbetunfOutputAggregator,
   ZornAccessor,
 } from './tropoignantInputOutputModifier';
 
@@ -45,7 +47,7 @@ export const buildOutputGritionAppreffingeBuilder = <
   TLeftVicken extends LeftVicken,
   TRightVickenTuple extends RightVickenTuple,
 >(
-  inputContext: InputContext,
+  inputOutputContext: InputOutputContext,
 ): OutputGritionAppreffingeBuilder<TLeftVicken, TRightVickenTuple> => {
   const buildoutputGritionAppreffinge: OutputGritionAppreffingeBuilder<
     TLeftVicken,
@@ -53,20 +55,14 @@ export const buildOutputGritionAppreffingeBuilder = <
   > = <TOutputVoictent extends OdeshinVoictent>(
     outputAppreffinge: OutputAppreffinge<TLeftVicken, TOutputVoictent>,
   ) => {
-    const nextContext: InputOutputContext = {
-      inputContext,
-      outputContext: {
-        aggregatePinbetunfOutput: buildPinbetunfOutputAggregator(
-          outputAppreffinge.gepp,
-        ),
-        constituentResultNormalizerList: [
-          buildOutputGritionNormalizer(
-            outputAppreffinge.gepp,
-            outputAppreffinge.getZorn,
-          ),
-        ],
-      },
-    };
+    const nextContext = buildInputOutputContextFromConstituentResultNormalizer({
+      previousContext: inputOutputContext,
+      normalizeResult: buildOutputGritionNormalizer(
+        outputAppreffinge.gepp,
+        outputAppreffinge.getZorn,
+      ),
+      outputGepp: outputAppreffinge.gepp,
+    });
 
     return {
       onPinbe: buildPinbetunfBuilder<

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/outputHubblepupAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/outputHubblepupAppreffingeBuilder.ts
@@ -6,7 +6,10 @@ import {
   RightVickenTuple,
 } from '../../../type-script-adapter/vicken';
 import { Voictent } from '../voictent';
-import { AggregatedOutput, InputOutputContext } from './estinantBuilderContext';
+import {
+  buildInputOutputContextFromConstituentResultNormalizer,
+  InputOutputContext,
+} from './estinantBuilderContext';
 import {
   buildOutputHubblepupTupleAppreffingeBuilder,
   OutputHubblepupTupleAppreffingeBuilderParent,
@@ -15,10 +18,7 @@ import {
   buildPinbetunfBuilder,
   PinbetunfBuilderParent,
 } from './pinbetunfBuilder';
-import {
-  buildOutputHubblepupNormalizer,
-  buildPinbetunfOutputAggregator,
-} from './tropoignantInputOutputModifier';
+import { buildOutputHubblepupNormalizer } from './tropoignantInputOutputModifier';
 
 type OutputAppreffinge<TOutputVoictent extends Voictent> = {
   gepp: TOutputVoictent['gepp'];
@@ -75,23 +75,11 @@ export const buildOutputHubblepupAppreffingeBuilder = <
   > = <TOutputVoictent extends Voictent>(
     outputAppreffinge: OutputAppreffinge<TOutputVoictent>,
   ) => {
-    const nextConstituentResultNormalizerList = [
-      ...inputOutputContext.outputContext.constituentResultNormalizerList,
-      buildOutputHubblepupNormalizer(outputAppreffinge.gepp),
-    ];
-
-    const nextContext: InputOutputContext = {
-      inputContext: inputOutputContext.inputContext,
-      outputContext: {
-        aggregatePinbetunfOutput:
-          nextConstituentResultNormalizerList.length < 2
-            ? buildPinbetunfOutputAggregator(outputAppreffinge.gepp)
-            : (aggregatedOutput: AggregatedOutput): AggregatedOutput => {
-                return aggregatedOutput;
-              },
-        constituentResultNormalizerList: nextConstituentResultNormalizerList,
-      },
-    };
+    const nextContext = buildInputOutputContextFromConstituentResultNormalizer({
+      previousContext: inputOutputContext,
+      normalizeResult: buildOutputHubblepupNormalizer(outputAppreffinge.gepp),
+      outputGepp: outputAppreffinge.gepp,
+    });
 
     return {
       toHubblepup: buildOutputHubblepupAppreffingeBuilder<

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/outputHubblepupTupleAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/outputHubblepupTupleAppreffingeBuilder.ts
@@ -6,15 +6,15 @@ import {
   RightVickenTuple,
 } from '../../../type-script-adapter/vicken';
 import { Voictent } from '../voictent';
-import { AggregatedOutput, InputOutputContext } from './estinantBuilderContext';
+import {
+  buildInputOutputContextFromConstituentResultNormalizer,
+  InputOutputContext,
+} from './estinantBuilderContext';
 import {
   buildPinbetunfBuilder,
   PinbetunfBuilderParent,
 } from './pinbetunfBuilder';
-import {
-  buildOutputHubblepupTupleNormalizer,
-  buildPinbetunfOutputAggregator,
-} from './tropoignantInputOutputModifier';
+import { buildOutputHubblepupTupleNormalizer } from './tropoignantInputOutputModifier';
 
 type OutputAppreffinge<TOutputVoictent extends Voictent> = {
   gepp: TOutputVoictent['gepp'];
@@ -66,23 +66,13 @@ export const buildOutputHubblepupTupleAppreffingeBuilder = <
   > = <TOutputVoictent extends Voictent>(
     outputAppreffinge: OutputAppreffinge<TOutputVoictent>,
   ) => {
-    const nextConstituentResultNormalizerList = [
-      ...inputOutputContext.outputContext.constituentResultNormalizerList,
-      buildOutputHubblepupTupleNormalizer(outputAppreffinge.gepp),
-    ];
-
-    const nextContext: InputOutputContext = {
-      inputContext: inputOutputContext.inputContext,
-      outputContext: {
-        aggregatePinbetunfOutput:
-          nextConstituentResultNormalizerList.length < 2
-            ? buildPinbetunfOutputAggregator(outputAppreffinge.gepp)
-            : (aggregatedOutput: AggregatedOutput): AggregatedOutput => {
-                return aggregatedOutput;
-              },
-        constituentResultNormalizerList: nextConstituentResultNormalizerList,
-      },
-    };
+    const nextContext = buildInputOutputContextFromConstituentResultNormalizer({
+      previousContext: inputOutputContext,
+      normalizeResult: buildOutputHubblepupTupleNormalizer(
+        outputAppreffinge.gepp,
+      ),
+      outputGepp: outputAppreffinge.gepp,
+    });
 
     return {
       toHubblepupTuple: buildOutputHubblepupTupleAppreffingeBuilder<

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/rightInputGritionTupleAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/rightInputGritionTupleAppreffingeBuilder.ts
@@ -8,11 +8,8 @@ import { VoictentToHubblepup } from '../../../type-script-adapter/voictent';
 import { ZornTuple } from '../../../utilities/semantic-types/zorn';
 import { OdeshinVoictent } from '../odeshinVoictent';
 import {
-  AggregatedOutput,
-  extendInputContext,
-  InputContext,
+  buildInputOutputContextFromRightInputContext,
   InputOutputContext,
-  RightInputHubblepupContext,
 } from './estinantBuilderContext';
 import {
   buildOutputGritionAppreffingeBuilder,
@@ -107,7 +104,7 @@ export const buildRightInputGritionTupleAppreffingeBuilder = <
   TLeftVicken extends LeftVicken,
   TRightVickenTuple extends RightVickenTuple,
 >(
-  inputContext: InputContext,
+  inputOutputContext: InputOutputContext,
 ): RightInputGritionTupleAppreffingeBuilder<TLeftVicken, TRightVickenTuple> => {
   const buildRightInputGritionTupleAppreffinge: RightInputGritionTupleAppreffingeBuilder<
     TLeftVicken,
@@ -122,9 +119,9 @@ export const buildRightInputGritionTupleAppreffingeBuilder = <
       TZornTuple
     >,
   ) => {
-    const nextInputContext = extendInputContext<RightInputHubblepupContext>({
-      inputContext,
-      nextRightInputContext: {
+    const nextContext = buildInputOutputContextFromRightInputContext({
+      previousContext: inputOutputContext,
+      rightInputContext: {
         gepp: rightAppreffinge.gepp,
         isWibiz: false,
         framate: rightAppreffinge.framate,
@@ -132,17 +129,6 @@ export const buildRightInputGritionTupleAppreffingeBuilder = <
         modifyTropoignantInput: odeshinTupleToGritionTuple,
       },
     });
-
-    const nextInputOutputContext: InputOutputContext = {
-      inputContext: nextInputContext,
-      outputContext: {
-        aggregatePinbetunfOutput: () => {
-          const aggregatedOutput: AggregatedOutput = {};
-          return aggregatedOutput;
-        },
-        constituentResultNormalizerList: [],
-      },
-    };
 
     type TNextRightVickenTuple = AppendRightVickenToTuple<
       TRightVickenTuple,
@@ -153,34 +139,34 @@ export const buildRightInputGritionTupleAppreffingeBuilder = <
       andFromGritionTuple: buildRightInputGritionTupleAppreffingeBuilder<
         TLeftVicken,
         TNextRightVickenTuple
-      >(nextInputContext),
+      >(nextContext),
       andFromHubblepupTuple: buildRightInputHubblepupTupleAppreffingeBuilder<
         TLeftVicken,
         TNextRightVickenTuple
-      >(nextInputContext),
+      >(nextContext),
       andFromOdeshinVoictent: buildRightInputOdeshinVoictentAppreffingeBuilder<
         TLeftVicken,
         TNextRightVickenTuple
-      >(nextInputContext),
+      >(nextContext),
       andFromVoictent: buildRightInputVoictentAppreffingeBuilder<
         TLeftVicken,
         TNextRightVickenTuple
-      >(nextInputContext),
+      >(nextContext),
 
       toGrition: buildOutputGritionAppreffingeBuilder<
         TLeftVicken,
         TNextRightVickenTuple
-      >(nextInputContext),
+      >(nextContext),
       toHubblepup: buildOutputHubblepupAppreffingeBuilder<
         TLeftVicken,
         TNextRightVickenTuple,
         OutputVickenTuple
-      >(nextInputOutputContext),
+      >(nextContext),
       toHubblepupTuple: buildOutputHubblepupTupleAppreffingeBuilder<
         TLeftVicken,
         TNextRightVickenTuple,
         OutputVickenTuple
-      >(nextInputOutputContext),
+      >(nextContext),
     };
   };
 

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/rightInputHubblepupTupleAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/rightInputHubblepupTupleAppreffingeBuilder.ts
@@ -8,11 +8,8 @@ import { VoictentToHubblepup } from '../../../type-script-adapter/voictent';
 import { ZornTuple } from '../../../utilities/semantic-types/zorn';
 import { Voictent } from '../voictent';
 import {
-  AggregatedOutput,
-  extendInputContext,
-  InputContext,
+  buildInputOutputContextFromRightInputContext,
   InputOutputContext,
-  RightInputHubblepupContext,
 } from './estinantBuilderContext';
 import {
   buildOutputGritionAppreffingeBuilder,
@@ -99,7 +96,7 @@ export const buildRightInputHubblepupTupleAppreffingeBuilder = <
   TLeftVicken extends LeftVicken,
   TRightVickenTuple extends RightVickenTuple,
 >(
-  inputContext: InputContext,
+  inputOutputContext: InputOutputContext,
 ): RightInputHubblepupTupleAppreffingeBuilder<
   TLeftVicken,
   TRightVickenTuple
@@ -114,9 +111,9 @@ export const buildRightInputHubblepupTupleAppreffingeBuilder = <
       TZornTuple
     >,
   ) => {
-    const nextInputContext = extendInputContext<RightInputHubblepupContext>({
-      inputContext,
-      nextRightInputContext: {
+    const nextContext = buildInputOutputContextFromRightInputContext({
+      previousContext: inputOutputContext,
+      rightInputContext: {
         gepp: rightAppreffinge.gepp,
         isWibiz: false,
         framate: rightAppreffinge.framate,
@@ -124,17 +121,6 @@ export const buildRightInputHubblepupTupleAppreffingeBuilder = <
         modifyTropoignantInput: hubblepupTupleToHubblepupTuple,
       },
     });
-
-    const nextInputOutputContext: InputOutputContext = {
-      inputContext: nextInputContext,
-      outputContext: {
-        aggregatePinbetunfOutput: () => {
-          const aggregatedOutput: AggregatedOutput = {};
-          return aggregatedOutput;
-        },
-        constituentResultNormalizerList: [],
-      },
-    };
 
     type TNextRightVickenTuple = AppendRightVickenToTuple<
       TRightVickenTuple,
@@ -145,30 +131,30 @@ export const buildRightInputHubblepupTupleAppreffingeBuilder = <
       andFromHubblepupTuple: buildRightInputHubblepupTupleAppreffingeBuilder<
         TLeftVicken,
         TNextRightVickenTuple
-      >(nextInputContext),
+      >(nextContext),
       andFromOdeshinVoictent: buildRightInputOdeshinVoictentAppreffingeBuilder<
         TLeftVicken,
         TNextRightVickenTuple
-      >(nextInputContext),
+      >(nextContext),
       andFromVoictent: buildRightInputVoictentAppreffingeBuilder<
         TLeftVicken,
         TNextRightVickenTuple
-      >(nextInputContext),
+      >(nextContext),
 
       toGrition: buildOutputGritionAppreffingeBuilder<
         TLeftVicken,
         TNextRightVickenTuple
-      >(nextInputContext),
+      >(nextContext),
       toHubblepup: buildOutputHubblepupAppreffingeBuilder<
         TLeftVicken,
         TNextRightVickenTuple,
         OutputVickenTuple
-      >(nextInputOutputContext),
+      >(nextContext),
       toHubblepupTuple: buildOutputHubblepupTupleAppreffingeBuilder<
         TLeftVicken,
         TNextRightVickenTuple,
         OutputVickenTuple
-      >(nextInputOutputContext),
+      >(nextContext),
     };
   };
 

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/rightInputOdeshinVoictentAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/rightInputOdeshinVoictentAppreffingeBuilder.ts
@@ -5,11 +5,8 @@ import {
   RightVickenTuple,
 } from '../../../type-script-adapter/vicken';
 import {
-  AggregatedOutput,
-  extendInputContext,
-  InputContext,
+  buildInputOutputContextFromRightInputContext,
   InputOutputContext,
-  RightInputVoictentContext,
 } from './estinantBuilderContext';
 import {
   buildOutputHubblepupAppreffingeBuilder,
@@ -59,7 +56,7 @@ export const buildRightInputOdeshinVoictentAppreffingeBuilder = <
   TLeftVicken extends LeftVicken,
   TRightVickenTuple extends RightVickenTuple,
 >(
-  inputContext: InputContext,
+  inputOutputContext: InputOutputContext,
 ): RightInputOdeshinVoictentAppreffingeBuilder<
   TLeftVicken,
   TRightVickenTuple
@@ -70,41 +67,30 @@ export const buildRightInputOdeshinVoictentAppreffingeBuilder = <
   > = <TRightInputVoictent extends OdeshinVoictent>(
     rightAppreffinge: RightAppreffinge<TRightInputVoictent>,
   ) => {
-    const nextInputContext = extendInputContext<RightInputVoictentContext>({
-      inputContext,
-      nextRightInputContext: {
+    const nextContext = buildInputOutputContextFromRightInputContext({
+      previousContext: inputOutputContext,
+      rightInputContext: {
         gepp: rightAppreffinge.gepp,
         isWibiz: true,
         modifyTropoignantInput: odeshinTupleToGritionTuple,
       },
     });
 
-    const nextInputOutputContext: InputOutputContext = {
-      inputContext: nextInputContext,
-      outputContext: {
-        aggregatePinbetunfOutput: () => {
-          const aggregatedOutput: AggregatedOutput = {};
-          return aggregatedOutput;
-        },
-        constituentResultNormalizerList: [],
-      },
-    };
-
     return {
       andFromOdeshinVoictent: buildRightInputOdeshinVoictentAppreffingeBuilder<
         TLeftVicken,
         NextVickenTuple<TRightVickenTuple, TRightInputVoictent>
-      >(nextInputContext),
+      >(nextContext),
       andFromVoictent: buildRightInputVoictentAppreffingeBuilder<
         TLeftVicken,
         NextVickenTuple<TRightVickenTuple, TRightInputVoictent>
-      >(nextInputContext),
+      >(nextContext),
 
       toHubblepup: buildOutputHubblepupAppreffingeBuilder<
         TLeftVicken,
         NextVickenTuple<TRightVickenTuple, TRightInputVoictent>,
         OutputVickenTuple
-      >(nextInputOutputContext),
+      >(nextContext),
     };
   };
 

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/rightInputVoictentAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/rightInputVoictentAppreffingeBuilder.ts
@@ -6,11 +6,8 @@ import {
 } from '../../../type-script-adapter/vicken';
 import { Voictent } from '../voictent';
 import {
-  AggregatedOutput,
-  extendInputContext,
-  InputContext,
+  buildInputOutputContextFromRightInputContext,
   InputOutputContext,
-  RightInputVoictentContext,
 } from './estinantBuilderContext';
 import {
   buildOutputHubblepupAppreffingeBuilder,
@@ -60,7 +57,7 @@ export const buildRightInputVoictentAppreffingeBuilder = <
   TLeftVicken extends LeftVicken,
   TRightVickenTuple extends RightVickenTuple,
 >(
-  inputContext: InputContext,
+  inputOutputContext: InputOutputContext,
 ): RightInputVoictentAppreffingeBuilder<TLeftVicken, TRightVickenTuple> => {
   const buildRightInputHubblepupAppreffinge: RightInputVoictentAppreffingeBuilder<
     TLeftVicken,
@@ -68,42 +65,31 @@ export const buildRightInputVoictentAppreffingeBuilder = <
   > = <TRightInputVoictent extends Voictent>(
     rightAppreffinge: RightAppreffinge<TRightInputVoictent>,
   ) => {
-    const nextInputContext = extendInputContext<RightInputVoictentContext>({
-      inputContext,
-      nextRightInputContext: {
+    const nextContext = buildInputOutputContextFromRightInputContext({
+      previousContext: inputOutputContext,
+      rightInputContext: {
         gepp: rightAppreffinge.gepp,
         isWibiz: true,
         modifyTropoignantInput: hubblepupTupleToHubblepupTuple,
       },
     });
 
-    const nextInputOutputContext: InputOutputContext = {
-      inputContext: nextInputContext,
-      outputContext: {
-        aggregatePinbetunfOutput: () => {
-          const aggregatedOutput: AggregatedOutput = {};
-          return aggregatedOutput;
-        },
-        constituentResultNormalizerList: [],
-      },
-    };
-
     return {
       andFromVoictent: buildRightInputVoictentAppreffingeBuilder<
         TLeftVicken,
         NextVickenTuple<TRightVickenTuple, TRightInputVoictent>
-      >(nextInputContext),
+      >(nextContext),
 
       toHubblepup: buildOutputHubblepupAppreffingeBuilder<
         TLeftVicken,
         NextVickenTuple<TRightVickenTuple, TRightInputVoictent>,
         OutputVickenTuple
-      >(nextInputOutputContext),
+      >(nextContext),
       toHubblepupTuple: buildOutputHubblepupTupleAppreffingeBuilder<
         TLeftVicken,
         NextVickenTuple<TRightVickenTuple, TRightInputVoictent>,
         OutputVickenTuple
-      >(nextInputOutputContext),
+      >(nextContext),
     };
   };
 


### PR DESCRIPTION
The estinant (programmed transform) builder is composed of granular builders.

- left input builders need to instantiate and empty right input tuple, and empty output tuple
- right input builders need to maintain the empty output tuple while growing the right input tuple
- output builders have different aggregation logic depending on if there is 1 or many outputs
    - the case where there are zero outputs is handled by the left and right input builders