### PR TITLE
Report consumed collections that will not be populated

### DIFF
--- a/packages/voictents-and-estinants-engine/src/core/engine/abstractInMemoryVoictent.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine/abstractInMemoryVoictent.ts
@@ -71,6 +71,10 @@ export abstract class AbstractInMemoryVoictent<
     });
   }
 
+  get isEmpty(): boolean {
+    return this.hubblepupTuple.length === 0;
+  }
+
   addHubblepup(hubblepup: TVoque['receivedHubblepup']): void {
     this.receivedHubblepup.thisTick = true;
 

--- a/packages/voictents-and-estinants-engine/src/core/engine/cachedOnDiskVoictent.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine/cachedOnDiskVoictent.ts
@@ -103,6 +103,10 @@ export class CachedOnDiskVoictent<TVoque extends GenericCachedOnDiskVoque>
     // no op
   }
 
+  get isEmpty(): boolean {
+    return this.hubblepupTuple.length === 0;
+  }
+
   addHubblepup(receivedHubblepup: TVoque['receivedHubblepup']): void {
     this.receivedHubblepup.thisTick = true;
 

--- a/packages/voictents-and-estinants-engine/src/core/engine/voictent.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine/voictent.ts
@@ -50,6 +50,10 @@ export class Voictent implements GenericVoictent2 {
     // no op
   }
 
+  get isEmpty(): boolean {
+    return this.hubblepupTuple.length === 0;
+  }
+
   addHubblepup(hubblepup: Hubblepup): void {
     this.receivedHubblepup.thisTick = true;
     this.hubblepupTuple.push(hubblepup);

--- a/packages/voictents-and-estinants-engine/src/core/engine/voictent2.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine/voictent2.ts
@@ -17,6 +17,7 @@ export type Voictent2<
   ): VoictentItemLanbe2<TRestrictingVoque, TVoque> | VoictentItemLanbe | null;
   onTickStart(): void;
   initialize(): void;
+  get isEmpty(): boolean;
   addHubblepup(hubblepup: TVoque['receivedHubblepup']): void;
 };
 

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/error/programErrorVoictent.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/error/programErrorVoictent.ts
@@ -88,15 +88,23 @@ export class ProgramErrorVoictent extends AbstractAsymmetricInMemoryVoictent2<
   protected onTransformedHubblepup(
     hubblepup: GenericProgramErrorVoque['emittedHubblepup'],
   ): void {
-    if (hubblepup instanceof Error) {
-      // TODO: serialize all errors
-      return;
-    }
-
     const serializedHubblepup: SerializedHubblepup = {
       text: serialize(hubblepup),
       fileExtensionSuffixIdentifier: FileExtensionSuffixIdentifier.Yaml,
     };
+
+    if (hubblepup instanceof Error) {
+      this.programFileCache.writeSerializedHubblepup({
+        voictentGepp: this.gepp,
+        nestedPath: 'error',
+        serializedHubblepup,
+        // TODO: this should be the same as the zorn referenced by getIndexByName
+        extensionlessFileName: uuid.v4(),
+      });
+
+      // TODO: serialize all errors
+      return;
+    }
 
     this.programFileCache.writeSerializedHubblepup({
       voictentGepp: this.gepp,

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/in-memory-cache/inMemoryCache.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/in-memory-cache/inMemoryCache.ts
@@ -77,6 +77,10 @@ export class InMemoryCache<TDatum> {
     thisTick: null,
   };
 
+  get isEmpty(): boolean {
+    return this.datumTuple.length === 0;
+  }
+
   onTickStart(): void {
     // eslint-disable-next-line prefer-destructuring
     this.receivedDatumState = {

--- a/packages/voictents-and-estinants-engine/src/example-programs/abstractSerializableVoictent.ts
+++ b/packages/voictents-and-estinants-engine/src/example-programs/abstractSerializableVoictent.ts
@@ -61,6 +61,8 @@ export abstract class AbstractSerializableVoictent<
 
   public readonly duplicateCountByCheckId = new Map<string, number>();
 
+  private hasReceivedItem = false;
+
   constructor({
     gepp,
     programFileCache,
@@ -81,6 +83,10 @@ export abstract class AbstractSerializableVoictent<
     });
   }
 
+  get isEmpty(): boolean {
+    return !this.hasReceivedItem;
+  }
+
   // eslint-disable-next-line class-methods-use-this
   createVoictentLanbe(): null {
     return null;
@@ -97,6 +103,8 @@ export abstract class AbstractSerializableVoictent<
   }
 
   addHubblepup(metahubblepup: AbstractSerializable): void {
+    this.hasReceivedItem = true;
+
     const metavoictentGepp = this.gepp;
     const serializedHubblepupGepp = metahubblepup.sourceGepp;
     const extensionlessFileName = metahubblepup.serializableId.replaceAll(

--- a/packages/voictents-and-estinants-engine/src/example-programs/engine-behavior/serializableErrorVoictent.ts
+++ b/packages/voictents-and-estinants-engine/src/example-programs/engine-behavior/serializableErrorVoictent.ts
@@ -34,6 +34,8 @@ export class SerializableErrorVoictent<
 
   private initialHubblepupTuple: TVoque['emittedHubblepup'][];
 
+  private hasReceivedItem = false;
+
   constructor({
     gepp,
     programFileCache,
@@ -70,7 +72,12 @@ export class SerializableErrorVoictent<
     });
   }
 
+  get isEmpty(): boolean {
+    return !this.hasReceivedItem;
+  }
+
   addHubblepup(hubblepup: Error): void {
+    this.hasReceivedItem = true;
     const currentErrorIndex = this.errorCount;
 
     this.programFileCache.writeSerializedHubblepup({


### PR DESCRIPTION
A common bug is to run a program with a broken stream of data. We can find if a program is broken if a collection is used by a transform, but has no initial inputs, or is not downstream of another transform.