### PR TITLE
Get directoryFact-parentFact relationships before making directory graph elements

### DIFF
--- a/debug/modelPrograms/voictents/serialized/sanity-snapshot/output-file-digest-list.yaml
+++ b/debug/modelPrograms/voictents/serialized/sanity-snapshot/output-file-digest-list.yaml
@@ -15,7 +15,7 @@
   - "fileName": "model-programs"
     "digest": "fa1895eb102228a933ac8a260f02647f495f1f63"
   - "fileName": "render-knowledge-graph"
-    "digest": "f8d38855e3a152d8422ff342f5c684545c83a2d4"
+    "digest": "23933ffa73bee053212c6a4bd623d306362d9c88"
   - "fileName": "render-type-script-file-relationships"
     "digest": "8f3273d841dd5a95c54ba5ed5c86614d1f53a2dd"
   - "fileName": "test-build-add-metadata-for-serialization"

--- a/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/input-output/engineEstinantInput2.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programmable-units/engine-program/input-output/engineEstinantInput2.ts
@@ -17,7 +17,7 @@ import { EngineVoqueLocator2 } from '../engineVoqueLocator2';
 const ENGINE_ESTINANT_INPUT_2_ZORN_TEMPLATE = [
   'inputIndex',
   'voictentName',
-  ['estinantLocator', EngineEstinantLocator2ZornClassSet],
+  ['estinantLocator', ...EngineEstinantLocator2ZornClassSet],
 ] as const satisfies GenericZorn2Template;
 type EngineEstinantInput2ZornTemplate =
   typeof ENGINE_ESTINANT_INPUT_2_ZORN_TEMPLATE;

--- a/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/app/browser/left-panel/metadataDisplay.tsx
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/app/browser/left-panel/metadataDisplay.tsx
@@ -41,6 +41,7 @@ const MetadataHeader: FunctionComponent<{
       {selectedMetadata !== null && (
         <button
           style={{
+            cursor: 'pointer',
             backgroundColor: ((): string => {
               switch (buttonState) {
                 case ButtonState.Normal:
@@ -70,7 +71,7 @@ const MetadataHeader: FunctionComponent<{
               });
           }}
         >
-          Copy Filepath
+          Copy File Path
         </button>
       )}
     </span>

--- a/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/boundary/boundaryFact.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/boundary/boundaryFact.ts
@@ -12,6 +12,7 @@ import {
   RootGraphLocator,
   RootGraphLocatorInstance,
 } from '../../../programmable-units/graph-visualization/directed-graph/rootGraphLocator';
+import { FactTypeName } from './factTypeName';
 
 type BaseBoundaryFact = {
   boundary: Boundary;
@@ -19,6 +20,7 @@ type BaseBoundaryFact = {
 };
 
 type BoundaryFactPrototype = {
+  get typeName(): FactTypeName.BoundaryFact;
   get zorn(): string;
   get rootGraphLocator(): RootGraphLocator;
   get directoryPathRelativeToCommonBoundary(): string;
@@ -35,6 +37,7 @@ export type BoundaryFact = ObjectWithPrototype<
 export const { BoundaryFactInstance } = buildConstructorFunctionWithName(
   'BoundaryFactInstance',
 )<BaseBoundaryFact, BoundaryFactPrototype, BoundaryFact>({
+  typeName: () => FactTypeName.BoundaryFact,
   zorn: (boundaryFact) => {
     return getZorn([boundaryFact.boundary.zorn, 'fact']);
   },

--- a/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/boundary/factTypeName.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/boundary/factTypeName.ts
@@ -1,0 +1,4 @@
+export enum FactTypeName {
+  BoundaryFact = 'BoundaryFact',
+  DirectoryFact = 'DirectoryFact',
+}

--- a/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/directory/directoryFact.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/directory/directoryFact.ts
@@ -8,6 +8,7 @@ import { getZorn } from '../../../../utilities/getZorn';
 import { getZornableId } from '../../../../utilities/getZornableId';
 import { Directory } from '../../../programmable-units/file/directory';
 import { BoundaryFact } from '../boundary/boundaryFact';
+import { FactTypeName } from '../boundary/factTypeName';
 
 type BaseDirectoryFact = {
   directory: Directory;
@@ -15,11 +16,10 @@ type BaseDirectoryFact = {
 };
 
 type DirectoryFactPrototype = {
+  get typeName(): FactTypeName.DirectoryFact;
   get zorn(): string;
   get subgraphZorn(): string;
   get subgraphId(): string;
-  get pathNodeSubgraphZorn(): string;
-  get pathNodeSubgraphId(): string;
   get directoryPathRelativeToParentDirectory(): string;
   get isBoundaryDirectory(): boolean;
 };
@@ -35,6 +35,7 @@ export type DirectoryFact = ObjectWithPrototype<
 export const { DirectoryFactInstance } = buildConstructorFunctionWithName(
   'DirectoryFactInstance',
 )<BaseDirectoryFact, DirectoryFactPrototype, DirectoryFact>({
+  typeName: () => FactTypeName.DirectoryFact,
   zorn: (directoryFact) => {
     return getZorn([
       directoryFact.boundaryFact.zorn,
@@ -48,12 +49,6 @@ export const { DirectoryFactInstance } = buildConstructorFunctionWithName(
   },
   subgraphId: (directoryFact) => {
     return getZornableId({ zorn: directoryFact.subgraphZorn });
-  },
-  pathNodeSubgraphZorn: (directoryFact) => {
-    return getZorn([directoryFact.zorn, 'path-node-subgraph']);
-  },
-  pathNodeSubgraphId: (directoryFact) => {
-    return getZornableId({ zorn: directoryFact.pathNodeSubgraphZorn });
   },
   directoryPathRelativeToParentDirectory: (directoryFact) => {
     return posix.relative(

--- a/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/directory/directoryToParentRelationshipFact.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/directory/directoryToParentRelationshipFact.ts
@@ -1,0 +1,113 @@
+import { InMemoryOdeshin2Voque } from '../../../../core/engine/inMemoryOdeshinVoictent2';
+import {
+  ObjectWithPrototype,
+  buildConstructorFunctionWithName,
+  memoizeGetter,
+} from '../../../../utilities/buildConstructorFunction';
+import {
+  GenericZorn2Template,
+  Zorn2,
+} from '../../../../utilities/semantic-types/zorn';
+import {
+  GraphConstituentLocator,
+  GraphConstituentLocatorInstance,
+} from '../../../programmable-units/graph-visualization/directed-graph/graphConstituentLocator';
+import { BoundaryFact } from '../boundary/boundaryFact';
+import { DirectoryFact } from './directoryFact';
+import { FactTypeName } from '../boundary/factTypeName';
+import { LocalDirectedGraphElement2Zorn } from '../../../programmable-units/graph-visualization/directed-graph/types';
+
+const DIRECTORY_TO_PARENT_RELATIONSHIP_FACT_ZORN_TEMPLATE = [
+  // TODO: make these Zorns when DirectoryFact and BoundaryFact have Zorn subclasses
+  'parentFact',
+  'childDirectoryFact',
+] as const satisfies GenericZorn2Template;
+type DirectoryToParentRelationshipFactZornTemplate =
+  typeof DIRECTORY_TO_PARENT_RELATIONSHIP_FACT_ZORN_TEMPLATE;
+class DirectoryToParentRelationshipFactZorn extends Zorn2<DirectoryToParentRelationshipFactZornTemplate> {
+  get rawTemplate(): DirectoryToParentRelationshipFactZornTemplate {
+    return DIRECTORY_TO_PARENT_RELATIONSHIP_FACT_ZORN_TEMPLATE;
+  }
+}
+
+type BaseDirectoryToParentRelationshipFact = {
+  childDirectoryFact: DirectoryFact;
+  inputParentDirectoryFact: DirectoryFact | null;
+};
+
+type DirectoryToParentRelationshipFactPrototype = {
+  get zorn(): DirectoryToParentRelationshipFactZorn;
+  get boundaryFact(): BoundaryFact;
+  get parentFact(): DirectoryFact | BoundaryFact;
+  get childDirectorySubgraphLocator(): GraphConstituentLocator;
+  get childDirectorySubgraphLabel(): string;
+};
+
+/**
+ * The relationship between a directory fact and its parent fact: another
+ * directory fact or a boundary fact. This includes metadata for graph elements
+ * related to a directory and its parent subgraph information
+ */
+type DirectoryToParentRelationshipFact = ObjectWithPrototype<
+  BaseDirectoryToParentRelationshipFact,
+  DirectoryToParentRelationshipFactPrototype
+>;
+
+export const { DirectoryToParentRelationshipFactInstance } =
+  buildConstructorFunctionWithName('DirectoryToParentRelationshipFactInstance')<
+    BaseDirectoryToParentRelationshipFact,
+    DirectoryToParentRelationshipFactPrototype,
+    DirectoryToParentRelationshipFact
+  >({
+    zorn: memoizeGetter((relationshipFact) => {
+      return new DirectoryToParentRelationshipFactZorn({
+        parentFact: relationshipFact.parentFact.zorn,
+        childDirectoryFact: relationshipFact.childDirectoryFact.zorn,
+      });
+    }),
+    boundaryFact: (relationshipFact) => {
+      return relationshipFact.childDirectoryFact.boundaryFact;
+    },
+    parentFact: (relationshipFact) => {
+      return (
+        relationshipFact.inputParentDirectoryFact ??
+        relationshipFact.boundaryFact
+      );
+    },
+    childDirectorySubgraphLocator: (relationshipFact) => {
+      const { parentFact } = relationshipFact;
+      const parentId =
+        parentFact.typeName === FactTypeName.BoundaryFact
+          ? parentFact.rootGraphLocator.id
+          : parentFact.subgraphId;
+
+      return new GraphConstituentLocatorInstance({
+        idOverride: relationshipFact.childDirectoryFact.subgraphId,
+        rootGraphLocator:
+          relationshipFact.childDirectoryFact.boundaryFact.rootGraphLocator,
+        parentId,
+        localZorn: LocalDirectedGraphElement2Zorn.buildClusterZorn({
+          distinguisher:
+            relationshipFact.childDirectoryFact.directory.directoryPath,
+        }),
+      });
+    },
+    childDirectorySubgraphLabel: (relationshipFact) => {
+      if (relationshipFact.parentFact.typeName === FactTypeName.BoundaryFact) {
+        return `${relationshipFact.parentFact.directoryPathRelativeToCommonBoundary}/`;
+      }
+
+      return `${relationshipFact.childDirectoryFact.directoryPathRelativeToParentDirectory}/`;
+    },
+  });
+
+export const DIRECTORY_TO_PARENT_RELATIONSHIP_FACT_GEPP =
+  'directory-to-parent-relationship-fact';
+
+type DirectoryToParentRelationshipFactGepp =
+  typeof DIRECTORY_TO_PARENT_RELATIONSHIP_FACT_GEPP;
+
+export type DirectoryToParentRelationshipFactVoque = InMemoryOdeshin2Voque<
+  DirectoryToParentRelationshipFactGepp,
+  DirectoryToParentRelationshipFact
+>;

--- a/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/directory/getDirectoryGraphElements.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/directory/getDirectoryGraphElements.ts
@@ -4,11 +4,11 @@ import {
   DIRECTED_GRAPH_ELEMENT_2_GEPP,
   DirectedGraphElement2Voque,
 } from '../../../programmable-units/graph-visualization/directed-graph/directedGraphElement2';
-import { DirectedSubgraph2Instance } from '../../../programmable-units/graph-visualization/directed-graph/directedSubgraph2';
-import { GraphConstituentLocatorInstance } from '../../../programmable-units/graph-visualization/directed-graph/graphConstituentLocator';
-import { LocalDirectedGraphElement2Zorn } from '../../../programmable-units/graph-visualization/directed-graph/types';
 import { THEME } from '../theme';
-import { DIRECTORY_FACT_GEPP, DirectoryFactVoque } from './directoryFact';
+import {
+  DIRECTORY_TO_PARENT_RELATIONSHIP_FACT_GEPP,
+  DirectoryToParentRelationshipFactVoque,
+} from './directoryToParentRelationshipFact';
 
 /**
  * Gets the directed graph elements for a directory in a boundary
@@ -16,74 +16,21 @@ import { DIRECTORY_FACT_GEPP, DirectoryFactVoque } from './directoryFact';
 export const getDirectoryGraphElements = buildEstinant({
   name: 'getDirectoryGraphElements',
 })
-  .fromHubblepup2<DirectoryFactVoque>({
-    gepp: DIRECTORY_FACT_GEPP,
+  .fromHubblepup2<DirectoryToParentRelationshipFactVoque>({
+    gepp: DIRECTORY_TO_PARENT_RELATIONSHIP_FACT_GEPP,
   })
-  .andFromHubblepupTuple2<DirectoryFactVoque, [] | [string]>({
-    gepp: DIRECTORY_FACT_GEPP,
-    framate: (directoryFact) => {
-      if (directoryFact.hubblepup.isBoundaryDirectory) {
-        return [];
-      }
-
-      return [directoryFact.hubblepup.directory.parentDirectoryPath];
-    },
-
-    croard: (directoryFact) => {
-      return directoryFact.hubblepup.directory.directoryPath;
-    },
-  })
-  .toHubblepupTuple2<DirectedGraphElement2Voque>({
+  .toHubblepup2<DirectedGraphElement2Voque>({
     gepp: DIRECTED_GRAPH_ELEMENT_2_GEPP,
   })
-  .onPinbe((directoryFact, [parentDirectoryFact]) => {
-    // TODO: if you build a directory relationship fact then you can contain this logic in that fact
-    let parentId: string;
-    let SubgraphLikeConstructor:
-      | typeof DirectedSubgraph2Instance
-      | typeof DirectedCluster2Instance;
-    let label: string;
-    if (parentDirectoryFact === undefined) {
-      parentId = directoryFact.boundaryFact.rootGraphLocator.id;
-      SubgraphLikeConstructor = DirectedCluster2Instance;
-      // SubgraphLikeConstructor = DirectedSubgraph2Instance;
-      label = `${directoryFact.boundaryFact.directoryPathRelativeToCommonBoundary}/`;
-    } else {
-      parentId = parentDirectoryFact.subgraphId;
-      SubgraphLikeConstructor = DirectedCluster2Instance;
-      label = `${directoryFact.directoryPathRelativeToParentDirectory}/`;
-    }
-
-    const directorySubgraph = new SubgraphLikeConstructor({
-      locator: new GraphConstituentLocatorInstance({
-        idOverride: directoryFact.subgraphId,
-        localZorn: LocalDirectedGraphElement2Zorn.buildClusterZorn({
-          distinguisher: directoryFact.subgraphZorn,
-        }),
-        rootGraphLocator: directoryFact.boundaryFact.rootGraphLocator,
-        parentId,
-      }),
+  .onPinbe((relationshipFact) => {
+    const directorySubgraph = new DirectedCluster2Instance({
+      locator: relationshipFact.childDirectorySubgraphLocator,
       inputAttributeByKey: {
-        label,
+        label: relationshipFact.childDirectorySubgraphLabel,
         ...THEME.directorySubgraph,
       },
     });
 
-    const pathNodeSubgraph = new DirectedCluster2Instance({
-      locator: new GraphConstituentLocatorInstance({
-        idOverride: directoryFact.pathNodeSubgraphId,
-        localZorn: LocalDirectedGraphElement2Zorn.buildClusterZorn({
-          distinguisher: directoryFact.pathNodeSubgraphZorn,
-        }),
-        rootGraphLocator: directoryFact.boundaryFact.rootGraphLocator,
-        parentId: directoryFact.subgraphId,
-      }),
-      inputAttributeByKey: {
-        label: '',
-        ...THEME.directorySubgraph,
-      },
-    });
-
-    return [directorySubgraph, pathNodeSubgraph];
+    return directorySubgraph;
   })
   .assemble();

--- a/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/directory/getDirectoryToParentRelationshipFact.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/directory/getDirectoryToParentRelationshipFact.ts
@@ -1,0 +1,43 @@
+import { buildEstinant } from '../../../adapter/estinant-builder/estinantBuilder';
+import { DIRECTORY_FACT_GEPP, DirectoryFactVoque } from './directoryFact';
+import {
+  DIRECTORY_TO_PARENT_RELATIONSHIP_FACT_GEPP,
+  DirectoryToParentRelationshipFactInstance,
+  DirectoryToParentRelationshipFactVoque,
+} from './directoryToParentRelationshipFact';
+
+/**
+ * Stores a relationship between a directory fact and its parent directory fact.
+ * The directory fact that corresponds to the directory of a boundary will not have a parent
+ * directory fact. The behavior in that case is encapsulated in the
+ * DirectoryToParentRelationshipFactInstance class.
+ */
+export const getDirectoryToParentRelationshipFact = buildEstinant({
+  name: 'getDirectoryToParentRelationshipFact',
+})
+  .fromHubblepup2<DirectoryFactVoque>({
+    gepp: DIRECTORY_FACT_GEPP,
+  })
+  .andFromHubblepupTuple2<DirectoryFactVoque, [] | [string]>({
+    gepp: DIRECTORY_FACT_GEPP,
+    framate: (directoryFact) => {
+      if (directoryFact.hubblepup.isBoundaryDirectory) {
+        return [];
+      }
+
+      return [directoryFact.hubblepup.directory.parentDirectoryPath];
+    },
+    croard: (directoryFact) => {
+      return directoryFact.hubblepup.directory.directoryPath;
+    },
+  })
+  .toHubblepup2<DirectoryToParentRelationshipFactVoque>({
+    gepp: DIRECTORY_TO_PARENT_RELATIONSHIP_FACT_GEPP,
+  })
+  .onPinbe((childDirectoryFact, [parentDirectoryFact = null]) => {
+    return new DirectoryToParentRelationshipFactInstance({
+      childDirectoryFact,
+      inputParentDirectoryFact: parentDirectoryFact,
+    });
+  })
+  .assemble();

--- a/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/renderKnowledgeGraph.ts
+++ b/packages/voictents-and-estinants-engine/src/custom/programs/render-knowledge-graph/renderKnowledgeGraph.ts
@@ -69,6 +69,7 @@ import { decodeAndRecastSvgDocument } from './decodeAndRecastSvgDocument';
 import { constructDynamicMetadataFile } from './constructDynamicMetadataFile';
 import { getAssociatedBoundaryFacts } from './associated-boundary/getAssociatedBoundaryFacts';
 import { getAssociatedBoundaryFactGraphElements } from './associated-boundary/getAssociatedBoundaryFactGraphElements';
+import { getDirectoryToParentRelationshipFact } from './directory/getDirectoryToParentRelationshipFact';
 
 const programFileCache = new ProgramFileCache({
   namespace: 'render-knowledge-graph',
@@ -140,6 +141,7 @@ digikikify({
     getDirectoriesWithFiles,
     getDirectoryBoundaryRelationship,
     getDirectoryFact,
+    getDirectoryToParentRelationshipFact,
     getDirectoryGraphElements,
 
     assertDirectoriesHaveBoundaries,

--- a/packages/voictents-and-estinants-engine/src/utilities/semantic-types/tuple.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/semantic-types/tuple.ts
@@ -1,1 +1,3 @@
 export type Tuple<T> = readonly T[];
+
+export type NonEmptyTuple<T> = readonly [T, ...T[]];

--- a/packages/voictents-and-estinants-engine/src/utilities/semantic-types/zorn.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/semantic-types/zorn.ts
@@ -1,5 +1,6 @@
 import { TupleToUnion, UnionToIntersection, Simplify } from 'type-fest';
 import { getTextDigest } from '../getTextDigest';
+import { NonEmptyTuple, Tuple } from './tuple';
 
 /**
  * An arbitrary identifier.
@@ -13,10 +14,9 @@ export type ZornTuple = readonly Zorn[];
 // eslint-disable-next-line @typescript-eslint/no-use-before-define
 export type ZornTuple2 = readonly (string | UnsafeZorn2)[];
 
-// eslint-disable-next-line @typescript-eslint/no-use-before-define
-// type UnsafeZorn2 = Zorn2<Zorn2Template>;
+type TemplateKey<TTemplateKey extends string> = TTemplateKey;
 
-type TemplateKey = string;
+type GenericTemplateKey = TemplateKey<string>;
 
 /** The dot-delimited path of a key through one or more nested zorns */
 type TemplateKeyPath = string;
@@ -32,61 +32,103 @@ type Zorn2Like = {
   forHuman: string;
 };
 
-// Should be: Record<string, InputValue>
+// TODO: Replace "UnsafeInputValueByTemplateKey" with an object type like
+// Record<string, string | zorn instance>, and debug the resulting errors
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type UnsafeInputValueByTemplateKey = any;
 
-type Zorn2LikeConstructor = {
-  new (inputValueByTemplateKey: UnsafeInputValueByTemplateKey): Zorn2Like;
+type Zorn2LikeConstructor<TZorn2Like extends Zorn2Like> = {
+  new (inputValueByTemplateKey: UnsafeInputValueByTemplateKey): TZorn2Like;
 };
 
-type SubzornTuple = readonly [
-  TemplateKey,
-  Zorn2LikeConstructor | readonly Zorn2LikeConstructor[],
-];
+type GenericZorn2LikeConstructor = Zorn2LikeConstructor<Zorn2Like>;
 
-type InputValue = TemplateKey | SubzornTuple;
+enum ZornTemplateKeyword {
+  LITERAL = '',
+}
 
-export type GenericZorn2Template = readonly InputValue[];
+type Subzorn = ZornTemplateKeyword | GenericZorn2LikeConstructor;
 
-type InputValueByTemplateKey<TTemplate extends GenericZorn2Template> = Simplify<
-  UnionToIntersection<
-    TupleToUnion<{
-      [TIndex in keyof TTemplate]: TTemplate[TIndex] extends string
-        ? { [TKey in TTemplate[TIndex]]: string }
-        : // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        TTemplate[TIndex] extends readonly [
-            string,
-            {
-              new (
-                ...parameterList: infer TParameterList
-              ): infer TZorn2LikeConstructor;
-            },
-          ]
-        ? { [TKey in TTemplate[TIndex][0]]: TZorn2LikeConstructor }
-        : TTemplate[TIndex] extends readonly [
-            string,
-            readonly {
-              new (
-                ...parameterList: infer TParameterList
-              ): infer TZorn2LikeConstructor;
-            }[],
-          ]
-        ? { [TKey in TTemplate[TIndex][0]]: TZorn2LikeConstructor }
-        : // both of these last two states are invalid, but the first is easier to debug
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        TTemplate[TIndex] extends readonly [string, any]
-        ? { [TKey in TTemplate[TIndex][0]]: never }
-        : never;
-    }>
-  >
+type SubzornTuple<TSubzornTuple extends Tuple<Subzorn>> = TSubzornTuple;
+type GenericSubzornTuple = SubzornTuple<Tuple<Subzorn>>;
+
+type SubzornSingleton<TSubzorn extends Subzorn> = SubzornTuple<[TSubzorn]>;
+
+type NonEmptySubzornTuple<
+  TFirstSubzorn extends Subzorn,
+  TRestSubzornTuple extends GenericSubzornTuple,
+> = readonly [TFirstSubzorn, ...TRestSubzornTuple];
+
+type GenericNonEmptySubzornTuple = NonEmptySubzornTuple<
+  Subzorn,
+  GenericSubzornTuple
 >;
 
+type SubzornTemplateEntry<
+  TTemplatekey extends GenericTemplateKey,
+  TNonEmptySubzornTuple extends GenericNonEmptySubzornTuple,
+> = readonly [TTemplatekey, ...TNonEmptySubzornTuple];
+
+type Zorn2TemplateEntry<
+  TTemplatekey extends GenericTemplateKey,
+  TNonEmptySubzornTuple extends GenericNonEmptySubzornTuple,
+> = TTemplatekey | SubzornTemplateEntry<TTemplatekey, TNonEmptySubzornTuple>;
+
+type GenericZorn2TemplateEntry = Zorn2TemplateEntry<
+  GenericTemplateKey,
+  GenericNonEmptySubzornTuple
+>;
+
+export type GenericZorn2Template = NonEmptyTuple<GenericZorn2TemplateEntry>;
+
+type InputValue<TSubzorn extends Subzorn> = TSubzorn extends ZornTemplateKeyword
+  ? OutputValue
+  : TSubzorn extends Zorn2LikeConstructor<infer TZorn2Like>
+  ? TZorn2Like
+  : never;
+
+type InputValueFromSubzornTuple<TSubzornTuple extends GenericSubzornTuple> =
+  TSubzornTuple extends SubzornSingleton<infer TSubzorn>
+    ? InputValue<TSubzorn>
+    : TSubzornTuple extends NonEmptySubzornTuple<
+        infer TFirstSubzorn,
+        infer TRestSubzornTuple
+      >
+    ? InputValue<TFirstSubzorn> | InputValueFromSubzornTuple<TRestSubzornTuple>
+    : never;
+
+type InputValueByTemplateKey<TZorn2Template extends GenericZorn2Template> =
+  Simplify<
+    UnionToIntersection<
+      TupleToUnion<{
+        [TIndex in keyof TZorn2Template]: TZorn2Template[TIndex] extends TemplateKey<
+          infer TTemplateKey
+        >
+          ? {
+              [TKey in TTemplateKey]: InputValueFromSubzornTuple<
+                [ZornTemplateKeyword]
+              >;
+            }
+          : TZorn2Template[TIndex] extends SubzornTemplateEntry<
+              infer TTemplateKey,
+              infer TNonEmptySubzornTuple
+            >
+          ? {
+              [TKey in TTemplateKey]: InputValueFromSubzornTuple<TNonEmptySubzornTuple>;
+            }
+          : never;
+      }>
+    >
+  >;
+
 type TemplateKeyTuple<TTemplate extends GenericZorn2Template> = {
-  [TIndex in keyof TTemplate]: TTemplate[TIndex] extends TemplateKey
+  [TIndex in keyof TTemplate]: TTemplate[TIndex] extends GenericTemplateKey
     ? TTemplate[TIndex]
-    : TTemplate[TIndex] extends SubzornTuple
-    ? TTemplate[TIndex][0]
+    : TTemplate[TIndex] extends SubzornTemplateEntry<
+        infer TTemplateKey,
+        GenericNonEmptySubzornTuple
+      >
+    ? TTemplateKey
     : never;
 };
 
@@ -111,6 +153,8 @@ type Zorn2Interface<TTemplate extends GenericZorn2Template> = {
 export abstract class Zorn2<TTemplate extends GenericZorn2Template>
   implements Zorn2Interface<TTemplate>
 {
+  static LITERAL = ZornTemplateKeyword.LITERAL;
+
   private memoizedValueByTemplateKeyPathList:
     | OutputValueByTemplateKeyPath[]
     | null = null;
@@ -206,4 +250,4 @@ export abstract class Zorn2<TTemplate extends GenericZorn2Template>
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type UnsafeZorn2 = Zorn2Interface<readonly any[]>;
+export type UnsafeZorn2 = Zorn2Interface<NonEmptyTuple<any>>;


### PR DESCRIPTION
The "Fact" objects abstract graph element locator information. Before this change, getDirectoryGraphElements had logic to determine the parent id. That logic now lives in this new fact.