### PR TITLE
Sound initial programs

### DIFF
--- a/packages/voictents-and-estinants-engine/src/core/engine/digikikify.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine/digikikify.ts
@@ -46,8 +46,9 @@ export type OnHubblepupAddedToVoictentsHandler = (quirm: Quirm) => void;
 export type RuntimeStatisticsHandler = (statistics: RuntimeStatistics) => void;
 
 export type DigikikifierInput = {
+  // TODO: remove "initialQuirmTuple" and make inputVoictentList required
   inputVoictentList?: GenericVoictent2[];
-  initialQuirmTuple: QuirmTuple;
+  initialQuirmTuple?: QuirmTuple;
   estinantTuple: EstinantTuple;
   onHubblepupAddedToVoictents: OnHubblepupAddedToVoictentsHandler;
   onFinish?: RuntimeStatisticsHandler;
@@ -101,7 +102,7 @@ type RuntimeStatistics = {
  */
 export const digikikify = ({
   inputVoictentList = [],
-  initialQuirmTuple,
+  initialQuirmTuple = [],
   estinantTuple,
   onHubblepupAddedToVoictents,
   onFinish,

--- a/packages/voictents-and-estinants-engine/src/core/engine/inMemoryOdeshinVoictent.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine/inMemoryOdeshinVoictent.ts
@@ -1,0 +1,24 @@
+import { Odeshin } from '../../custom/adapter/odeshin';
+import { Gepp } from '../engine-shell/voictent/gepp';
+import {
+  InMemoryVoictent,
+  InMemoryVoictentConfiguration,
+} from './inMemoryVoictent';
+
+export type InMemoryOdeshinVoictentConfiguration<
+  TGepp extends Gepp,
+  THubblepup extends Odeshin,
+> = InMemoryVoictentConfiguration<TGepp, THubblepup>;
+
+export type GenericInMemoryOdeshinVoictentConfiguration =
+  InMemoryVoictentConfiguration<Gepp, Odeshin>;
+
+export class InMemoryOdeshinVoictent<
+  TVoictentConfiguration extends GenericInMemoryOdeshinVoictentConfiguration,
+> extends InMemoryVoictent<TVoictentConfiguration> {
+  // eslint-disable-next-line class-methods-use-this
+  getSerializableId(hubblepup: TVoictentConfiguration['hubblepup']): string {
+    // TODO: move the responsibility of normalizing the serializable id elsewhere
+    return hubblepup.zorn.replaceAll('/', ' | ');
+  }
+}

--- a/packages/voictents-and-estinants-engine/src/core/engine/inMemoryVoictent.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine/inMemoryVoictent.ts
@@ -180,21 +180,29 @@ export class InMemoryVoictent<
     }
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  getSerializableId(
+    hubblepup: TVoictentConfiguration['hubblepup'],
+    listIndex: number,
+  ): string {
+    return `${listIndex}`;
+  }
+
   private dereference(
     lanbe: VoictentItemLanbe2<TVoictentConfiguration>,
   ): TVoictentConfiguration['indexedHubblepup'] {
-    const currentIndex = this.getLanbeIndex(lanbe);
+    const listIndex = this.getLanbeIndex(lanbe);
 
-    if (currentIndex === InMemoryVoictent.minimumInclusiveIndex) {
+    if (listIndex === InMemoryVoictent.minimumInclusiveIndex) {
       throw Error('There is nothing to reference');
     }
 
-    const hubblepup = this.hubblepupTuple[currentIndex];
+    const hubblepup = this.hubblepupTuple[listIndex];
     return {
       hubblepup,
       indexByName: {
-        serializableId: `${currentIndex}`,
-        listIndex: currentIndex,
+        serializableId: this.getSerializableId(hubblepup, listIndex),
+        listIndex,
       },
     };
   }

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/datum-test-case-input/datumTestCaseInput.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/datum-test-case-input/datumTestCaseInput.ts
@@ -1,3 +1,4 @@
+import { InMemoryVoictentConfiguration } from '../../../core/engine/inMemoryVoictent';
 import { Grition } from '../../adapter/grition';
 import { OdeshinFromGrition } from '../../adapter/odeshin';
 import { Voictent } from '../../adapter/voictent';
@@ -17,6 +18,12 @@ export type DatumTestCaseInputVoictent = Voictent<
   DatumTestCaseInputGepp,
   DatumTestCaseInputOdeshin
 >;
+
+export type DatumTestCaseInputVoictentConfiguration =
+  InMemoryVoictentConfiguration<
+    DatumTestCaseInputGepp,
+    DatumTestCaseInputOdeshin
+  >;
 
 class CustomObject {
   constructor(public datumList: unknown[]) {}

--- a/packages/voictents-and-estinants-engine/src/example-programs/jsonSerializableVoictent.ts
+++ b/packages/voictents-and-estinants-engine/src/example-programs/jsonSerializableVoictent.ts
@@ -1,0 +1,115 @@
+import { posix } from 'path';
+import fs from 'fs';
+import { Hubblepup } from '../core/engine-shell/quirm/hubblepup';
+import { Gepp } from '../core/engine-shell/voictent/gepp';
+import { Voictent2 } from '../core/engine/voictent2';
+import { VoictentConfiguration } from '../core/engine/voictentConfiguration';
+import { jsonUtils } from '../utilities/json';
+import { serializeError } from '../utilities/serializeError';
+
+const createDirectory = (directoryPath: string): void => {
+  if (!fs.existsSync(directoryPath)) {
+    // eslint-disable-next-line no-console
+    console.log(`NEW: ${directoryPath}`);
+  }
+
+  fs.mkdirSync(directoryPath, { recursive: true });
+};
+
+// TODO: make the root a generic on-disk cache location that is shared by any on-disk voictent
+const ROOT_DIRECTORY = 'debug';
+createDirectory(ROOT_DIRECTORY);
+
+export type JsonSerializableIndexByName = {
+  serializableId: string;
+};
+
+export type JsonSerializable = {
+  gepp: string;
+  serializableId: string;
+  datum: unknown;
+};
+
+export type GenericJsonSerializableSourceVoictentConfiguration =
+  VoictentConfiguration<Gepp, Hubblepup, JsonSerializableIndexByName>;
+
+export type JsonSerializableVoictentConfiguration<TGepp extends Gepp> =
+  VoictentConfiguration<TGepp, JsonSerializable, JsonSerializableIndexByName>;
+
+export type GenericJsonSerializableVoictentConfiguration =
+  JsonSerializableVoictentConfiguration<Gepp>;
+
+export type JsonSerializableVoictentConstructorInput<
+  TVoictentConfiguration extends GenericJsonSerializableVoictentConfiguration,
+> = {
+  nameSpace: string;
+  gepp: TVoictentConfiguration['gepp'];
+  initialHubblepupTuple: TVoictentConfiguration['hubblepupTuple'];
+};
+
+export class JsonSerializableVoictent<
+  TVoictentConfiguration extends GenericJsonSerializableVoictentConfiguration,
+> implements Voictent2<TVoictentConfiguration>
+{
+  public readonly nameSpace: string;
+
+  public readonly gepp: TVoictentConfiguration['gepp'];
+
+  constructor({
+    nameSpace,
+    gepp,
+    initialHubblepupTuple,
+  }: JsonSerializableVoictentConstructorInput<TVoictentConfiguration>) {
+    this.nameSpace = nameSpace;
+    this.gepp = gepp;
+
+    const voictentDirectoryPath = posix.join(ROOT_DIRECTORY, this.nameSpace);
+    fs.rmSync(voictentDirectoryPath, { recursive: true, force: true });
+
+    initialHubblepupTuple.forEach((hubblepup) => {
+      this.addHubblepup(hubblepup);
+    });
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  createVoictentLanbe(): null {
+    return null;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  createVoictentItemLanbe(): null {
+    return null;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  onTickStart(): void {
+    // no op
+  }
+
+  addHubblepup(hubblepup: JsonSerializable): void {
+    const serializedResult = jsonUtils.lossyMultilineSerialize(hubblepup.datum);
+    const text =
+      typeof serializedResult === 'string'
+        ? serializedResult
+        : serializeError(serializedResult);
+
+    const extensionSuffix =
+      typeof serializedResult === 'string' ? 'json' : 'txt';
+
+    const directoryPath = posix.join(
+      ROOT_DIRECTORY,
+      this.nameSpace,
+      this.gepp,
+      hubblepup.gepp,
+    );
+
+    createDirectory(directoryPath);
+
+    const filePath = posix.join(
+      directoryPath,
+      `${hubblepup.serializableId}.${extensionSuffix}`,
+    );
+
+    fs.writeFileSync(filePath, text);
+  }
+}

--- a/packages/voictents-and-estinants-engine/src/example-programs/serializableVoictent.ts
+++ b/packages/voictents-and-estinants-engine/src/example-programs/serializableVoictent.ts
@@ -98,7 +98,10 @@ export class SerializableVoictent<
 
     createDirectory(directoryPath);
 
-    const filePath = posix.join(directoryPath, hubblepup.serializableId);
+    const filePath = posix.join(
+      directoryPath,
+      `${hubblepup.serializableId}.yml`,
+    );
 
     const text = serialize(hubblepup.datum);
 

--- a/packages/voictents-and-estinants-engine/src/example-programs/testGetCustomTypedDatum.ts
+++ b/packages/voictents-and-estinants-engine/src/example-programs/testGetCustomTypedDatum.ts
@@ -1,0 +1,78 @@
+import { Estinant } from '../core/engine-shell/estinant/estinant';
+import { QuirmList } from '../core/engine-shell/quirm/quirm';
+import { digikikify } from '../core/engine/digikikify';
+import { InMemoryOdeshinVoictent } from '../core/engine/inMemoryOdeshinVoictent';
+import { InMemoryVoictentConfiguration } from '../core/engine/inMemoryVoictent';
+import {
+  DATUM_TEST_CASE_INPUT_GEPP,
+  DATUM_TEST_CASE_INPUT_ODESHIN_LIST,
+  DatumTestCaseInputOdeshin,
+} from '../custom/programmable-units/datum-test-case-input/datumTestCaseInput';
+import { getCustomTypedDatum } from '../utilities/typed-datum/customTypedDatum';
+import { buildAddMetadataForSerialization } from './buildAddMetadataForSerialization';
+import {
+  JsonSerializableVoictent,
+  JsonSerializableVoictentConfiguration,
+} from './jsonSerializableVoictent';
+
+type SConfiguration = JsonSerializableVoictentConfiguration<'serialized'>;
+type TypedDatumVoictentConfiguration = InMemoryVoictentConfiguration<
+  'typed-datum',
+  unknown
+>;
+
+digikikify({
+  inputVoictentList: [
+    new InMemoryOdeshinVoictent({
+      gepp: DATUM_TEST_CASE_INPUT_GEPP,
+      initialHubblepupTuple: DATUM_TEST_CASE_INPUT_ODESHIN_LIST,
+    }),
+    new InMemoryOdeshinVoictent({
+      gepp: 'typed-datum',
+      initialHubblepupTuple: [],
+    }),
+    new JsonSerializableVoictent<SConfiguration>({
+      nameSpace: 'test-get-custom-typed-datum',
+      gepp: 'serialized',
+      initialHubblepupTuple: [],
+    }),
+  ],
+  initialQuirmTuple: [],
+  estinantTuple: [
+    {
+      name: 'getCustomTypedTestCaseInputTypeName',
+      leftAppreffinge: {
+        gepp: DATUM_TEST_CASE_INPUT_GEPP,
+      },
+      rightAppreffingeTuple: [],
+      tropoig: (input): QuirmList => {
+        const inputOdeshin = input.hubblepup as DatumTestCaseInputOdeshin;
+        const testCaseInput = inputOdeshin.grition;
+
+        const typedDatum = getCustomTypedDatum(testCaseInput);
+
+        return [
+          {
+            gepp: 'typed-datum',
+            hubblepup: {
+              zorn: inputOdeshin.zorn,
+              grition: {
+                typeName: typedDatum.typeName,
+              },
+            },
+          },
+        ];
+      },
+      // TODO: improve the typing of the core estinant
+    } satisfies Estinant,
+
+    buildAddMetadataForSerialization<
+      TypedDatumVoictentConfiguration,
+      SConfiguration
+    >({
+      inputGepp: 'typed-datum',
+      outputGepp: 'serialized',
+    }),
+  ],
+  onHubblepupAddedToVoictents: () => {},
+});

--- a/packages/voictents-and-estinants-engine/src/example-programs/testGetTypeScriptTypedDatum.ts
+++ b/packages/voictents-and-estinants-engine/src/example-programs/testGetTypeScriptTypedDatum.ts
@@ -1,0 +1,78 @@
+import { Estinant } from '../core/engine-shell/estinant/estinant';
+import { QuirmList } from '../core/engine-shell/quirm/quirm';
+import { digikikify } from '../core/engine/digikikify';
+import { InMemoryOdeshinVoictent } from '../core/engine/inMemoryOdeshinVoictent';
+import { InMemoryVoictentConfiguration } from '../core/engine/inMemoryVoictent';
+import {
+  DATUM_TEST_CASE_INPUT_GEPP,
+  DATUM_TEST_CASE_INPUT_ODESHIN_LIST,
+  DatumTestCaseInputOdeshin,
+} from '../custom/programmable-units/datum-test-case-input/datumTestCaseInput';
+import { getTypeScriptTypedDatum } from '../utilities/typed-datum/type-script/typeScriptTypedDatum';
+import { buildAddMetadataForSerialization } from './buildAddMetadataForSerialization';
+import {
+  JsonSerializableVoictent,
+  JsonSerializableVoictentConfiguration,
+} from './jsonSerializableVoictent';
+
+type SConfiguration = JsonSerializableVoictentConfiguration<'serialized'>;
+type TypedDatumVoictentConfiguration = InMemoryVoictentConfiguration<
+  'typed-datum',
+  unknown
+>;
+
+digikikify({
+  inputVoictentList: [
+    new InMemoryOdeshinVoictent({
+      gepp: DATUM_TEST_CASE_INPUT_GEPP,
+      initialHubblepupTuple: DATUM_TEST_CASE_INPUT_ODESHIN_LIST,
+    }),
+    new InMemoryOdeshinVoictent({
+      gepp: 'typed-datum',
+      initialHubblepupTuple: [],
+    }),
+    new JsonSerializableVoictent<SConfiguration>({
+      nameSpace: 'test-get-type-script-typed-datum',
+      gepp: 'serialized',
+      initialHubblepupTuple: [],
+    }),
+  ],
+  initialQuirmTuple: [],
+  estinantTuple: [
+    {
+      name: 'getTypedTestCaseInputTypeName',
+      leftAppreffinge: {
+        gepp: DATUM_TEST_CASE_INPUT_GEPP,
+      },
+      rightAppreffingeTuple: [],
+      tropoig: (input): QuirmList => {
+        const inputOdeshin = input.hubblepup as DatumTestCaseInputOdeshin;
+        const testCaseInput = inputOdeshin.grition;
+
+        const typedDatum = getTypeScriptTypedDatum(testCaseInput);
+
+        return [
+          {
+            gepp: 'typed-datum',
+            hubblepup: {
+              zorn: inputOdeshin.zorn,
+              grition: {
+                typeName: typedDatum.typeName,
+              },
+            },
+          },
+        ];
+      },
+      // TODO: improve the typing of the core estinant
+    } satisfies Estinant,
+
+    buildAddMetadataForSerialization<
+      TypedDatumVoictentConfiguration,
+      SConfiguration
+    >({
+      inputGepp: 'typed-datum',
+      outputGepp: 'serialized',
+    }),
+  ],
+  onHubblepupAddedToVoictents: () => {},
+});

--- a/packages/voictents-and-estinants-engine/src/example-programs/testJsonSerialization.ts
+++ b/packages/voictents-and-estinants-engine/src/example-programs/testJsonSerialization.ts
@@ -1,0 +1,35 @@
+import { digikikify } from '../core/engine/digikikify';
+import { InMemoryOdeshinVoictent } from '../core/engine/inMemoryOdeshinVoictent';
+import {
+  DATUM_TEST_CASE_INPUT_GEPP,
+  DATUM_TEST_CASE_INPUT_ODESHIN_LIST,
+} from '../custom/programmable-units/datum-test-case-input/datumTestCaseInput';
+import { buildAddMetadataForSerialization } from './buildAddMetadataForSerialization';
+import {
+  JsonSerializableVoictent,
+  JsonSerializableVoictentConfiguration,
+} from './jsonSerializableVoictent';
+
+type SConfiguration = JsonSerializableVoictentConfiguration<'serialized'>;
+
+digikikify({
+  inputVoictentList: [
+    new InMemoryOdeshinVoictent({
+      gepp: DATUM_TEST_CASE_INPUT_GEPP,
+      initialHubblepupTuple: DATUM_TEST_CASE_INPUT_ODESHIN_LIST,
+    }),
+    new JsonSerializableVoictent<SConfiguration>({
+      nameSpace: 'test-json-serialization',
+      gepp: 'serialized',
+      initialHubblepupTuple: [],
+    }),
+  ],
+  initialQuirmTuple: [],
+  estinantTuple: [
+    buildAddMetadataForSerialization({
+      inputGepp: DATUM_TEST_CASE_INPUT_GEPP,
+      outputGepp: 'serialized',
+    }),
+  ],
+  onHubblepupAddedToVoictents: () => {},
+});

--- a/packages/voictents-and-estinants-engine/src/example-programs/testSerialize.ts
+++ b/packages/voictents-and-estinants-engine/src/example-programs/testSerialize.ts
@@ -1,0 +1,37 @@
+import { digikikify } from '../core/engine/digikikify';
+import { InMemoryOdeshinVoictent } from '../core/engine/inMemoryOdeshinVoictent';
+import {
+  DATUM_TEST_CASE_INPUT_GEPP,
+  DATUM_TEST_CASE_INPUT_ODESHIN_LIST,
+  DatumTestCaseInputVoictentConfiguration,
+} from '../custom/programmable-units/datum-test-case-input/datumTestCaseInput';
+import { buildAddMetadataForSerialization } from './buildAddMetadataForSerialization';
+import { JsonSerializableVoictentConfiguration } from './jsonSerializableVoictent';
+import { SerializableVoictent } from './serializableVoictent';
+
+type SConfiguration = JsonSerializableVoictentConfiguration<'serialized'>;
+
+digikikify({
+  inputVoictentList: [
+    new InMemoryOdeshinVoictent({
+      gepp: DATUM_TEST_CASE_INPUT_GEPP,
+      initialHubblepupTuple: DATUM_TEST_CASE_INPUT_ODESHIN_LIST,
+    }),
+    new SerializableVoictent<SConfiguration>({
+      nameSpace: 'test-serialize',
+      gepp: 'serialized',
+      initialHubblepupTuple: [],
+    }),
+  ],
+  initialQuirmTuple: [],
+  estinantTuple: [
+    buildAddMetadataForSerialization<
+      DatumTestCaseInputVoictentConfiguration,
+      SConfiguration
+    >({
+      inputGepp: DATUM_TEST_CASE_INPUT_GEPP,
+      outputGepp: 'serialized',
+    }),
+  ],
+  onHubblepupAddedToVoictents: () => {},
+});

--- a/packages/voictents-and-estinants-engine/src/utilities/json.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/json.ts
@@ -29,6 +29,15 @@ export type Json =
 export type ToJson<T extends Json> = T;
 
 export const jsonUtils = {
-  multilineSerialize: (datum: Json): string => JSON.stringify(datum, null, 2),
+  lossyMultilineSerialize: (datum: unknown): string | Error => {
+    return jsonUtils.multilineSerialize(datum as Json);
+  },
+  multilineSerialize: (datum: Json): string | Error => {
+    try {
+      return JSON.stringify(datum, null, 2);
+    } catch (error) {
+      return error as Error;
+    }
+  },
   parse: (text: string): Json => JSON.parse(text) as Json,
 };

--- a/packages/voictents-and-estinants-engine/src/utilities/serializeError.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/serializeError.ts
@@ -1,0 +1,7 @@
+export const serializeError = (error: Error): string => {
+  if (error.stack === undefined) {
+    throw Error('"stack" is undefined');
+  }
+
+  return error.stack;
+};


### PR DESCRIPTION
Now that collections are first-class inputs to a program, we can create serialization collections, and use those collections to test `getTypeScriptTypedDatum`, `getCustomTypedDatum` and `serialize` in that order. Previously, the test for `serialize` depended on itself.