### PR TITLE
Add a simple representation of TypeScript file imports

### DIFF
--- a/debug/modelPrograms/voictents/serialized/sanity-snapshot/output-file-digest-list.yaml
+++ b/debug/modelPrograms/voictents/serialized/sanity-snapshot/output-file-digest-list.yaml
@@ -15,7 +15,7 @@
   - "fileName": "model-programs"
     "digest": "23eb4f85daa644b17fc969fb8374c0c57e615005"
   - "fileName": "render-knowledge-graph"
-    "digest": "6c1e6d50e2dc40c43566844f6037b58438a5165f"
+    "digest": "5773dfb0cef87cfa73b71ffd311ebdf3029e55ed"
   - "fileName": "render-type-script-file-relationships"
     "digest": "ecb9cd2058324740069af74af96116ed61bd9cd6"
   - "fileName": "test-build-add-metadata-for-serialization"

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/directed-graph/directedGraphEdge2.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/graph-visualization/directed-graph/directedGraphEdge2.ts
@@ -25,7 +25,7 @@ export type DirectedGraphEdge2 = ObjectWithPrototype<
 
 export const { DirectedGraphEdge2Instance } = buildConstructorFunctionWithName(
   'DirectedGraphEdge2Instance',
-)<BaseDirectedGraphEdge2, DirectedGraphEdge2Prototype>({
+)<BaseDirectedGraphEdge2, DirectedGraphEdge2Prototype, DirectedGraphEdge2>({
   zorn: (directedEdge) => {
     return getZorn([directedEdge.rootGraphLocator.zorn, directedEdge.id]);
   },

--- a/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/dependency/dependencyFact.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/dependency/dependencyFact.ts
@@ -1,0 +1,57 @@
+import { InMemoryOdeshin2Voque } from '../../../../core/engine/inMemoryOdeshinVoictent2';
+import {
+  ObjectWithPrototype,
+  buildConstructorFunctionWithName,
+} from '../../../../utilities/buildConstructorFunction';
+import { getZorn } from '../../../../utilities/getZorn';
+import { FileFact } from '../file/fileFact';
+
+type BaseDependencyFact = {
+  importingFact: FileFact;
+  importedFact: FileFact;
+};
+
+type DependencyFactPrototype = {
+  get zorn(): string;
+  get tailId(): string;
+  get headId(): string;
+};
+
+/**
+ * Presentation metadata for a relationship between two TypeScript files. A piece of knowledge.
+ */
+type DependencyFact = ObjectWithPrototype<
+  BaseDependencyFact,
+  DependencyFactPrototype
+>;
+
+export const { DependencyFactInstance } = buildConstructorFunctionWithName(
+  'DependencyFactInstance',
+)<BaseDependencyFact, DependencyFactPrototype, DependencyFact>({
+  zorn: (dependencyFact) => {
+    return getZorn([
+      dependencyFact.importingFact.directoryFact.boundaryFact.boundary
+        .displayName,
+      dependencyFact.importingFact.file.onDiskFileName.camelCase,
+      'depends-on',
+      dependencyFact.importedFact.directoryFact.boundaryFact.boundary
+        .displayName,
+      dependencyFact.importedFact.file.onDiskFileName.camelCase,
+    ]);
+  },
+  tailId: (dependencyFact) => {
+    return dependencyFact.importingFact.nodeId;
+  },
+  headId: (dependencyFact) => {
+    return dependencyFact.importedFact.nodeId;
+  },
+});
+
+export const DEPENDENCY_FACT_GEPP = 'dependency-fact';
+
+type DependencyFactGepp = typeof DEPENDENCY_FACT_GEPP;
+
+export type DependencyFactVoque = InMemoryOdeshin2Voque<
+  DependencyFactGepp,
+  DependencyFact
+>;

--- a/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/dependency/getDependencyFacts.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/dependency/getDependencyFacts.ts
@@ -1,0 +1,52 @@
+import { buildEstinant } from '../../../adapter/estinant-builder/estinantBuilder';
+import {
+  TYPE_SCRIPT_FILE_IMPORT_LIST_GEPP,
+  TypeScriptFileImportListVoque,
+} from '../../../programmable-units/type-script-file/typeScriptFileImportList';
+import { FILE_FACT_GEPP, FileFactVoque } from '../file/fileFact';
+import {
+  DEPENDENCY_FACT_GEPP,
+  DependencyFactInstance,
+  DependencyFactVoque,
+} from './dependencyFact';
+
+/**
+ * Get graph metadata for relationships between TypeScript files
+ */
+export const getDependencyFacts = buildEstinant({
+  name: 'getDependencyFacts',
+})
+  .fromHubblepup2<TypeScriptFileImportListVoque>({
+    gepp: TYPE_SCRIPT_FILE_IMPORT_LIST_GEPP,
+  })
+  .andFromHubblepupTuple2<FileFactVoque, [string, ...string[]]>({
+    gepp: FILE_FACT_GEPP,
+    framate: (importList) => {
+      return [
+        // TODO: replace "zorn" with filepath
+        importList.hubblepup.zorn,
+        ...importList.hubblepup.list
+          .filter((importItem) => importItem.isInternal)
+          .map((importItem) => {
+            return importItem.sourcePath;
+          }),
+      ];
+    },
+    croard: (fileFact) => {
+      return fileFact.hubblepup.file.filePath;
+    },
+  })
+  .toHubblepupTuple2<DependencyFactVoque>({
+    gepp: DEPENDENCY_FACT_GEPP,
+  })
+  .onPinbe((importList, [importingFact, ...importedFileFactList]) => {
+    const outputList = importedFileFactList.map((importedFact) => {
+      return new DependencyFactInstance({
+        importingFact,
+        importedFact,
+      });
+    });
+
+    return outputList;
+  })
+  .assemble();

--- a/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/dependency/getDependencyGraphElements.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/dependency/getDependencyGraphElements.ts
@@ -1,0 +1,42 @@
+import { buildEstinant } from '../../../adapter/estinant-builder/estinantBuilder';
+import { DirectedGraphEdge2Instance } from '../../../programmable-units/graph-visualization/directed-graph/directedGraphEdge2';
+import {
+  DIRECTED_GRAPH_ELEMENT_2_GEPP,
+  DirectedGraphElement2Voque,
+} from '../../../programmable-units/graph-visualization/directed-graph/directedGraphElement2';
+import { DEPENDENCY_FACT_GEPP, DependencyFactVoque } from './dependencyFact';
+
+/**
+ * Gets the directed graph elements for an import relationship between two
+ * TypeScript files within a boundary
+ *
+ * @note this gets the graph elements for a dependency relationship; not to be confused with getting all "dependency graph" elements.
+ */
+export const getDependencyGraphElements = buildEstinant({
+  name: 'getDependencyGraphElements',
+})
+  .fromHubblepup2<DependencyFactVoque>({
+    gepp: DEPENDENCY_FACT_GEPP,
+  })
+  .toHubblepupTuple2<DirectedGraphElement2Voque>({
+    gepp: DIRECTED_GRAPH_ELEMENT_2_GEPP,
+  })
+  .onPinbe((dependencyFact) => {
+    if (
+      dependencyFact.importingFact.directoryFact.boundaryFact.zorn !==
+      dependencyFact.importedFact.directoryFact.boundaryFact.zorn
+    ) {
+      return [];
+    }
+
+    const edge = new DirectedGraphEdge2Instance({
+      tailId: dependencyFact.tailId,
+      headId: dependencyFact.headId,
+      rootGraphLocator:
+        dependencyFact.importingFact.directoryFact.boundaryFact
+          .rootGraphLocator,
+    });
+
+    return [edge];
+  })
+  .assemble();

--- a/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/file/fileFact.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/file/fileFact.ts
@@ -22,7 +22,7 @@ type FileFactPrototype = {
 /**
  * Presentation metadata for a file. A piece of knowledge.
  */
-type FileFact = ObjectWithPrototype<BaseFileFact, FileFactPrototype>;
+export type FileFact = ObjectWithPrototype<BaseFileFact, FileFactPrototype>;
 
 export const { FileFactInstance } = buildConstructorFunctionWithName(
   'FileFactInstance',

--- a/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/renderKnowledgeGraph.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/renderKnowledgeGraph.ts
@@ -60,6 +60,8 @@ import {
 import { getDirectoryBoundaryRelationship } from './directory/getDirectoryBoundaryRelationship';
 import { getFileFact } from './file/getFileFact';
 import { getFileGraphElements } from './file/getFileGraphElements';
+import { getDependencyFacts } from './dependency/getDependencyFacts';
+import { getDependencyGraphElements } from './dependency/getDependencyGraphElements';
 
 const programFileCache = new ProgramFileCache({
   namespace: 'render-knowledge-graph',
@@ -137,6 +139,9 @@ digikikify({
 
     getFileFact,
     getFileGraphElements,
+
+    getDependencyFacts,
+    getDependencyGraphElements,
 
     groupGraphElements,
     getDirectedGraphFromGraphElementGroup,


### PR DESCRIPTION
Adds dependency arrows for TypeScript file imports to the knowledge graph. This is just a first pass on presenting this information.