### PR TITLE
Update estinant builder to use core estinant 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "eslint-plugin-jsdoc": "^39.8.0",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-unicorn": "^45.0.2",
-        "markdownlint-cli": "^0.32.2"
+        "markdownlint-cli": "^0.32.2",
+        "typescript": "^5.0.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4526,14 +4527,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "license": "Apache-2.0",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/uc.micro": {
@@ -4747,11 +4749,37 @@
         "yaml": "^2.2.1"
       }
     },
+    "packages/constraint-engine/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "packages/ikaria-test": {
       "devDependencies": {
         "base-tsconfig": "*",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.4"
+      }
+    },
+    "packages/ikaria-test/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "packages/mouse-test": {
@@ -4840,6 +4868,19 @@
         "ikaria-test": "*",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.4"
+      }
+    },
+    "packages/rat-test/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "packages/voictents-and-estinants-engine": {
@@ -5799,6 +5840,14 @@
         "rat-test": "*",
         "typescript": "^4.9.4",
         "yaml": "^2.2.1"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.9.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+          "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+          "dev": true
+        }
       }
     },
     "create-require": {
@@ -6608,6 +6657,14 @@
         "base-tsconfig": "*",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.4"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.9.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+          "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+          "dev": true
+        }
       }
     },
     "import-fresh": {
@@ -7410,6 +7467,14 @@
         "ikaria-test": "*",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.4"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.9.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+          "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+          "dev": true
+        }
       }
     },
     "rc": {
@@ -7943,7 +8008,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.4"
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw=="
     },
     "uc.micro": {
       "version": "1.0.6",
@@ -8012,7 +8079,7 @@
       "requires": {
         "@typescript-eslint/typescript-estree": "^5.54.0",
         "cheerio": "^1.0.0-rc.12",
-        "comment-parser": "*",
+        "comment-parser": "^1.3.1",
         "nodemon": "^2.0.22",
         "type-fest": "^3.6.1",
         "uuid": "^9.0.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "eslint-plugin-jsdoc": "^39.8.0",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-unicorn": "^45.0.2",
-    "markdownlint-cli": "^0.32.2"
+    "markdownlint-cli": "^0.32.2",
+    "typescript": "^5.0.4"
   },
   "workspaces": [
     "packages/*"

--- a/packages/voictents-and-estinants-engine/src/core/engine-shell/appreffinge/leftInputAppreffinge.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine-shell/appreffinge/leftInputAppreffinge.ts
@@ -3,7 +3,7 @@ import { GenericLeftInputVicken } from '../vicken/leftInputVicken';
 export type LeftInputAppreffinge<
   TLeftInputVicken extends GenericLeftInputVicken,
 > = {
-  gepp: TLeftInputVicken['gepp'];
+  gepp: TLeftInputVicken['voque']['gepp'];
   isWibiz: TLeftInputVicken['isWibiz'];
 };
 

--- a/packages/voictents-and-estinants-engine/src/core/engine-shell/appreffinge/rightInputAppreffinge.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine-shell/appreffinge/rightInputAppreffinge.ts
@@ -13,7 +13,7 @@ export type RightInputAppreffinge<
   TRightInputVicken extends GenericRightInputVicken,
 > = Merge<
   {
-    gepp: TRightInputVicken['gepp'];
+    gepp: TRightInputVicken['voque']['gepp'];
     isWibiz: TRightInputVicken['isWibiz'];
   },
   TRightInputVicken extends GenericRightInputHubblepupTupleVicken

--- a/packages/voictents-and-estinants-engine/src/core/engine-shell/estinant/tropoignant.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine-shell/estinant/tropoignant.ts
@@ -26,3 +26,9 @@ export type Tropoignant2<
   leftInput: TLeftVicken['tropoignantInput'],
   ...rightInputTuple: RightInputVickenTupleTropoignantInputTuple<TRightVickenTuple>
 ) => TOutputVicken['tropoignantOutput'];
+
+export type GenericTropoignant2 = Tropoignant2<
+  GenericLeftInputVicken,
+  GenericRightInputVickenTuple,
+  GenericOutputVicken
+>;

--- a/packages/voictents-and-estinants-engine/src/core/engine-shell/quirm/quirm.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine-shell/quirm/quirm.ts
@@ -1,4 +1,5 @@
 import { List } from '../../../utilities/semantic-types/list';
+import { GenericVoque } from '../../engine/voque';
 import { Gepp } from '../voictent/gepp';
 import { Hubblepup } from './hubblepup';
 
@@ -14,3 +15,10 @@ export type Quirm = {
 export type QuirmTuple = readonly Quirm[];
 
 export type QuirmList = List<Quirm>;
+
+export type Quirm2<TVoque extends GenericVoque> = {
+  gepp: TVoque['gepp'];
+  hubblepup: TVoque['emittedHubblepup'];
+};
+
+export type GenericQuirm2 = Quirm2<GenericVoque>;

--- a/packages/voictents-and-estinants-engine/src/core/engine-shell/vicken/leftInputVicken.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine-shell/vicken/leftInputVicken.ts
@@ -1,18 +1,17 @@
 import { GenericVoque, UnsafeVoque } from '../../engine/voque';
-import { Gepp } from '../voictent/gepp';
 
 type BaseLeftInputVicken<
-  TGepp extends Gepp,
+  TVoque extends GenericVoque,
   TTropoignantInput,
   TIsWibiz extends boolean,
 > = {
-  gepp: TGepp;
+  voque: TVoque;
   tropoignantInput: TTropoignantInput;
   isWibiz: TIsWibiz;
 };
 
 export type LeftInputHubblepupVicken<TVoque extends GenericVoque> =
-  BaseLeftInputVicken<TVoque['gepp'], TVoque['indexedEmittedHubblepup'], false>;
+  BaseLeftInputVicken<TVoque, TVoque['indexedEmittedHubblepup'], false>;
 
 export type GenericLeftInputHubblepupVicken =
   LeftInputHubblepupVicken<GenericVoque>;
@@ -21,7 +20,7 @@ export type UnsafeLeftInputHubblepupVicken =
   LeftInputHubblepupVicken<UnsafeVoque>;
 
 export type LeftInputVoictentVicken<TVoque extends GenericVoque> =
-  BaseLeftInputVicken<TVoque['gepp'], TVoque['emittedVoictent'], true>;
+  BaseLeftInputVicken<TVoque, TVoque['emittedVoictent'], true>;
 
 export type GenericLeftInputVoictentVicken =
   LeftInputVoictentVicken<GenericVoque>;

--- a/packages/voictents-and-estinants-engine/src/core/engine-shell/vicken/outputVicken.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine-shell/vicken/outputVicken.ts
@@ -15,6 +15,7 @@ type OutputGeppTuple<TOutputVoqueOptionTuple extends GenericVoqueTuple> = {
 };
 
 export type OutputVicken<TOutputVoqueOptionTuple extends GenericVoqueTuple> = {
+  outputVoqueOptionTuple: TOutputVoqueOptionTuple;
   geppTuple: OutputGeppTuple<TOutputVoqueOptionTuple>;
   tropoignantOutput: Simplify<
     UnionToIntersection<OutputRecordUnion<TOutputVoqueOptionTuple>>

--- a/packages/voictents-and-estinants-engine/src/core/engine-shell/vicken/rightInputVicken.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine-shell/vicken/rightInputVicken.ts
@@ -1,15 +1,14 @@
 import { GenericVoque, UnsafeVoque } from '../../engine/voque';
 import { ZornTuple } from '../../../utilities/semantic-types/zorn';
-import { Gepp } from '../voictent/gepp';
 import { Tuple } from '../../../utilities/semantic-types/tuple';
 
 type BaseRightInputVicken<
-  TGepp extends Gepp,
+  TVoque extends GenericVoque,
   TTropoignantInput,
   TIsWibiz extends boolean,
   TZornTuple extends ZornTuple,
 > = {
-  gepp: TGepp;
+  voque: TVoque;
   tropoignantInput: TTropoignantInput;
   isWibiz: TIsWibiz;
   zornTuple: TZornTuple;
@@ -27,7 +26,7 @@ export type RightInputHubblepupTupleVicken<
   TVoque extends GenericVoque,
   TZornTuple extends ZornTuple,
 > = BaseRightInputVicken<
-  TVoque['gepp'],
+  TVoque,
   RightTropoignantInputTupleFromZornTuple<TVoque, TZornTuple>,
   false,
   TZornTuple
@@ -40,7 +39,7 @@ export type UnsafeRightInputHubblepupTupleVicken =
   RightInputHubblepupTupleVicken<UnsafeVoque, ZornTuple>;
 
 export type RightInputVoictentVicken<TVoque extends GenericVoque> =
-  BaseRightInputVicken<TVoque['gepp'], TVoque['emittedVoictent'], true, never>;
+  BaseRightInputVicken<TVoque, TVoque['emittedVoictent'], true, never>;
 
 export type GenericRightInputVoictentVicken =
   RightInputVoictentVicken<GenericVoque>;

--- a/packages/voictents-and-estinants-engine/src/core/engine/digikikify.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine/digikikify.ts
@@ -195,7 +195,7 @@ export const digikikify = ({
       `Encountered ${errorMessageList.length} errors:`,
       ...errorMessageList.slice(0, 100).map((errorMessage, index) => {
         // 4 accounts for 2 spaces and then a 2 digit number
-        return `${`${index}`.padStart(4, ' ')} ${errorMessage}`;
+        return `${`${index}`.padStart(4, ' ')}: ${errorMessage}`;
       }),
     ].join('\n');
 
@@ -427,6 +427,15 @@ export const digikikify = ({
                 leftInputTypeName === ReferenceTypeName.IndexedVoictentItem
               ) {
                 zornTuple = rightDreanor.framate(leftInputReferenceValue);
+              } else if (
+                rightDreanor.typeName ===
+                  DreanorTypeName.RightVoictentItem2Dreanor &&
+                leftInputTypeName === ReferenceTypeName.Voictent
+              ) {
+                // TODO: this cast is incorrect, and is masking some underlying issue. The input type should probably be "never"
+                zornTuple = rightDreanor.framate(
+                  leftInput as GenericIndexedHubblepup,
+                );
               } else {
                 // TODO: remove this else once all voictent item lanbes return indexed hubblepups
 

--- a/packages/voictents-and-estinants-engine/src/core/engine/voque.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine/voque.ts
@@ -28,6 +28,7 @@ export type GenericVoque = Voque<
   HubblepupIndexByName,
   unknown
 >;
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type UnsafeVoque = Voque<any, any, any, any, any>;
 

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/estinantAssembler.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/estinantAssembler.ts
@@ -1,18 +1,46 @@
-import { Estinant as CoreEstinant } from '../../../core/engine-shell/estinant/estinant';
-import { Estinant2 } from '../../../type-script-adapter/estinant/estinant';
-import { QuirmList } from '../../../type-script-adapter/quirm';
+import { RightInputAppreffinge } from '../../../core/engine-shell/appreffinge/rightInputAppreffinge';
 import {
+  Estinant2,
+  GenericEstinant2,
+} from '../../../core/engine-shell/estinant/estinant';
+import { GenericTropoignant2 } from '../../../core/engine-shell/estinant/tropoignant';
+import { GenericIndexedHubblepup } from '../../../core/engine-shell/quirm/hubblepup';
+import {
+  GenericLeftInputVicken,
+  LeftInputVoictentVicken,
+} from '../../../core/engine-shell/vicken/leftInputVicken';
+import { GenericOutputVicken } from '../../../core/engine-shell/vicken/outputVicken';
+import {
+  GenericRightInputHubblepupTupleVicken,
+  GenericRightInputVoictentVicken,
+} from '../../../core/engine-shell/vicken/rightInputVicken';
+import {
+  CoreOutputVickenFromOutputVickenTuple,
+  CoreRightInputVickenTupleFromRightVickenTuple,
   LeftVicken,
   OutputVickenTuple,
   RightVickenTuple,
 } from '../../../type-script-adapter/vicken';
-import { AssemblerContext } from './estinantBuilderContext';
+import { AdaptedVoqueFromVoictent } from '../../../type-script-adapter/voictent';
+import { Zorn, ZornTuple } from '../../../utilities/semantic-types/zorn';
+import {
+  AssemblerContext,
+  CoreConstituentOutputEntry,
+} from './estinantBuilderContext';
 
 export type EstinantAssembler<
   TLeftVicken extends LeftVicken,
   TRightVickenTuple extends RightVickenTuple,
   TOutputVickenTuple extends OutputVickenTuple,
-> = () => Estinant2<TLeftVicken, TRightVickenTuple, TOutputVickenTuple>;
+> = () => CoreOutputVickenFromOutputVickenTuple<TOutputVickenTuple> extends GenericOutputVicken
+  ? Estinant2<
+      LeftInputVoictentVicken<
+        AdaptedVoqueFromVoictent<TLeftVicken['voictent']>
+      >,
+      CoreRightInputVickenTupleFromRightVickenTuple<TRightVickenTuple>,
+      CoreOutputVickenFromOutputVickenTuple<TOutputVickenTuple>
+    >
+  : never;
 
 export const buildEstinantAssembler = <
   TLeftVicken extends LeftVicken,
@@ -32,71 +60,104 @@ export const buildEstinantAssembler = <
       outputContext,
     } = assemblerContext;
 
-    const estinant = {
-      name: instantiationContext.name,
-      leftAppreffinge: {
-        gepp: leftInputContext.gepp,
-        isWibiz: leftInputContext.isWibiz,
-      },
-      rightAppreffingeTuple: rightInputContextTuple.map((rightInputContext) => {
-        if (rightInputContext.isWibiz) {
-          return {
-            gepp: rightInputContext.gepp,
-            isWibiz: rightInputContext.isWibiz,
-            framate: () => [''],
-            croard: () => '',
-          };
-        }
+    const tropoig: GenericTropoignant2 = (leftInput, ...rightInputTuple) => {
+      const adaptedLeftInput = leftInputContext.isWibiz
+        ? leftInput
+        : (leftInput as GenericIndexedHubblepup).hubblepup;
 
-        return {
-          gepp: rightInputContext.gepp,
-          isWibiz: rightInputContext.isWibiz,
-          framate: rightInputContext.framate,
-          croard: rightInputContext.croard,
-        };
-      }),
-      tropoig: (leftInput, ...rightInputTuple): QuirmList => {
-        /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-        const modifiedLeftInput = leftInputContext.modifyTropoignantInput(
-          leftInput.hubblepup,
-        );
-        const modifiedRightInputTuple = rightInputContextTuple.map(
-          (rightInputContext, index) => {
-            const rightInput = rightInputTuple[index];
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-            return rightInputContext.modifyTropoignantInput(
-              rightInput.hubblepup,
-            );
-          },
-        );
-        const modifiedOutput = assemblerContext.pinbe(
-          modifiedLeftInput,
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-          ...modifiedRightInputTuple,
-        );
+      /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+      const modifiedLeftInput =
+        leftInputContext.modifyTropoignantInput(adaptedLeftInput);
+      const modifiedRightInputTuple = rightInputContextTuple.map(
+        (rightInputContext, index) => {
+          const rightInput = rightInputTuple[index];
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+          return rightInputContext.modifyTropoignantInput(
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            rightInput,
+          );
+        },
+      );
+      const modifiedOutput = assemblerContext.pinbe(
+        modifiedLeftInput,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        ...modifiedRightInputTuple,
+      );
 
-        const aggregatedOutput =
-          outputContext.aggregatePinbetunfOutput(modifiedOutput);
+      const aggregatedOutput =
+        outputContext.aggregatePinbetunfOutput(modifiedOutput);
 
-        const quirmList = outputContext.constituentResultNormalizerList.flatMap(
+      const outputEntryList =
+        outputContext.constituentResultNormalizerList.map<CoreConstituentOutputEntry>(
           (normalizeResult) => {
-            const resultList = normalizeResult(
-              leftInput.hubblepup,
+            const outputEntry = normalizeResult(
+              adaptedLeftInput,
               modifiedLeftInput,
               aggregatedOutput,
             );
-            return resultList;
+            return outputEntry;
           },
         );
-        /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+      /* eslint-enable @typescript-eslint/no-unsafe-assignment */
 
-        return quirmList;
+      const output = Object.fromEntries(outputEntryList);
+
+      return output;
+    };
+
+    const estinant = {
+      version: 2,
+      name: instantiationContext.name,
+      leftInputAppreffinge: {
+        gepp: leftInputContext.gepp,
+        isWibiz: leftInputContext.isWibiz,
       },
-    } satisfies CoreEstinant as unknown as Estinant2<
-      TLeftVicken,
-      TRightVickenTuple,
-      TOutputVickenTuple
-    >;
+      rightInputAppreffingeTuple: rightInputContextTuple.map(
+        (rightInputContext) => {
+          if (rightInputContext.isWibiz) {
+            return {
+              gepp: rightInputContext.gepp,
+              isWibiz: rightInputContext.isWibiz,
+              framate: undefined,
+              croard: undefined,
+            } satisfies RightInputAppreffinge<
+              GenericLeftInputVicken,
+              GenericRightInputVoictentVicken
+            >;
+          }
+
+          return {
+            gepp: rightInputContext.gepp,
+            isWibiz: rightInputContext.isWibiz,
+            framate: (leftInput): ZornTuple => {
+              const indexedLeftHubblepup = leftInput as GenericIndexedHubblepup;
+
+              return rightInputContext.framate(
+                indexedLeftHubblepup.hubblepup,
+              ) as ZornTuple;
+            },
+            croard: (indexedRightHubblepup): Zorn => {
+              return rightInputContext.croard(indexedRightHubblepup.hubblepup);
+            },
+          } satisfies RightInputAppreffinge<
+            GenericLeftInputVicken,
+            GenericRightInputHubblepupTupleVicken
+          >;
+        },
+      ),
+      outputAppreffinge: {
+        geppTuple: outputContext.geppTuple,
+      },
+      tropoig,
+    } satisfies GenericEstinant2 as unknown as CoreOutputVickenFromOutputVickenTuple<TOutputVickenTuple> extends GenericOutputVicken
+      ? Estinant2<
+          LeftInputVoictentVicken<
+            AdaptedVoqueFromVoictent<TLeftVicken['voictent']>
+          >,
+          CoreRightInputVickenTupleFromRightVickenTuple<TRightVickenTuple>,
+          CoreOutputVickenFromOutputVickenTuple<TOutputVickenTuple>
+        >
+      : never;
     return estinant;
   };
 

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/estinantBuilderContext.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/estinantBuilderContext.ts
@@ -1,5 +1,5 @@
+import { Hubblepup } from '../../../core/engine-shell/quirm/hubblepup';
 import { Gepp } from '../../../type-script-adapter/gepp';
-import { QuirmList } from '../../../type-script-adapter/quirm';
 import { Voictent } from '../../../type-script-adapter/voictent';
 import {
   Straline,
@@ -52,15 +52,19 @@ export type PinbetunfOutputAggregator<> = (
   modifiedOutput: any,
 ) => AggregatedOutput;
 
+// note: using HubblepupTuple instead of Hubblepup[] cause an issue in "estinantAssembler"'s tropoig
+export type CoreConstituentOutputEntry = [Gepp, Hubblepup[]];
+
 export type ConstituentResultNormalizer = (
   leftInput: unknown,
   modifiedInput: unknown,
   aggregatedOutput: AggregatedOutput,
-) => QuirmList;
+) => CoreConstituentOutputEntry;
 
 export type AggregatedOutputContext = {
   aggregatePinbetunfOutput: PinbetunfOutputAggregator;
   constituentResultNormalizerList: ConstituentResultNormalizer[];
+  geppTuple: Gepp[];
 };
 
 export type RightInputContextTupleToModifiedInputTuple<
@@ -174,6 +178,7 @@ export const buildInputOutputContextFromLeftInputContext = ({
     outputContext: {
       aggregatePinbetunfOutput: buildEmptyAggregatedOutput,
       constituentResultNormalizerList: [],
+      geppTuple: [],
     },
   };
 };
@@ -221,6 +226,7 @@ export const buildInputOutputContextFromConstituentResultNormalizer = ({
     inputContext,
     outputContext: {
       constituentResultNormalizerList: previousConstituentResultNormalizerList,
+      geppTuple: previousGeppTuple,
     },
   },
   normalizeResult,
@@ -242,6 +248,7 @@ export const buildInputOutputContextFromConstituentResultNormalizer = ({
     outputContext: {
       aggregatePinbetunfOutput,
       constituentResultNormalizerList: nextConstituentResultNormalizerList,
+      geppTuple: [...previousGeppTuple, outputGepp],
     },
   };
 };

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/leftInputOdeshinVoictentAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/leftInputOdeshinVoictentAppreffingeBuilder.ts
@@ -2,7 +2,6 @@ import {
   buildOutputHubblepupAppreffingeBuilder,
   OutputHubblepupAppreffingeBuilderParent,
 } from './outputHubblepupAppreffingeBuilder';
-import { odeshinTupleToGritionTuple } from './tropoignantInputOutputModifier';
 import { LeftOdeshinVoictentVicken } from '../../../type-script-adapter/vicken';
 import {
   buildInputOutputContextFromLeftInputContext,
@@ -34,6 +33,7 @@ import {
   buildRightInputGritionTupleAppreffingeBuilder,
   RightInputGritionTupleAppreffingeBuilderParent,
 } from './rightInputGritionTupleAppreffingeBuilder';
+import { OdeshinTuple } from '../odeshin';
 
 type LeftVicken<TInputVoictent extends OdeshinVoictent> =
   LeftOdeshinVoictentVicken<TInputVoictent>;
@@ -91,7 +91,8 @@ export const buildLeftInputOdeshinVoictentAppreffingeBuilder = (
         leftInputContext: {
           gepp: leftAppreffinge.gepp,
           isWibiz: true,
-          modifyTropoignantInput: odeshinTupleToGritionTuple,
+          modifyTropoignantInput: (leftInput: OdeshinTuple) =>
+            leftInput.map((odeshin) => odeshin.grition),
         },
       });
 

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/outputGritionConditionalAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/outputGritionConditionalAppreffingeBuilder.ts
@@ -1,4 +1,4 @@
-import { Quirm } from '../../../type-script-adapter/quirm';
+import { Hubblepup } from '../../../core/engine-shell/quirm/hubblepup';
 import { LeftVicken } from '../../../type-script-adapter/vicken';
 import { Predicate } from '../../../utilities/predicate';
 import { OdeshinVoictent } from '../odeshinVoictent';
@@ -57,23 +57,23 @@ export const buildOutputGritionConditionalAppreffingeBuilder = <
     ) => {
       const predicateResult = outputAppreffinge.pinbe(modifiedLeftInput);
 
+      let hubblepupTuple: Hubblepup[];
       if (predicateResult) {
         const zorn = outputAppreffinge.getZorn(
           leftInput as TLeftVicken['tropoignantInput'],
         );
 
-        const quirm: Quirm = {
-          gepp: outputAppreffinge.gepp,
-          hubblepup: {
-            zorn,
-            grition: modifiedLeftInput,
-          },
+        const hubblepup = {
+          zorn,
+          grition: modifiedLeftInput,
         };
 
-        return [quirm];
+        hubblepupTuple = [hubblepup];
+      } else {
+        hubblepupTuple = [];
       }
 
-      return [];
+      return [outputAppreffinge.gepp, hubblepupTuple];
     };
 
     const nextContext = buildInputOutputContextFromConstituentResultNormalizer({

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/rightInputGritionTupleAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/rightInputGritionTupleAppreffingeBuilder.ts
@@ -35,7 +35,7 @@ import {
   buildRightInputVoictentAppreffingeBuilder,
   RightInputVoictentAppreffingeBuilderParent,
 } from './rightInputVoictentAppreffingeBuilder';
-import { odeshinTupleToGritionTuple } from './tropoignantInputOutputModifier';
+import { indexedOdeshinTupleToGritionTuple } from './tropoignantInputOutputModifier';
 
 type RightAppreffinge<
   TLeftVicken extends LeftVicken,
@@ -127,7 +127,7 @@ export const buildRightInputGritionTupleAppreffingeBuilder = <
         isWibiz: false,
         framate: rightAppreffinge.framate,
         croard: rightAppreffinge.croard,
-        modifyTropoignantInput: odeshinTupleToGritionTuple,
+        modifyTropoignantInput: indexedOdeshinTupleToGritionTuple,
       },
     });
 

--- a/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/tropoignantInputOutputModifier.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/adapter/estinant-builder/tropoignantInputOutputModifier.ts
@@ -1,15 +1,15 @@
-import { Hubblepup } from '../../../core/engine-shell/quirm/hubblepup';
-import { Quirm, QuirmList } from '../../../core/engine-shell/quirm/quirm';
+import {
+  GenericIndexedHubblepupTuple,
+  Hubblepup,
+} from '../../../core/engine-shell/quirm/hubblepup';
+import { QuirmList } from '../../../core/engine-shell/quirm/quirm';
 import { Gepp } from '../../../type-script-adapter/gepp';
 import { HubblepupTuple } from '../../../type-script-adapter/hubblepup';
 import { StringZorn } from '../../../utilities/semantic-types/zorn';
 import { Grition, GritionTuple } from '../grition';
 import { Odeshin, OdeshinTuple } from '../odeshin';
 import {
-  AggregatedOutput,
-  AggregatedOutputContext,
   ConstituentResultNormalizer,
-  InputOutputContext,
   PinbetunfOutputAggregator,
 } from './estinantBuilderContext';
 
@@ -17,9 +17,26 @@ export const hubblepupTupleToHubblepupTuple = (
   inputTuple: HubblepupTuple,
 ): HubblepupTuple => inputTuple;
 
+export const indexedOdeshinTupleToGritionTuple = (
+  inputTuple: GenericIndexedHubblepupTuple,
+): GritionTuple => {
+  const odeshinTuple = inputTuple.map((x) => x.hubblepup as Odeshin);
+  const gritionTuple = odeshinTuple.map((odeshin: Odeshin) => {
+    return odeshin.grition;
+  });
+
+  return gritionTuple;
+};
+
 export const odeshinTupleToGritionTuple = (
-  inputTuple: OdeshinTuple,
-): GritionTuple => inputTuple.map((odeshin) => odeshin.grition);
+  odeshinTuple: OdeshinTuple,
+): GritionTuple => {
+  const gritionTuple = odeshinTuple.map((odeshin: Odeshin) => {
+    return odeshin.grition;
+  });
+
+  return gritionTuple;
+};
 
 export const hubblepupToHubblepup = (input: Hubblepup): Hubblepup => input;
 
@@ -48,15 +65,8 @@ export const buildOutputHubblepupTupleNormalizer = (
     modifiedInput,
     aggregatedOutput,
   ) => {
-    const hubblepupTuple = aggregatedOutput[gepp] as HubblepupTuple;
-    const quirmList = hubblepupTuple.map<Quirm>((hubblepup) => {
-      return {
-        gepp,
-        hubblepup,
-      };
-    });
-
-    return quirmList;
+    const hubblepupTuple = aggregatedOutput[gepp] as Hubblepup[];
+    return [gepp, hubblepupTuple];
   };
 
   return normalizeHubblepupTuple;
@@ -71,12 +81,7 @@ export const buildOutputHubblepupNormalizer = (
     aggregatedOutput,
   ) => {
     const hubblepup = aggregatedOutput[gepp];
-    const quirm: Quirm = {
-      gepp,
-      hubblepup,
-    };
-
-    return [quirm];
+    return [gepp, [hubblepup]];
   };
 
   return normalizeHubblepup;
@@ -102,36 +107,9 @@ export const buildOutputGritionNormalizer = (
       zorn,
       grition,
     };
-    const quirm: Quirm = {
-      gepp,
-      hubblepup,
-    };
 
-    return [quirm];
+    return [gepp, [hubblepup]];
   };
 
   return normalizeGrition;
-};
-
-export const extendInputOutputContext = (
-  { instantiationContext, inputContext, outputContext }: InputOutputContext,
-  normalizeNextConstituentResult: ConstituentResultNormalizer,
-): InputOutputContext => {
-  const nextOutputContext: AggregatedOutputContext = {
-    aggregatePinbetunfOutput: (aggregatedOutput: AggregatedOutput) => {
-      return aggregatedOutput;
-    },
-    constituentResultNormalizerList: [
-      ...outputContext.constituentResultNormalizerList,
-      normalizeNextConstituentResult,
-    ],
-  };
-
-  const nextInputOutputContext: InputOutputContext = {
-    instantiationContext,
-    inputContext,
-    outputContext: nextOutputContext,
-  };
-
-  return nextInputOutputContext;
 };

--- a/packages/voictents-and-estinants-engine/src/custom/debugger/quirmDebugger.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/debugger/quirmDebugger.ts
@@ -1,15 +1,16 @@
 import fs from 'fs';
 import { posix } from 'path';
 import * as uuid from 'uuid';
-import { QuirmDebugger } from '../../type-script-adapter/digikikify';
+import { SimplerQuirmDebugger } from '../../type-script-adapter/digikikify';
 import { serialize } from '../../utilities/typed-datum/serializer/serialize';
 import { isOdeshin } from '../adapter/odeshin';
-import { Voictent } from '../adapter/voictent';
 import {
   OutputFileVoictent,
   OUTPUT_FILE_GEPP,
 } from '../programmable-units/output-file/outputFile';
 import { LanbeTypeName } from '../../core/engine-shell/voictent/lanbe';
+import { GenericVoque } from '../../core/engine/voque';
+import { AdaptedVoqueFromVoictent } from '../../type-script-adapter/voictent';
 
 // TODO: move to a utility or something
 export const escapePathSeparator = (text: string): string =>
@@ -18,7 +19,7 @@ export const escapePathSeparator = (text: string): string =>
 export const buildQuirmDebugger = (
   programName: string,
   debugDirectoryPath: 'debug' | 'snapshot' = 'debug',
-): QuirmDebugger<OutputFileVoictent> => {
+): SimplerQuirmDebugger<AdaptedVoqueFromVoictent<OutputFileVoictent>> => {
   const createDirectory = (directoryPath: string): void => {
     if (!fs.existsSync(directoryPath)) {
       // eslint-disable-next-line no-console
@@ -67,7 +68,9 @@ export const buildQuirmDebugger = (
     fs.writeFileSync(filePath, text);
   };
 
-  const quirmDebugger: QuirmDebugger<OutputFileVoictent> = {
+  const quirmDebugger: SimplerQuirmDebugger<
+    AdaptedVoqueFromVoictent<OutputFileVoictent>
+  > = {
     handlerByGepp: {
       [OUTPUT_FILE_GEPP]: ({ gepp, hubblepup }) => {
         const { fileName, fileExtensionSuffix, text } = hubblepup;
@@ -205,16 +208,17 @@ export const buildQuirmDebugger = (
 export const buildBasicQuirmDebugger = (
   programName: string,
   debugDirectoryPath?: 'debug' | 'snapshot',
-): QuirmDebugger<Voictent> => {
+): SimplerQuirmDebugger<GenericVoque> => {
   const quirmDebugger = buildQuirmDebugger(programName, debugDirectoryPath);
 
   return {
-    ...quirmDebugger,
     handlerByGepp: {},
+    defaultHandler: quirmDebugger.defaultHandler,
+    onFinish: quirmDebugger.onFinish,
   };
 };
 
 export const buildDefaultHandler = (
   programName: string,
-): QuirmDebugger<Voictent>['defaultHandler'] =>
+): SimplerQuirmDebugger<GenericVoque>['defaultHandler'] =>
   buildBasicQuirmDebugger(programName).defaultHandler;

--- a/packages/voictents-and-estinants-engine/src/type-script-adapter/digikikify.ts
+++ b/packages/voictents-and-estinants-engine/src/type-script-adapter/digikikify.ts
@@ -4,7 +4,6 @@ import {
 } from '../core/engine/digikikify';
 import { EstinantTuple as CoreEstinantTuple } from '../core/engine-shell/estinant/estinant';
 import { Quirm } from '../core/engine-shell/quirm/quirm';
-import { StralineTuple } from '../utilities/semantic-types/straline';
 import { Estinant, Estinant2 } from './estinant/estinant';
 import { RightVickenTuple, VickenTupleToVoictentTuple } from './vicken';
 import {
@@ -107,20 +106,11 @@ type DigikikifyInput<TEstinantTuple extends AnyEstinantTuple> = {
   quirmDebugger?: QuirmDebuggerFromEstinantTuple<TEstinantTuple>;
 };
 
-type InferredDigikikifyInput<TPotentialEstinantTuple> =
-  TPotentialEstinantTuple extends AnyEstinantTuple
-    ? DigikikifyInput<TPotentialEstinantTuple>
-    : DigikikifyInput<[]>;
-
-/**
- * Inputs types are inferred from the "estinantTuple" type, so if the "estinantTuple" type
- * is not an EstinantTuple then all inputs get inferred to empty lists.
- */
-export const digikikify = <TPotentialEstinantTuple extends StralineTuple>({
+export const digikikify = <TEstinantTuple extends AnyEstinantTuple>({
   initialVoictentsByGepp,
   estinantTuple,
   quirmDebugger: inputDebugger,
-}: InferredDigikikifyInput<TPotentialEstinantTuple>): void => {
+}: DigikikifyInput<TEstinantTuple>): void => {
   const inferredVoictentList = Object.entries(initialVoictentsByGepp).map(
     ([gepp, initialHubblepupTuple]) => {
       return new InMemoryVoictent({
@@ -134,7 +124,7 @@ export const digikikify = <TPotentialEstinantTuple extends StralineTuple>({
     inputVoictentList: inferredVoictentList,
     estinantTuple: estinantTuple as CoreEstinantTuple,
     onHubblepupAddedToVoictents: (quirm) => {
-      const quirmDebugger = inputDebugger as QuirmDebugger<Voictent>;
+      const quirmDebugger = inputDebugger as unknown as QuirmDebugger<Voictent>;
 
       if (!quirmDebugger) {
         return;

--- a/packages/voictents-and-estinants-engine/src/type-script-adapter/digikikify.ts
+++ b/packages/voictents-and-estinants-engine/src/type-script-adapter/digikikify.ts
@@ -1,130 +1,154 @@
+import { UnionToIntersection } from 'type-fest';
 import {
   RuntimeStatisticsHandler,
   digikikify as coreDigikikify,
 } from '../core/engine/digikikify';
-import { EstinantTuple as CoreEstinantTuple } from '../core/engine-shell/estinant/estinant';
-import { Quirm } from '../core/engine-shell/quirm/quirm';
-import { Estinant, Estinant2 } from './estinant/estinant';
-import { RightVickenTuple, VickenTupleToVoictentTuple } from './vicken';
 import {
-  Voictent,
-  VoictentArrayToVoictentItem,
-  VoictentToQuirm,
-  VoictentUnionToAggregateVoictentItemRecord,
-  VoictentUnionToAggregateVoictentRecord,
-} from './voictent';
+  UnsafeEstinant2,
+  Estinant2 as CoreEstinant2,
+  UnsafeEstinant2Tuple,
+  GenericEstinant2Tuple,
+  GenericEstinant2,
+} from '../core/engine-shell/estinant/estinant';
+import { GenericQuirm2, Quirm2 } from '../core/engine-shell/quirm/quirm';
+import { Estinant, Estinant2 } from './estinant/estinant';
 import { Hubblepup } from './hubblepup';
 import { InMemoryVoictent } from '../core/engine/inMemoryVoictent';
+import { GenericVoque } from '../core/engine/voque';
+import { Gepp } from '../core/engine-shell/voictent/gepp';
+import { HubblepupTuple } from '../core/engine-shell/quirm/hubblepup';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyEstinant = Estinant<any, any> | Estinant2<any, any, any>;
 
-type AnyEstinantTuple = readonly AnyEstinant[];
-
-type IDK<TRightVickenTuple extends RightVickenTuple> = {
-  [Index in keyof TRightVickenTuple]: TRightVickenTuple[Index]['voictent'];
-};
-
-/**
- * Combines the input and output VoictentTuple types for each each estinant individually
- */
-type EstinantTupleToCombinedVoictentTuple<
-  TEstinantTuple extends AnyEstinantTuple,
-> = {
-  [Index in keyof TEstinantTuple]: TEstinantTuple[Index] extends Estinant<
-    infer TInputVition,
-    infer TOutputVoictentTuple
-  >
-    ?
-        | TInputVition['leftVoictent']
-        | VickenTupleToVoictentTuple<TInputVition['rightVickenTuple']>[number]
-        | TOutputVoictentTuple[number]
-    : TEstinantTuple[Index] extends Estinant2<
-        infer TLeftVicken,
-        infer TRightVickenTuple,
-        infer TOutputVickenTuple
-      >
-    ?
-        | TLeftVicken['voictent']
-        | IDK<TRightVickenTuple>[number]
-        | TOutputVickenTuple[number]['voictent']
-    : never;
-};
-
-type EstinantTupleToVoictentUnion<TEstinantTuple extends AnyEstinantTuple> =
-  EstinantTupleToCombinedVoictentTuple<TEstinantTuple>[number];
-
-type EstinantTupleToVoictentArray<TEstinantTuple extends AnyEstinantTuple> =
-  EstinantTupleToVoictentUnion<TEstinantTuple>[];
-
-type EstinantTupleToPartialAggregateVoictentRecord<
-  TEstinantTuple extends AnyEstinantTuple,
-> = Partial<
-  VoictentUnionToAggregateVoictentRecord<
-    EstinantTupleToVoictentUnion<TEstinantTuple>
-  >
->;
-
-type EstinantTupleToPartialAggregateQuirmHandler<
-  TEstinantTuple extends AnyEstinantTuple,
-> = {
-  [Key in keyof VoictentUnionToAggregateVoictentItemRecord<
-    EstinantTupleToVoictentUnion<TEstinantTuple>
-  >]?: (quirm: {
-    gepp: Key;
-    hubblepup: VoictentUnionToAggregateVoictentItemRecord<
-      EstinantTupleToVoictentUnion<TEstinantTuple>
-    >[Key];
-  }) => void;
-};
-
-type OnHubblepupAddedToVoictentsHandler<
-  TEstinantTuple extends AnyEstinantTuple,
-> = (
-  voictentItem: VoictentArrayToVoictentItem<
-    EstinantTupleToVoictentArray<TEstinantTuple>
-  >,
+type QuirmHandler<TVoque extends GenericVoque> = (
+  quirm: Quirm2<TVoque>,
 ) => void;
 
-export type QuirmDebugger<TVoictent extends Voictent> = {
-  handlerByGepp: {
-    [Key in TVoictent['gepp']]?: (quirm: VoictentToQuirm<TVoictent>) => void;
-  };
-  defaultHandler: (quirm: Quirm) => void;
+type PartialQuirmHandlerDebuggerByGeppUnion<TVoqueUnion extends GenericVoque> =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TVoqueUnion extends any
+    ? { [TGepp in TVoqueUnion['gepp']]?: QuirmHandler<TVoqueUnion> }
+    : never;
+
+type QuirmUnionFromVoqueUnion<TVoqueUnion extends GenericVoque> =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TVoqueUnion extends any ? Quirm2<TVoqueUnion> : never;
+
+type OnHubblepupAddedToVoictentsHandler2<TVoqueUnion extends GenericVoque> = (
+  quirm: QuirmUnionFromVoqueUnion<TVoqueUnion>,
+) => void;
+
+type EstinantInputOutputVoqueUnion<TEstinant extends UnsafeEstinant2> =
+  TEstinant extends CoreEstinant2<
+    infer TLeftInputVicken,
+    infer TRightInputVickenTuple,
+    infer TOutputVicken
+  >
+    ?
+        | TLeftInputVicken['voque']
+        | TRightInputVickenTuple[number]['voque']
+        | TOutputVicken['outputVoqueOptionTuple'][number]
+    : never;
+
+type EstinantTupleInputOutputVoqueUnion<
+  TEstinantTuple extends UnsafeEstinant2Tuple,
+> = {
+  [Index in keyof TEstinantTuple]: EstinantInputOutputVoqueUnion<
+    TEstinantTuple[Index]
+  >;
+}[number];
+
+type PartialQuirmDebuggerByGepp<TVoqueUnion extends GenericVoque> =
+  UnionToIntersection<PartialQuirmHandlerDebuggerByGeppUnion<TVoqueUnion>>;
+
+export type SimplerQuirmDebugger<TVoqueUnion extends GenericVoque> = {
+  handlerByGepp: PartialQuirmDebuggerByGepp<TVoqueUnion>;
+  defaultHandler: (quirm: GenericQuirm2) => void;
   onFinish: RuntimeStatisticsHandler;
 };
 
-type QuirmDebuggerFromEstinantTuple<TEstinantTuple extends AnyEstinantTuple> = {
-  handlerByGepp: EstinantTupleToPartialAggregateQuirmHandler<TEstinantTuple>;
-  defaultHandler: OnHubblepupAddedToVoictentsHandler<TEstinantTuple>;
+export type QuirmDebuggerFromVoqueUnion<TVoqueUnion extends GenericVoque> = {
+  handlerByGepp: PartialQuirmDebuggerByGepp<TVoqueUnion>;
+  defaultHandler: OnHubblepupAddedToVoictentsHandler2<TVoqueUnion>;
   onFinish?: RuntimeStatisticsHandler;
 };
 
-type DigikikifyInput<TEstinantTuple extends AnyEstinantTuple> = {
-  initialVoictentsByGepp: EstinantTupleToPartialAggregateVoictentRecord<TEstinantTuple>;
+type QuirmDebuggerFromEstinantTuple<
+  TEstinantTuple extends UnsafeEstinant2Tuple,
+> = QuirmDebuggerFromVoqueUnion<
+  EstinantTupleInputOutputVoqueUnion<TEstinantTuple>
+>;
+
+type InitialHubblepupTupleByGeppUnionFromVoqueUnion<
+  TVoqueUnion extends GenericVoque,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+> = TVoqueUnion extends any
+  ? { [Key in TVoqueUnion['gepp']]?: TVoqueUnion['receivedHubblepup'][] }
+  : never;
+
+type InitialHubblepupTupleByGepp<TEstinantTuple extends UnsafeEstinant2Tuple> =
+  UnionToIntersection<
+    InitialHubblepupTupleByGeppUnionFromVoqueUnion<
+      EstinantTupleInputOutputVoqueUnion<TEstinantTuple>
+    >
+  >;
+
+type DigikikifyInput<TEstinantTuple extends UnsafeEstinant2Tuple> = {
+  initialVoictentsByGepp: InitialHubblepupTupleByGepp<TEstinantTuple>;
   estinantTuple: TEstinantTuple;
   quirmDebugger?: QuirmDebuggerFromEstinantTuple<TEstinantTuple>;
 };
 
-export const digikikify = <TEstinantTuple extends AnyEstinantTuple>({
-  initialVoictentsByGepp,
+export const digikikify = <TEstinantTuple extends UnsafeEstinant2Tuple>({
+  // TODO: apply this renaming to programs
+  initialVoictentsByGepp: initialHubblepupTupleByGepp,
   estinantTuple,
   quirmDebugger: inputDebugger,
 }: DigikikifyInput<TEstinantTuple>): void => {
-  const inferredVoictentList = Object.entries(initialVoictentsByGepp).map(
-    ([gepp, initialHubblepupTuple]) => {
-      return new InMemoryVoictent({
-        gepp,
-        initialHubblepupTuple: initialHubblepupTuple as Hubblepup[],
-      });
-    },
+  const inferredGeppSet = new Set(
+    Object.keys(initialHubblepupTupleByGepp as Record<Gepp, HubblepupTuple>),
   );
 
+  const inferredVoictentList = Object.entries(
+    initialHubblepupTupleByGepp as Record<Gepp, HubblepupTuple>,
+  ).map(([gepp, initialHubblepupTuple]) => {
+    return new InMemoryVoictent({
+      gepp,
+      initialHubblepupTuple: initialHubblepupTuple as Hubblepup[],
+    });
+  });
+
+  const estinantGeppList = estinantTuple.flatMap<Gepp>(
+    (estinant: GenericEstinant2) => [
+      estinant.leftInputAppreffinge.gepp,
+      ...estinant.rightInputAppreffingeTuple.map(
+        (appreffinge) => appreffinge.gepp,
+      ),
+      ...estinant.outputAppreffinge.geppTuple,
+    ],
+  );
+
+  const estinantGeppSet = new Set(estinantGeppList);
+
+  const otherInputGeppList = [...estinantGeppSet].filter(
+    (gepp) => !inferredGeppSet.has(gepp),
+  );
+  const otherVoictentList = otherInputGeppList.map((gepp) => {
+    return new InMemoryVoictent({
+      gepp,
+      initialHubblepupTuple: [],
+    });
+  });
+
+  const inputVoictentList = [...inferredVoictentList, ...otherVoictentList];
+
   coreDigikikify({
-    inputVoictentList: inferredVoictentList,
-    estinantTuple: estinantTuple as CoreEstinantTuple,
+    inputVoictentList,
+    estinantTuple,
     onHubblepupAddedToVoictents: (quirm) => {
-      const quirmDebugger = inputDebugger as unknown as QuirmDebugger<Voictent>;
+      const quirmDebugger =
+        inputDebugger as QuirmDebuggerFromEstinantTuple<GenericEstinant2Tuple>;
 
       if (!quirmDebugger) {
         return;

--- a/packages/voictents-and-estinants-engine/src/type-script-adapter/vicken.ts
+++ b/packages/voictents-and-estinants-engine/src/type-script-adapter/vicken.ts
@@ -1,11 +1,21 @@
+import {
+  LeftInputHubblepupVicken,
+  LeftInputVoictentVicken,
+} from '../core/engine-shell/vicken/leftInputVicken';
+import {
+  RightInputHubblepupTupleVicken,
+  RightInputVoictentVicken,
+} from '../core/engine-shell/vicken/rightInputVicken';
 import { OdeshinVoictent } from '../custom/adapter/odeshinVoictent';
 import { Tuple } from '../utilities/semantic-types/tuple';
 import { Zorn, ZornTuple } from '../utilities/semantic-types/zorn';
 import {
+  AdaptedVoqueFromVoictent,
   Voictent,
   VoictentTuple,
   VoictentTupleToHubblepupTuple,
 } from './voictent';
+import { OutputVicken as CoreOutputVicken } from '../core/engine-shell/vicken/outputVicken';
 
 export type Vicken<
   TVoictent extends Voictent = Voictent,
@@ -74,6 +84,13 @@ export type LeftVicken =
   | LeftHubblepupVicken
   | LeftGritionVicken;
 
+export type CoreLeftInputVickenFromLeftVicken<TLeftVicken extends LeftVicken> =
+  TLeftVicken extends LeftVoictentVicken | LeftOdeshinVoictentVicken
+    ? LeftInputVoictentVicken<AdaptedVoqueFromVoictent<TLeftVicken['voictent']>>
+    : LeftInputHubblepupVicken<
+        AdaptedVoqueFromVoictent<TLeftVicken['voictent']>
+      >;
+
 export type RightVoictentVicken<TVoictent extends Voictent = Voictent> = {
   voictent: TVoictent;
   tropoignantInput: TVoictent['hubblepupTuple'];
@@ -129,6 +146,25 @@ export type AppendRightVickenToTuple<
   TNextRightVicken extends RightVicken,
 > = [...TRightVickenTuple, TNextRightVicken];
 
+export type CoreRightInputVickenFromRightVicken<
+  TRightVicken extends RightVicken,
+> = TRightVicken extends RightHubblepupVicken | RightGritionVicken
+  ? RightInputHubblepupTupleVicken<
+      AdaptedVoqueFromVoictent<TRightVicken['voictent']>,
+      TRightVicken['zornTuple']
+    >
+  : RightInputVoictentVicken<
+      AdaptedVoqueFromVoictent<TRightVicken['voictent']>
+    >;
+
+export type CoreRightInputVickenTupleFromRightVickenTuple<
+  TRightVickenTuple extends RightVickenTuple,
+> = {
+  [Index in keyof TRightVickenTuple]: CoreRightInputVickenFromRightVicken<
+    TRightVickenTuple[Index]
+  >;
+};
+
 // I DONT THINK VICKEN IS THE RIGHT TERM HERE, BUT WE'LL DEAL WITH THAT LATER(tm)
 export type OutputVoictentVicken<TVoictent extends Voictent = Voictent> = {
   voictent: TVoictent;
@@ -166,3 +202,11 @@ export type AppendOutputVickenToTuple<
   TOutputVickenTuple extends OutputVickenTuple,
   TNextOutputVicken extends OutputVicken,
 > = [...TOutputVickenTuple, TNextOutputVicken];
+
+export type CoreOutputVickenFromOutputVickenTuple<
+  TOutputVickenTuple extends OutputVickenTuple,
+> = CoreOutputVicken<{
+  [Index in keyof TOutputVickenTuple]: AdaptedVoqueFromVoictent<
+    TOutputVickenTuple[Index]['voictent']
+  >;
+}>;

--- a/packages/voictents-and-estinants-engine/src/type-script-adapter/voictent.ts
+++ b/packages/voictents-and-estinants-engine/src/type-script-adapter/voictent.ts
@@ -1,3 +1,4 @@
+import { Voque } from '../core/engine/voque';
 import { MergeTuple } from '../utilities/mergeTuple';
 import { List } from '../utilities/semantic-types/list';
 import { Tuple } from '../utilities/semantic-types/tuple';
@@ -126,3 +127,15 @@ export type VoictentUnionToAggregateVoictentItemRecord<
   [TVoictent in TVoictentUnion as TVoictent['gepp'] &
     string]: TVoictent['hubblepupTuple'][number];
 };
+
+export type AdaptedVoqueFromVoictent<TVoictent extends Voictent> =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TVoictent extends any
+    ? Voque<
+        TVoictent['gepp'],
+        TVoictent['hubblepupTuple'][number],
+        TVoictent['hubblepupTuple'][number],
+        never,
+        TVoictent['hubblepupTuple']
+      >
+    : never;


### PR DESCRIPTION
There's still some logic adapting Core Estinant2 to the old estinant type, so we'll need to update that.