### PR TITLE
Separate collection input and output types and add a cached on disk collection

### DIFF
--- a/packages/voictents-and-estinants-engine/src/core/engine-shell/voictent/lanbe.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine-shell/voictent/lanbe.ts
@@ -51,7 +51,7 @@ export type VoictentItemLanbe2<
 > = BaseLanbe<
   LanbeTypeName.VoictentItemLanbe2,
   ReferenceTypeName.IndexedVoictentItem,
-  TVoictentConfiguration['indexedOutputHubblepup']
+  TVoictentConfiguration['indexedEmittedHubblepup']
 >;
 
 export type GenericVoictentItemLanbe2 =

--- a/packages/voictents-and-estinants-engine/src/core/engine-shell/voictent/lanbe.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine-shell/voictent/lanbe.ts
@@ -51,7 +51,7 @@ export type VoictentItemLanbe2<
 > = BaseLanbe<
   LanbeTypeName.VoictentItemLanbe2,
   ReferenceTypeName.IndexedVoictentItem,
-  TVoictentConfiguration['indexedHubblepup']
+  TVoictentConfiguration['indexedOutputHubblepup']
 >;
 
 export type GenericVoictentItemLanbe2 =

--- a/packages/voictents-and-estinants-engine/src/core/engine/inMemoryOdeshinVoictent.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine/inMemoryOdeshinVoictent.ts
@@ -17,7 +17,9 @@ export class InMemoryOdeshinVoictent<
   TVoictentConfiguration extends GenericInMemoryOdeshinVoictentConfiguration,
 > extends InMemoryVoictent<TVoictentConfiguration> {
   // eslint-disable-next-line class-methods-use-this
-  getSerializableId(hubblepup: TVoictentConfiguration['hubblepup']): string {
+  getSerializableId(
+    hubblepup: TVoictentConfiguration['inputHubblepup'],
+  ): string {
     // TODO: move the responsibility of normalizing the serializable id elsewhere
     return hubblepup.zorn.replaceAll('/', ' | ');
   }

--- a/packages/voictents-and-estinants-engine/src/core/engine/inMemoryOdeshinVoictent.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine/inMemoryOdeshinVoictent.ts
@@ -18,7 +18,7 @@ export class InMemoryOdeshinVoictent<
 > extends InMemoryVoictent<TVoictentConfiguration> {
   // eslint-disable-next-line class-methods-use-this
   getSerializableId(
-    hubblepup: TVoictentConfiguration['inputHubblepup'],
+    hubblepup: TVoictentConfiguration['receivedHubblepup'],
   ): string {
     // TODO: move the responsibility of normalizing the serializable id elsewhere
     return hubblepup.zorn.replaceAll('/', ' | ');

--- a/packages/voictents-and-estinants-engine/src/core/engine/inMemoryVoictent.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine/inMemoryVoictent.ts
@@ -34,7 +34,13 @@ type ReceivedHubblepupState = {
 export type InMemoryVoictentConfiguration<
   TGepp extends Gepp,
   THubblepup extends Hubblepup,
-> = VoictentConfiguration<TGepp, THubblepup, InMemoryIndexByName>;
+> = VoictentConfiguration<
+  TGepp,
+  THubblepup,
+  THubblepup,
+  InMemoryIndexByName,
+  THubblepup[]
+>;
 
 export type GenericInMemoryVoictentConfiguration =
   InMemoryVoictentConfiguration<Gepp, Hubblepup>;
@@ -43,7 +49,7 @@ export type InMemoryVoictentConstructorInput<
   TVoictentConfiguration extends GenericInMemoryVoictentConfiguration,
 > = {
   gepp: TVoictentConfiguration['gepp'];
-  initialHubblepupTuple: TVoictentConfiguration['hubblepupTuple'];
+  initialHubblepupTuple: TVoictentConfiguration['outputVoictent'];
 };
 
 export class InMemoryVoictent<
@@ -52,7 +58,7 @@ export class InMemoryVoictent<
 {
   public readonly gepp: TVoictentConfiguration['gepp'];
 
-  hubblepupTuple: TVoictentConfiguration['hubblepup'][] = [];
+  hubblepupTuple: TVoictentConfiguration['outputVoictent'] = [];
 
   indicesByLanbe: Map<VoictentItemLanbe2<TVoictentConfiguration>, number> =
     new Map();
@@ -80,8 +86,9 @@ export class InMemoryVoictent<
     });
   }
 
-  addHubblepup(hubblepup: TVoictentConfiguration['hubblepup']): void {
+  addHubblepup(hubblepup: TVoictentConfiguration['inputHubblepup']): void {
     this.receivedHubblepup.thisTick = true;
+
     this.hubblepupTuple.push(hubblepup);
   }
 
@@ -182,7 +189,7 @@ export class InMemoryVoictent<
 
   // eslint-disable-next-line class-methods-use-this
   getSerializableId(
-    hubblepup: TVoictentConfiguration['hubblepup'],
+    hubblepup: TVoictentConfiguration['inputHubblepup'],
     listIndex: number,
   ): string {
     return `${listIndex}`;
@@ -190,7 +197,7 @@ export class InMemoryVoictent<
 
   private dereference(
     lanbe: VoictentItemLanbe2<TVoictentConfiguration>,
-  ): TVoictentConfiguration['indexedHubblepup'] {
+  ): TVoictentConfiguration['indexedOutputHubblepup'] {
     const listIndex = this.getLanbeIndex(lanbe);
 
     if (listIndex === InMemoryVoictent.minimumInclusiveIndex) {

--- a/packages/voictents-and-estinants-engine/src/core/engine/inMemoryVoictent.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine/inMemoryVoictent.ts
@@ -49,7 +49,7 @@ export type InMemoryVoictentConstructorInput<
   TVoictentConfiguration extends GenericInMemoryVoictentConfiguration,
 > = {
   gepp: TVoictentConfiguration['gepp'];
-  initialHubblepupTuple: TVoictentConfiguration['outputVoictent'];
+  initialHubblepupTuple: TVoictentConfiguration['emittedVoictent'];
 };
 
 export class InMemoryVoictent<
@@ -58,7 +58,7 @@ export class InMemoryVoictent<
 {
   public readonly gepp: TVoictentConfiguration['gepp'];
 
-  hubblepupTuple: TVoictentConfiguration['outputVoictent'] = [];
+  hubblepupTuple: TVoictentConfiguration['emittedVoictent'] = [];
 
   indicesByLanbe: Map<VoictentItemLanbe2<TVoictentConfiguration>, number> =
     new Map();
@@ -86,7 +86,7 @@ export class InMemoryVoictent<
     });
   }
 
-  addHubblepup(hubblepup: TVoictentConfiguration['inputHubblepup']): void {
+  addHubblepup(hubblepup: TVoictentConfiguration['receivedHubblepup']): void {
     this.receivedHubblepup.thisTick = true;
 
     this.hubblepupTuple.push(hubblepup);
@@ -189,7 +189,7 @@ export class InMemoryVoictent<
 
   // eslint-disable-next-line class-methods-use-this
   getSerializableId(
-    hubblepup: TVoictentConfiguration['inputHubblepup'],
+    hubblepup: TVoictentConfiguration['receivedHubblepup'],
     listIndex: number,
   ): string {
     return `${listIndex}`;
@@ -197,7 +197,7 @@ export class InMemoryVoictent<
 
   private dereference(
     lanbe: VoictentItemLanbe2<TVoictentConfiguration>,
-  ): TVoictentConfiguration['indexedOutputHubblepup'] {
+  ): TVoictentConfiguration['indexedEmittedHubblepup'] {
     const listIndex = this.getLanbeIndex(lanbe);
 
     if (listIndex === InMemoryVoictent.minimumInclusiveIndex) {

--- a/packages/voictents-and-estinants-engine/src/core/engine/voictent2.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine/voictent2.ts
@@ -14,7 +14,7 @@ export type Voictent2<
     debugName: string,
   ): VoictentItemLanbe2<TVoictentConfiguration> | VoictentItemLanbe | null;
   onTickStart(): void;
-  addHubblepup(hubblepup: TVoictentConfiguration['inputHubblepup']): void;
+  addHubblepup(hubblepup: TVoictentConfiguration['receivedHubblepup']): void;
 };
 
 export type GenericVoictent2 = Voictent2<GenericVoictentConfiguration>;

--- a/packages/voictents-and-estinants-engine/src/core/engine/voictent2.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine/voictent2.ts
@@ -14,7 +14,7 @@ export type Voictent2<
     debugName: string,
   ): VoictentItemLanbe2<TVoictentConfiguration> | VoictentItemLanbe | null;
   onTickStart(): void;
-  addHubblepup(hubblepup: TVoictentConfiguration['hubblepup']): void;
+  addHubblepup(hubblepup: TVoictentConfiguration['inputHubblepup']): void;
 };
 
 export type GenericVoictent2 = Voictent2<GenericVoictentConfiguration>;

--- a/packages/voictents-and-estinants-engine/src/core/engine/voictentConfiguration.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine/voictentConfiguration.ts
@@ -7,17 +7,17 @@ import { Gepp } from '../engine-shell/voictent/gepp';
 
 export type VoictentConfiguration<
   TGepp extends Gepp,
-  TInputHubblepup extends Hubblepup,
-  TOutputHubblepup extends Hubblepup,
+  TReceivedHubblepup extends Hubblepup,
+  TEmittedHubblepup extends Hubblepup,
   IndexByName extends HubblepupIndexByName,
-  TOutputVoictent,
+  TEmittedVoictent,
 > = {
   gepp: TGepp;
   indexByName: IndexByName;
-  inputHubblepup: TInputHubblepup;
-  outputHubblepup: TOutputHubblepup;
-  indexedOutputHubblepup: IndexedHubblepup<TOutputHubblepup, IndexByName>;
-  outputVoictent: TOutputVoictent;
+  receivedHubblepup: TReceivedHubblepup;
+  emittedHubblepup: TEmittedHubblepup;
+  indexedEmittedHubblepup: IndexedHubblepup<TEmittedHubblepup, IndexByName>;
+  emittedVoictent: TEmittedVoictent;
 };
 
 export type GenericVoictentConfiguration = VoictentConfiguration<

--- a/packages/voictents-and-estinants-engine/src/core/engine/voictentConfiguration.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine/voictentConfiguration.ts
@@ -1,4 +1,3 @@
-import { Tuple } from '../../utilities/semantic-types/tuple';
 import {
   Hubblepup,
   HubblepupIndexByName,
@@ -8,18 +7,23 @@ import { Gepp } from '../engine-shell/voictent/gepp';
 
 export type VoictentConfiguration<
   TGepp extends Gepp,
-  THubblepup extends Hubblepup,
+  TInputHubblepup extends Hubblepup,
+  TOutputHubblepup extends Hubblepup,
   IndexByName extends HubblepupIndexByName,
+  TOutputVoictent,
 > = {
   gepp: TGepp;
   indexByName: IndexByName;
-  hubblepup: THubblepup;
-  hubblepupTuple: Tuple<THubblepup>;
-  indexedHubblepup: IndexedHubblepup<THubblepup, IndexByName>;
+  inputHubblepup: TInputHubblepup;
+  outputHubblepup: TOutputHubblepup;
+  indexedOutputHubblepup: IndexedHubblepup<TOutputHubblepup, IndexByName>;
+  outputVoictent: TOutputVoictent;
 };
 
 export type GenericVoictentConfiguration = VoictentConfiguration<
   Gepp,
   Hubblepup,
-  HubblepupIndexByName
+  Hubblepup,
+  HubblepupIndexByName,
+  unknown
 >;

--- a/packages/voictents-and-estinants-engine/src/example-programs/jsonSerializableVoictent.ts
+++ b/packages/voictents-and-estinants-engine/src/example-programs/jsonSerializableVoictent.ts
@@ -56,7 +56,7 @@ export type JsonSerializableVoictentConstructorInput<
 > = {
   nameSpace: string;
   gepp: TVoictentConfiguration['gepp'];
-  initialHubblepupTuple: TVoictentConfiguration['inputHubblepup'][];
+  initialHubblepupTuple: TVoictentConfiguration['receivedHubblepup'][];
 };
 
 export class JsonSerializableVoictent<

--- a/packages/voictents-and-estinants-engine/src/example-programs/jsonSerializableVoictent.ts
+++ b/packages/voictents-and-estinants-engine/src/example-programs/jsonSerializableVoictent.ts
@@ -31,10 +31,22 @@ export type JsonSerializable = {
 };
 
 export type GenericJsonSerializableSourceVoictentConfiguration =
-  VoictentConfiguration<Gepp, Hubblepup, JsonSerializableIndexByName>;
+  VoictentConfiguration<
+    Gepp,
+    Hubblepup,
+    Hubblepup,
+    JsonSerializableIndexByName,
+    Hubblepup[]
+  >;
 
 export type JsonSerializableVoictentConfiguration<TGepp extends Gepp> =
-  VoictentConfiguration<TGepp, JsonSerializable, JsonSerializableIndexByName>;
+  VoictentConfiguration<
+    TGepp,
+    JsonSerializable,
+    JsonSerializable,
+    JsonSerializableIndexByName,
+    JsonSerializable[]
+  >;
 
 export type GenericJsonSerializableVoictentConfiguration =
   JsonSerializableVoictentConfiguration<Gepp>;
@@ -44,7 +56,7 @@ export type JsonSerializableVoictentConstructorInput<
 > = {
   nameSpace: string;
   gepp: TVoictentConfiguration['gepp'];
-  initialHubblepupTuple: TVoictentConfiguration['hubblepupTuple'];
+  initialHubblepupTuple: TVoictentConfiguration['inputHubblepup'][];
 };
 
 export class JsonSerializableVoictent<

--- a/packages/voictents-and-estinants-engine/src/example-programs/serializableVoictent.ts
+++ b/packages/voictents-and-estinants-engine/src/example-programs/serializableVoictent.ts
@@ -51,14 +51,14 @@ export type GenericSerializableVoictentConfiguration =
   SerializableVoictentConfiguration<Gepp>;
 
 export type IndexedSerializable =
-  GenericSerializableVoictentConfiguration['indexedOutputHubblepup'];
+  GenericSerializableVoictentConfiguration['indexedEmittedHubblepup'];
 
 export type SerializableVoictentConstructorInput<
   TVoictentConfiguration extends GenericSerializableVoictentConfiguration,
 > = {
   nameSpace: string;
   gepp: TVoictentConfiguration['gepp'];
-  initialHubblepupTuple: TVoictentConfiguration['inputHubblepup'][];
+  initialHubblepupTuple: TVoictentConfiguration['receivedHubblepup'][];
 };
 
 export class SerializableVoictent<

--- a/packages/voictents-and-estinants-engine/src/example-programs/serializableVoictent.ts
+++ b/packages/voictents-and-estinants-engine/src/example-programs/serializableVoictent.ts
@@ -30,23 +30,35 @@ export type Serializable = {
 };
 
 export type GenericSerializableSourceVoictentConfiguration =
-  VoictentConfiguration<Gepp, Hubblepup, SerializableIndexByName>;
+  VoictentConfiguration<
+    Gepp,
+    Hubblepup,
+    Hubblepup,
+    SerializableIndexByName,
+    Hubblepup[]
+  >;
 
 export type SerializableVoictentConfiguration<TGepp extends Gepp> =
-  VoictentConfiguration<TGepp, Serializable, SerializableIndexByName>;
+  VoictentConfiguration<
+    TGepp,
+    Serializable,
+    Serializable,
+    SerializableIndexByName,
+    Serializable[]
+  >;
 
 export type GenericSerializableVoictentConfiguration =
   SerializableVoictentConfiguration<Gepp>;
 
 export type IndexedSerializable =
-  GenericSerializableVoictentConfiguration['indexedHubblepup'];
+  GenericSerializableVoictentConfiguration['indexedOutputHubblepup'];
 
 export type SerializableVoictentConstructorInput<
   TVoictentConfiguration extends GenericSerializableVoictentConfiguration,
 > = {
   nameSpace: string;
   gepp: TVoictentConfiguration['gepp'];
-  initialHubblepupTuple: TVoictentConfiguration['hubblepupTuple'];
+  initialHubblepupTuple: TVoictentConfiguration['inputHubblepup'][];
 };
 
 export class SerializableVoictent<

--- a/packages/voictents-and-estinants-engine/src/example-programs/serializableVoictent.ts
+++ b/packages/voictents-and-estinants-engine/src/example-programs/serializableVoictent.ts
@@ -77,8 +77,12 @@ export class SerializableVoictent<
     this.nameSpace = nameSpace;
     this.gepp = gepp;
 
-    const voictentDirectoryPath = posix.join(ROOT_DIRECTORY, this.nameSpace);
-    fs.rmSync(voictentDirectoryPath, { recursive: true, force: true });
+    const voictentGeppDirectoryPath = posix.join(
+      ROOT_DIRECTORY,
+      this.nameSpace,
+      this.gepp,
+    );
+    fs.rmSync(voictentGeppDirectoryPath, { recursive: true, force: true });
 
     initialHubblepupTuple.forEach((hubblepup) => {
       this.addHubblepup(hubblepup);

--- a/packages/voictents-and-estinants-engine/src/example-programs/testCachedOnDiskDatum.ts
+++ b/packages/voictents-and-estinants-engine/src/example-programs/testCachedOnDiskDatum.ts
@@ -1,0 +1,67 @@
+import fs from 'fs';
+import { digikikify } from '../core/engine/digikikify';
+import {
+  InMemoryVoictent,
+  InMemoryVoictentConfiguration,
+} from '../core/engine/inMemoryVoictent';
+import {
+  CacheableAccessor,
+  CachedOnDiskVoictent,
+  CachedOnDiskVoictentConfiguration,
+} from '../core/engine/cachedOnDiskVoictent';
+import { QuirmList } from '../core/engine-shell/quirm/quirm';
+
+type InputVoictentConfiguration = InMemoryVoictentConfiguration<
+  'input',
+  CacheableAccessor<string>
+>;
+
+type CachedVoictentConfiguration = CachedOnDiskVoictentConfiguration<
+  'cached',
+  string
+>;
+
+const nameSpace = 'test-cached-on-disk-datum';
+
+const filePath =
+  'packages/voictents-and-estinants-engine/src/core/engine/digikikify.ts';
+
+digikikify({
+  inputVoictentList: [
+    new InMemoryVoictent<InputVoictentConfiguration>({
+      gepp: 'input',
+      initialHubblepupTuple: [
+        {
+          zorn: filePath.replaceAll('/', ' | '),
+          lastModified: fs.statSync(filePath).mtime.toISOString(),
+          grition:
+            (): CachedVoictentConfiguration['emittedHubblepup']['grition'] => {
+              const text = fs.readFileSync(filePath, 'utf8');
+              return text;
+            },
+        },
+      ],
+    }),
+    new CachedOnDiskVoictent<CachedVoictentConfiguration>({
+      nameSpace,
+      gepp: 'cached',
+    }),
+  ],
+  estinantTuple: [
+    {
+      leftAppreffinge: {
+        gepp: 'input',
+      },
+      rightAppreffingeTuple: [],
+      tropoig: (rawInput): QuirmList => {
+        return [
+          {
+            gepp: 'cached',
+            hubblepup: rawInput.hubblepup,
+          },
+        ];
+      },
+    },
+  ],
+  onHubblepupAddedToVoictents: () => {},
+});

--- a/packages/voictents-and-estinants-engine/src/utilities/json.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/json.ts
@@ -30,14 +30,14 @@ export type ToJson<T extends Json> = T;
 
 export const jsonUtils = {
   lossyMultilineSerialize: (datum: unknown): string | Error => {
-    return jsonUtils.multilineSerialize(datum as Json);
-  },
-  multilineSerialize: (datum: Json): string | Error => {
     try {
-      return JSON.stringify(datum, null, 2);
+      return jsonUtils.multilineSerialize(datum as Json);
     } catch (error) {
       return error as Error;
     }
+  },
+  multilineSerialize: (datum: Json): string => {
+    return JSON.stringify(datum, null, 2);
   },
   parse: (text: string): Json => JSON.parse(text) as Json,
 };


### PR DESCRIPTION
The cached on disk collection receives an input datum with an inner-datum accessor while emitting a datum that has the resolved inner datum. This way the collection can use the on-disk data if available and only call the accessor if needed. The collection also does not emit a datum until that datum is received so that downstream transforms aren't triggered twice.