### PR TITLE
Associate top level comments to program body statements

### DIFF
--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/leftInputVoictentAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/leftInputVoictentAppreffingeBuilder.ts
@@ -22,6 +22,10 @@ import {
   buildRightInputGritionTupleAppreffingeBuilder,
   RightInputGritionTupleAppreffingeBuilderParent,
 } from './rightInputGritionTupleAppreffingeBuilder';
+import {
+  buildPinbetunfBuilder,
+  PinbetunfBuilderParent,
+} from './pinbetunfBuilder';
 
 type LeftVicken<TInputVoictent extends Voictent> =
   LeftVoictentVicken<TInputVoictent>;
@@ -45,6 +49,11 @@ export type LeftInputVoictentAppreffingeBuilder = <
   RightInputVoictentAppreffingeBuilderParent<
     LeftVicken<TInputVoictent>,
     RightVickenTuple
+  > &
+  PinbetunfBuilderParent<
+    LeftVicken<TInputVoictent>,
+    RightVickenTuple,
+    OutputVickenTuple
   > &
   OutputHubblepupAppreffingeBuilderParent<
     LeftVicken<TInputVoictent>,
@@ -81,6 +90,12 @@ export const buildLeftInputVoictentAppreffingeBuilder = (
         andFromVoictent: buildRightInputVoictentAppreffingeBuilder<
           LeftVicken<TInputVoictent>,
           RightVickenTuple
+        >(nextContext),
+
+        onPinbe: buildPinbetunfBuilder<
+          LeftVicken<TInputVoictent>,
+          RightVickenTuple,
+          OutputVickenTuple
         >(nextContext),
 
         toHubblepup: buildOutputHubblepupAppreffingeBuilder<

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/engineEstinant.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/engineEstinant.ts
@@ -11,6 +11,7 @@ export type EngineEstinant = {
   estinantName: string;
   estinantFilePath: string;
   exportedIdentifierName: string;
+  commentText: string;
   inputList: EstinantInputList;
   outputList: EstinantOutputList;
 };

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/estinant-call-expression-parameter/getEstinantBuilderCallExpressionParts.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/estinant-call-expression-parameter/getEstinantBuilderCallExpressionParts.ts
@@ -73,12 +73,15 @@ export const getEstinantBuilderCallExpressionParts = buildEstinant({
       const engineEstinantLocator = engineEstinantLocatorInput.grition;
       const { programName, estinantName } = engineEstinantLocator;
 
-      const node = bodyDeclarationsByIdentifier.get(
+      const commentedBodyDeclaration = bodyDeclarationsByIdentifier.get(
         engineEstinantLocator.exportedIdentifierName,
       );
 
       const initExpression =
-        node?.type === AST_NODE_TYPES.VariableDeclarator ? node.init : null;
+        commentedBodyDeclaration?.identifiableNode?.type ===
+        AST_NODE_TYPES.VariableDeclarator
+          ? commentedBodyDeclaration.identifiableNode.init
+          : null;
 
       const callExpression = isCallExpression(initExpression)
         ? initExpression
@@ -97,7 +100,8 @@ export const getEstinantBuilderCallExpressionParts = buildEstinant({
                   filePath: engineEstinantLocator.estinantFilePath,
                 },
                 metadata: {
-                  hasNode: node !== undefined,
+                  hasIdentifiableNode:
+                    commentedBodyDeclaration?.identifiableNode !== undefined,
                   hasInitExpression: initExpression !== null,
                   hasCallExpression: callExpression !== null,
                   initExpression,

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/estinant-call-expression-parameter/getEstinantBuilderCallExpressionParts.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/estinant-call-expression-parameter/getEstinantBuilderCallExpressionParts.ts
@@ -414,6 +414,7 @@ export const getEstinantBuilderCallExpressionParts = buildEstinant({
             grition: {
               id: uuid.v4(),
               ...engineEstinantLocator,
+              commentText: commentedBodyDeclaration?.commentText ?? '',
               inputList,
               outputList,
             } satisfies EngineEstinant,

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/file/enumerateFileSystemObjects.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/file/enumerateFileSystemObjects.ts
@@ -50,6 +50,11 @@ const partsToKebabCase = (x: string[]): string => {
   return x.join('-');
 };
 
+/**
+ * Traverses the file system starting from a given directory path, and outputs
+ * all of the encountered directories and files. It ignores file system nodes based
+ * on the input configuration's ignored list configuration.
+ */
 export const enumerateFileSystemObjects = buildEstinant({
   name: 'enumerateFileSystemObjects',
 })

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/getDirectedGraph.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/getDirectedGraph.ts
@@ -243,6 +243,15 @@ export const getDirectedGraph = buildEstinant({
             label: 'Type',
             value: 'Estinant',
           },
+          {
+            label: 'Comment',
+            // TODO: handle this character re-mapping in a more sustainable way
+            value: estinant.commentText
+              .replaceAll('\n', '')
+              .replaceAll('*', '')
+              .replaceAll("'", '')
+              .replaceAll('"', ''),
+          },
         ],
       };
     });

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file/commentedProgramBodyDeclarationList.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file/commentedProgramBodyDeclarationList.ts
@@ -1,0 +1,31 @@
+import { TSESTree } from '@typescript-eslint/typescript-estree';
+import { Grition } from '../../adapter/grition';
+import { OdeshinFromGrition } from '../../adapter/odeshin';
+import { Voictent } from '../../adapter/voictent';
+import { IdentifiableProgramBodyStatementNode } from './getIdentifiableProgramBodyStatementNode';
+
+export type CommentedProgramBodyDeclaration = {
+  commentText: string | null;
+  bodyStatement: TSESTree.ProgramStatement;
+  identifiableNode: IdentifiableProgramBodyStatementNode | null;
+};
+
+export type CommentedProgramBodyDeclarationList =
+  CommentedProgramBodyDeclaration[];
+
+export type CommentedProgramBodyDeclarationListGrition =
+  Grition<CommentedProgramBodyDeclarationList>;
+
+export type CommentedProgramBodyDeclarationListOdeshin =
+  OdeshinFromGrition<CommentedProgramBodyDeclarationListGrition>;
+
+export const COMMENTED_PROGRAM_BODY_DECLARATION_LIST_GEPP =
+  'commented-program-body-declaration-list';
+
+export type CommentedProgramBodyDeclarationListGepp =
+  typeof COMMENTED_PROGRAM_BODY_DECLARATION_LIST_GEPP;
+
+export type CommentedProgramBodyDeclarationListVoictent = Voictent<
+  CommentedProgramBodyDeclarationListGepp,
+  CommentedProgramBodyDeclarationListOdeshin
+>;

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file/commentedProgramBodyDeclarationList.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file/commentedProgramBodyDeclarationList.ts
@@ -10,6 +10,12 @@ export type CommentedProgramBodyDeclaration = {
   identifiableNode: IdentifiableProgramBodyStatementNode | null;
 };
 
+export type IdentifiableCommentedProgramBodyDeclaration = {
+  commentText: string | null;
+  bodyStatement: TSESTree.ProgramStatement;
+  identifiableNode: IdentifiableProgramBodyStatementNode;
+};
+
 export type CommentedProgramBodyDeclarationList =
   CommentedProgramBodyDeclaration[];
 

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file/getCommentedProgramBodyDeclarationList.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file/getCommentedProgramBodyDeclarationList.ts
@@ -1,0 +1,53 @@
+import { TSESTree } from '@typescript-eslint/typescript-estree';
+import { buildEstinant } from '../../adapter/estinant-builder/estinantBuilder';
+import {
+  COMMENTED_PROGRAM_BODY_DECLARATION_LIST_GEPP,
+  CommentedProgramBodyDeclaration,
+  CommentedProgramBodyDeclarationListVoictent,
+} from './commentedProgramBodyDeclarationList';
+import {
+  PARSED_TYPE_SCRIPT_FILE_GEPP,
+  ParsedTypeScriptFileVoictent,
+} from './parsedTypeScriptFile';
+import { getIdentifiableProgramBodyStatementNode } from './getIdentifiableProgramBodyStatementNode';
+
+export const getCommentedProgramBodyDeclarationList = buildEstinant({
+  name: 'getCommentedProgramBodyDeclarationList',
+})
+  .fromGrition<ParsedTypeScriptFileVoictent>({
+    gepp: PARSED_TYPE_SCRIPT_FILE_GEPP,
+  })
+  .toGrition<CommentedProgramBodyDeclarationListVoictent>({
+    gepp: COMMENTED_PROGRAM_BODY_DECLARATION_LIST_GEPP,
+    getZorn: (leftInput) => leftInput.zorn,
+  })
+  .onPinbe((parsedTypeScriptFile) => {
+    const commentList: TSESTree.Comment[] =
+      parsedTypeScriptFile.program.comments ?? [];
+
+    const programBodyStatementList = parsedTypeScriptFile.program.body;
+
+    const outputList =
+      programBodyStatementList.map<CommentedProgramBodyDeclaration>(
+        (programBodyStatement) => {
+          const comment = commentList.find((nextComment) => {
+            return (
+              programBodyStatement.loc.start.line ===
+              nextComment.loc.end.line + 1
+            );
+          });
+
+          const identifiableNode =
+            getIdentifiableProgramBodyStatementNode(programBodyStatement);
+
+          return {
+            commentText: comment?.value ?? null,
+            bodyStatement: programBodyStatement,
+            identifiableNode,
+          } satisfies CommentedProgramBodyDeclaration;
+        },
+      );
+
+    return outputList;
+  })
+  .assemble();

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file/getIdentifiableProgramBodyStatementNode.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file/getIdentifiableProgramBodyStatementNode.ts
@@ -1,0 +1,37 @@
+import { TSESTree } from '@typescript-eslint/typescript-estree';
+import { isExportNamedTypeDeclaration } from '../../../utilities/type-script-ast/isExportNamedTypeDeclaration';
+import { isExportNamedVariableDeclaration } from '../../../utilities/type-script-ast/isExportNamedVariableDeclaration';
+import {
+  IdentifiableTypeDeclaration,
+  isIdentifiableTypeDeclaration,
+} from '../../../utilities/type-script-ast/isIdentifiableTypeDeclaration';
+import {
+  IdentifiableVariableDeclarator,
+  isIdentifiableVariableDeclaration,
+} from '../../../utilities/type-script-ast/isIdentifiableVariableDeclaration';
+
+export type IdentifiableProgramBodyStatementNode =
+  | IdentifiableVariableDeclarator
+  | IdentifiableTypeDeclaration;
+
+export const getIdentifiableProgramBodyStatementNode = (
+  statement: TSESTree.ProgramStatement,
+): IdentifiableProgramBodyStatementNode | null => {
+  if (isExportNamedVariableDeclaration(statement)) {
+    return statement.declaration.declarations[0];
+  }
+
+  if (isIdentifiableVariableDeclaration(statement)) {
+    return statement.declarations[0];
+  }
+
+  if (isExportNamedTypeDeclaration(statement)) {
+    return statement.declaration;
+  }
+
+  if (isIdentifiableTypeDeclaration(statement)) {
+    return statement;
+  }
+
+  return null;
+};

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file/parseTypeScriptFile.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/type-script-file/parseTypeScriptFile.ts
@@ -38,6 +38,7 @@ export const parseTypeScriptFile = buildEstinant({
       const program: TSESTree.Program = parser.parse(fileContents, {
         project: './tsconfig.json',
         tsconfigRootDir: inputGrition.rootDirectory,
+        loc: true,
         comment: true,
       });
 

--- a/packages/voictents-and-estinants-engine/src/custom/programs/comments-example/commentsExample.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/comments-example/commentsExample.ts
@@ -1,0 +1,29 @@
+import { digikikify } from '../../../type-script-adapter/digikikify';
+import { buildBasicQuirmDebugger } from '../../debugger/quirmDebugger';
+import { categorizeFiles } from '../../programmable-units/file/categorizeFiles';
+import { enumerateFileSystemObjects } from '../../programmable-units/file/enumerateFileSystemObjects';
+import {
+  FILE_SYSTEM_OBJECT_ENUMERATOR_CONFIGURATION_GEPP,
+  VOICTENTS_AND_ESTINANTS_FULL_FILE_SYSTEM_OBJECT_ENUMERATOR_CONFIGURATION,
+} from '../../programmable-units/file/fileSystemObjectEnumeratorConfiguration';
+import { associateTypeScriptFileToTypescriptConfiguration } from '../../programmable-units/type-script-file/associateTypeScriptFileToTypescriptConfiguration';
+import { getCommentedProgramBodyDeclarationList } from '../../programmable-units/type-script-file/getCommentedProgramBodyDeclarationList';
+import { parseTypeScriptFile } from '../../programmable-units/type-script-file/parseTypeScriptFile';
+
+digikikify({
+  initialVoictentsByGepp: {
+    [FILE_SYSTEM_OBJECT_ENUMERATOR_CONFIGURATION_GEPP]: [
+      VOICTENTS_AND_ESTINANTS_FULL_FILE_SYSTEM_OBJECT_ENUMERATOR_CONFIGURATION,
+    ],
+  },
+  estinantTuple: [
+    enumerateFileSystemObjects,
+    categorizeFiles,
+
+    associateTypeScriptFileToTypescriptConfiguration,
+    parseTypeScriptFile,
+
+    getCommentedProgramBodyDeclarationList,
+  ],
+  quirmDebugger: buildBasicQuirmDebugger('commentsExample'),
+});

--- a/packages/voictents-and-estinants-engine/src/custom/programs/model-programs/modelPrograms.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/model-programs/modelPrograms.ts
@@ -22,6 +22,7 @@ import { getDirectedGraph } from '../../programmable-units/getDirectedGraph';
 import { addInteractivityToSvgDocument } from '../../programmable-units/graph-visualization/addInteractivityToSvgDocument';
 import { renderGraphvizCodeToSvgDocument } from '../../programmable-units/graph-visualization/renderGraphvizCodeToSvgDocument';
 import { encodeDirectedGraphAsGraphvizCode } from '../../programmable-units/graph-visualization/encodeDirectedGraphAsGraphvizCode';
+import { getCommentedProgramBodyDeclarationList } from '../../programmable-units/type-script-file/getCommentedProgramBodyDeclarationList';
 
 digikikify({
   initialVoictentsByGepp: {
@@ -36,6 +37,7 @@ digikikify({
 
     associateTypeScriptFileToTypescriptConfiguration,
     parseTypeScriptFile,
+    getCommentedProgramBodyDeclarationList,
     getProgramBodyDeclarationsByIdentifier,
     getTypeScriptFileImportList,
 

--- a/snapshot/commentsExample/commentsExample-runtime-profile.txt
+++ b/snapshot/commentsExample/commentsExample-runtime-profile.txt
@@ -1,0 +1,65 @@
+Collections:
+
+    file-system-object-enumerator-configuration
+      I: |X------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+      C: |-X-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+
+    file
+      I: |-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-|
+      C: |--X----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+
+    directory
+      I: |-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+      C: |--X----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+
+    type-script-file
+      I: |--XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX--|
+      C: |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------X-|
+
+    type-script-file-configuration
+      I: |---XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-|
+      C: |------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------X|
+
+    parsed-type-script-file
+      I: |----XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX|
+      C: |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+
+    commented-program-body-declaration-list
+      I: |-----XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX|
+      C: |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+
+    html-file
+      I: |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------XX|
+      C: |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+
+Transforms:
+
+  enumerateFileSystemObjects
+    file-system-object-enumerator-configuration
+      I: |X------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+         |_________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________|
+      E: |1------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+
+  categorizeFiles
+    file
+      I: |-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-|
+         |_________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________|
+      E: |-11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111-|
+
+  associateTypeScriptFileToTypescriptConfiguration
+    type-script-file
+      I: |--XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX--|
+         |_________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________|
+      E: |--111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111--|
+
+  parseTypeScriptFile
+    type-script-file-configuration
+      I: |---XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-|
+         |_________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________|
+      E: |---111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111-|
+
+  getCommentedProgramBodyDeclarationList
+    parsed-type-script-file
+      I: |----XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX|
+         |_________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________|
+      E: |----111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111|


### PR DESCRIPTION
Comment association is a fairly controversial topic, so we'll stick to only the top level comments of a file when it comes to associating a comment to an AST node.

We can now also render estinant comments in the program model!