### PR TITLE
Html data injection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4849,6 +4849,7 @@
       "devDependencies": {
         "@typescript-eslint/typescript-estree": "^5.54.0",
         "cheerio": "^1.0.0-rc.12",
+        "comment-parser": "^1.3.1",
         "nodemon": "^2.0.22",
         "type-fest": "^3.6.1"
       }
@@ -8011,6 +8012,7 @@
       "requires": {
         "@typescript-eslint/typescript-estree": "^5.54.0",
         "cheerio": "^1.0.0-rc.12",
+        "comment-parser": "*",
         "nodemon": "^2.0.22",
         "type-fest": "^3.6.1",
         "uuid": "^9.0.0"

--- a/packages/voictents-and-estinants-engine/package.json
+++ b/packages/voictents-and-estinants-engine/package.json
@@ -5,6 +5,7 @@
   "devDependencies": {
     "@typescript-eslint/typescript-estree": "^5.54.0",
     "cheerio": "^1.0.0-rc.12",
+    "comment-parser": "^1.3.1",
     "nodemon": "^2.0.22",
     "type-fest": "^3.6.1"
   }

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/getDirectedGraph.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/getDirectedGraph.ts
@@ -244,7 +244,7 @@ export const getDirectedGraph = buildEstinant({
             value: 'Estinant',
           },
           {
-            label: 'Comment',
+            label: 'Description',
             value: estinant.commentText,
           },
         ],

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/getDirectedGraph.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/getDirectedGraph.ts
@@ -245,12 +245,7 @@ export const getDirectedGraph = buildEstinant({
           },
           {
             label: 'Comment',
-            // TODO: handle this character re-mapping in a more sustainable way
-            value: estinant.commentText
-              .replaceAll('\n', '')
-              .replaceAll('*', '')
-              .replaceAll("'", '')
-              .replaceAll('"', ''),
+            value: estinant.commentText,
           },
         ],
       };

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/interactiveSvg.html
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/interactiveSvg.html
@@ -22,13 +22,13 @@
     }
 
     #side-panel label {
-      font-size: 14px;
-      margin-bottom: 4px;
+      font-size: 18px;
+      margin-bottom: 6px;
       font-weight: bold;
     }
 
     #side-panel p {
-      font-size: 12px;
+      font-size: 14px;
       margin: 0px;
       margin-bottom: 12px;
     }


### PR DESCRIPTION
- Update the directed graph metadata by id to be injected into the HTML as JS code instead of as JSON
- Use the comment-parser library to parse typedoc comments for use in the directed graphs