### PR TITLE
Create a new object factory pattern

### DIFF
--- a/packages/voictents-and-estinants-engine/src/utilities/constructor-function/constructorFunctionBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/constructor-function/constructorFunctionBuilder.ts
@@ -1,0 +1,103 @@
+import { NonEmptyTuple } from '../semantic-types/tuple';
+import { ConstructorFunction, ConstructorFunctionName } from './types';
+
+type GenericPropertyName = string;
+export type GenericPropertyNameTuple = NonEmptyTuple<GenericPropertyName>;
+
+type ObjectLike<TPropertyName extends GenericPropertyName> = Record<
+  TPropertyName,
+  unknown
+>;
+export type GenericObjectLike = ObjectLike<GenericPropertyName>;
+
+export type ConstructedInstance<
+  TInstancePropertyNameTuple extends GenericPropertyNameTuple,
+> = ObjectLike<TInstancePropertyNameTuple[number]>;
+
+export type GenericConstructedInstance =
+  ConstructedInstance<GenericPropertyNameTuple>;
+
+export type GenericConstructorInput = GenericObjectLike;
+
+type ConstructorFunctionFromBuilderContext<
+  TConstructorInput extends GenericConstructorInput,
+  TConstructedInstance extends GenericConstructedInstance,
+> = ConstructorFunction<
+  [constructorInput: TConstructorInput],
+  TConstructedInstance
+>;
+
+export type ConstructorInputTransformer<
+  TConstructorInput extends GenericConstructorInput,
+  TConstructedInstance extends GenericConstructedInstance,
+> = (input: TConstructorInput) => TConstructedInstance;
+
+export type GenericConstructorInputTransformer = ConstructorInputTransformer<
+  GenericConstructorInput,
+  GenericConstructedInstance
+>;
+
+export type ConstructorFunctionBuilderContext = {
+  constructorName: ConstructorFunctionName;
+  transformInput: GenericConstructorInputTransformer;
+  instancePropertyNameTuple: GenericPropertyNameTuple;
+};
+
+const CONSTRUCTOR_KEY_NAME = 'constructor';
+
+export const buildConstructorFunction = <
+  TConstructorInput extends GenericConstructorInput,
+  TConstructedInstance extends GenericConstructedInstance,
+>({
+  constructorName,
+  transformInput,
+  instancePropertyNameTuple,
+}: ConstructorFunctionBuilderContext): ConstructorFunctionFromBuilderContext<
+  TConstructorInput,
+  TConstructedInstance
+> => {
+  // TODO: add more input parameters to define a prototype if needed (probably not needed though)
+  const prototype = {};
+
+  const constructorFunction = function (
+    this: GenericConstructedInstance,
+    input: GenericConstructorInput,
+  ): void {
+    // "restrictedInstance" ignores extraneous properties, because structural typing allows "rawInstance" to have more properties than specified
+    const rawInstance: GenericConstructedInstance = transformInput(input);
+    const restrictedInstance: GenericConstructedInstance = Object.fromEntries(
+      instancePropertyNameTuple.map((instancePropertyName) => {
+        const value: unknown = rawInstance[instancePropertyName];
+        return [instancePropertyName, value];
+      }),
+    );
+
+    Object.assign(this, restrictedInstance);
+  };
+
+  Object.defineProperty(constructorFunction, 'name', {
+    value: constructorName,
+  });
+
+  Object.assign(prototype, {
+    [CONSTRUCTOR_KEY_NAME]: constructorFunction,
+  });
+
+  Object.assign(constructorFunction, { prototype });
+
+  return constructorFunction as unknown as ConstructorFunctionFromBuilderContext<
+    TConstructorInput,
+    TConstructedInstance
+  >;
+};
+
+export type NamedConstructorFunctionParent<
+  TConstructorFunctionName extends ConstructorFunctionName,
+  TConstructorInput extends GenericConstructorInput,
+  TConstructedInstance extends GenericConstructedInstance,
+> = {
+  [TKey in TConstructorFunctionName]: ConstructorFunctionFromBuilderContext<
+    TConstructorInput,
+    TConstructedInstance
+  >;
+};

--- a/packages/voictents-and-estinants-engine/src/utilities/constructor-function/namedConstructorFunctionAssembler.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/constructor-function/namedConstructorFunctionAssembler.ts
@@ -1,0 +1,66 @@
+import {
+  ConstructorFunctionBuilderContext,
+  GenericConstructedInstance,
+  GenericConstructorInput,
+  NamedConstructorFunctionParent,
+  buildConstructorFunction,
+} from './constructorFunctionBuilder';
+import { ConstructorFunctionName } from './types';
+
+export type NamedConstructorFunctionAssemblerContext =
+  ConstructorFunctionBuilderContext;
+
+type NamedConstructorFunctionAssembler<
+  TConstructorFunctionName extends ConstructorFunctionName,
+  TConstructorInput extends GenericConstructorInput,
+  TConstructedInstance extends GenericConstructedInstance,
+> = () => NamedConstructorFunctionParent<
+  TConstructorFunctionName,
+  TConstructorInput,
+  TConstructedInstance
+>;
+
+export const buildNamedConstructorFunctionAssembler = <
+  TConstructorFunctionName extends ConstructorFunctionName,
+  TConstructorInput extends GenericConstructorInput,
+  TConstructedInstance extends GenericConstructedInstance,
+>(
+  assemblerContext: NamedConstructorFunctionAssemblerContext,
+): NamedConstructorFunctionAssembler<
+  TConstructorFunctionName,
+  TConstructorInput,
+  TConstructedInstance
+> => {
+  const assembleNamedConstructorFunction: NamedConstructorFunctionAssembler<
+    TConstructorFunctionName,
+    TConstructorInput,
+    TConstructedInstance
+  > = () => {
+    const constructorFunction = buildConstructorFunction<
+      TConstructorInput,
+      TConstructedInstance
+    >(assemblerContext);
+
+    return {
+      [assemblerContext.constructorName]: constructorFunction,
+    } as NamedConstructorFunctionParent<
+      TConstructorFunctionName,
+      TConstructorInput,
+      TConstructedInstance
+    >;
+  };
+
+  return assembleNamedConstructorFunction;
+};
+
+export type NamedConstructorFunctionAssemblerParent<
+  TConstructorFunctionName extends ConstructorFunctionName,
+  TConstructorInput extends GenericConstructorInput,
+  TConstructedInstance extends GenericConstructedInstance,
+> = {
+  assemble: NamedConstructorFunctionAssembler<
+    TConstructorFunctionName,
+    TConstructorInput,
+    TConstructedInstance
+  >;
+};

--- a/packages/voictents-and-estinants-engine/src/utilities/constructor-function/namedConstructorFunctionBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/constructor-function/namedConstructorFunctionBuilder.ts
@@ -1,0 +1,34 @@
+import { GenericPropertyNameTuple } from './constructorFunctionBuilder';
+import {
+  NamedConstructorFunctionInstanceTypeBuilderParent,
+  buildNamedConstructorFunctionInstanceTypeBuilder,
+} from './namedConstructorFunctionInstanceTypeBuilder';
+import { ConstructorFunctionName } from './types';
+
+type NamedConstructorFunctionBuilderContext<
+  TConstructorFunctionName extends ConstructorFunctionName,
+  TConstructedInstancePropertyNameTuple extends GenericPropertyNameTuple,
+> = {
+  constructorName: TConstructorFunctionName;
+  instancePropertyNameTuple: TConstructedInstancePropertyNameTuple;
+};
+
+export const buildNamedConstructorFunction = <
+  TConstructorFunctionName extends ConstructorFunctionName,
+  TConstructedInstancePropertyNameTuple extends GenericPropertyNameTuple,
+>(
+  context: NamedConstructorFunctionBuilderContext<
+    TConstructorFunctionName,
+    TConstructedInstancePropertyNameTuple
+  >,
+): NamedConstructorFunctionInstanceTypeBuilderParent<
+  TConstructorFunctionName,
+  TConstructedInstancePropertyNameTuple
+> => {
+  return {
+    withTypes: buildNamedConstructorFunctionInstanceTypeBuilder<
+      TConstructorFunctionName,
+      TConstructedInstancePropertyNameTuple
+    >(context),
+  };
+};

--- a/packages/voictents-and-estinants-engine/src/utilities/constructor-function/namedConstructorFunctionInstanceTypeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/constructor-function/namedConstructorFunctionInstanceTypeBuilder.ts
@@ -1,0 +1,156 @@
+import { IsNever } from 'type-fest/source/internal';
+import {
+  GenericPropertyNameTuple,
+  ConstructedInstance,
+  GenericObjectLike,
+  GenericConstructedInstance,
+  ConstructorInputTransformer,
+  GenericConstructorInputTransformer,
+} from './constructorFunctionBuilder';
+import {
+  NamedConstructorFunctionAssemblerContext,
+  NamedConstructorFunctionAssemblerParent,
+  buildNamedConstructorFunctionAssembler,
+} from './namedConstructorFunctionAssembler';
+import { ConstructorFunctionName } from './types';
+import { SpreadN } from '../spreadN';
+
+type TypeCheckErrorMessages<
+  TInitializationErrorMessage,
+  TMissingPropertyName,
+  TExtraneousPropertyName,
+> = {
+  typeCheckErrorMesssages: {
+    initialization: TInitializationErrorMessage;
+    instancePropertyNameTuple: {
+      missingProperties: TMissingPropertyName;
+      extraneousProperties: TExtraneousPropertyName;
+    };
+  };
+};
+
+type NormalizePropertyNameUnion<TPropertyName extends string> =
+  IsNever<TPropertyName> extends true ? '' : TPropertyName;
+
+type ConditionalTypeCheckErrorMessage<
+  TConstructedInstancePropertyNameTupleIsList extends boolean,
+  TConstructedInstanceKey extends string,
+  TConstructedInstancePropertyName extends string,
+> = TConstructedInstancePropertyNameTupleIsList extends true
+  ? TypeCheckErrorMessages<
+      'Initial context object must end in `as const`',
+      '',
+      ''
+    >
+  : TypeCheckErrorMessages<
+      '',
+      NormalizePropertyNameUnion<
+        Exclude<TConstructedInstanceKey, TConstructedInstancePropertyName>
+      >,
+      NormalizePropertyNameUnion<
+        Exclude<TConstructedInstancePropertyName, TConstructedInstanceKey>
+      >
+    >;
+
+type TypeCheckErrorMessageFromInitialContext<
+  TConstructedInstance extends GenericConstructedInstance,
+  TConstructedInstancePropertyNameTuple extends GenericPropertyNameTuple,
+> = ConditionalTypeCheckErrorMessage<
+  TConstructedInstancePropertyNameTuple extends TConstructedInstancePropertyNameTuple[number][]
+    ? true
+    : false,
+  Extract<keyof TConstructedInstance, string>,
+  TConstructedInstancePropertyNameTuple[number]
+>;
+
+type PartialNamedConstructorFunctionAssemblerContext<
+  TConstructorInput extends GenericObjectLike,
+  TConstructedInstancePropertyNameTuple extends GenericPropertyNameTuple,
+  TConstructedInstance extends ConstructedInstance<TConstructedInstancePropertyNameTuple>,
+> = SpreadN<
+  [
+    TypeCheckErrorMessageFromInitialContext<
+      TConstructedInstance,
+      TConstructedInstancePropertyNameTuple
+    >,
+    {
+      transformInput: ConstructorInputTransformer<
+        TConstructorInput,
+        TConstructedInstance
+      >;
+    },
+  ]
+>;
+
+type NamedConstructorFunctionInstanceTypeBuilder<
+  TConstructorFunctionName extends ConstructorFunctionName,
+  TConstructedInstancePropertyNameTuple extends GenericPropertyNameTuple,
+> = <
+  TConstructorInput extends GenericObjectLike,
+  TConstructedInstance extends ConstructedInstance<TConstructedInstancePropertyNameTuple>,
+>(
+  partialAssemblerContext: PartialNamedConstructorFunctionAssemblerContext<
+    TConstructorInput,
+    TConstructedInstancePropertyNameTuple,
+    TConstructedInstance
+  >,
+) => NamedConstructorFunctionAssemblerParent<
+  TConstructorFunctionName,
+  TConstructorInput,
+  TConstructedInstance
+>;
+
+type NamedConstructedFunctionInstanceTypeBuilderContext = Pick<
+  NamedConstructorFunctionAssemblerContext,
+  'constructorName' | 'instancePropertyNameTuple'
+>;
+
+export const buildNamedConstructorFunctionInstanceTypeBuilder = <
+  TConstructorFunctionName extends ConstructorFunctionName,
+  TConstructedInstancePropertyNameTuple extends GenericPropertyNameTuple,
+>(
+  context: NamedConstructedFunctionInstanceTypeBuilderContext,
+): NamedConstructorFunctionInstanceTypeBuilder<
+  TConstructorFunctionName,
+  TConstructedInstancePropertyNameTuple
+> => {
+  const buildNamedConstructorFunctionInstanceType: NamedConstructorFunctionInstanceTypeBuilder<
+    TConstructorFunctionName,
+    TConstructedInstancePropertyNameTuple
+  > = <
+    TConstructorInput extends GenericObjectLike,
+    TConstructedInstance extends ConstructedInstance<TConstructedInstancePropertyNameTuple>,
+  >(
+    partialAssemblerContext: PartialNamedConstructorFunctionAssemblerContext<
+      TConstructorInput,
+      TConstructedInstancePropertyNameTuple,
+      TConstructedInstance
+    >,
+  ) => {
+    const nextContext: NamedConstructorFunctionAssemblerContext = {
+      ...context,
+      transformInput:
+        partialAssemblerContext.transformInput as GenericConstructorInputTransformer,
+    };
+
+    return {
+      assemble: buildNamedConstructorFunctionAssembler<
+        TConstructorFunctionName,
+        TConstructorInput,
+        TConstructedInstance
+      >(nextContext),
+    };
+  };
+
+  return buildNamedConstructorFunctionInstanceType;
+};
+
+export type NamedConstructorFunctionInstanceTypeBuilderParent<
+  TConstructorFunctionName extends ConstructorFunctionName,
+  TConstructedInstancePropertyNameTuple extends GenericPropertyNameTuple,
+> = {
+  withTypes: NamedConstructorFunctionInstanceTypeBuilder<
+    TConstructorFunctionName,
+    TConstructedInstancePropertyNameTuple
+  >;
+};

--- a/packages/voictents-and-estinants-engine/src/utilities/constructor-function/types.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/constructor-function/types.ts
@@ -1,0 +1,10 @@
+import { UnsafeTuple } from '../semantic-types/tuple';
+import { TypeScriptObjectInstance } from '../typed-datum/type-script/object';
+
+export type ConstructorFunctionName = string;
+
+export type ConstructorFunction<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TConstructorParameterTuple extends UnsafeTuple,
+  TInstanceType extends TypeScriptObjectInstance,
+> = { new (...args: TConstructorParameterTuple): TInstanceType };

--- a/packages/voictents-and-estinants-engine/src/utilities/semantic-types/tuple.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/semantic-types/tuple.ts
@@ -1,3 +1,6 @@
 export type Tuple<T> = readonly T[];
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type UnsafeTuple = Tuple<any>;
+
 export type NonEmptyTuple<T> = readonly [T, ...T[]];

--- a/packages/voictents-and-estinants-engine/src/utilities/simplify.ts
+++ b/packages/voictents-and-estinants-engine/src/utilities/simplify.ts
@@ -1,0 +1,7 @@
+/**
+ * Merges two objects without making the intellisense do something dumb, unlike
+ * type-fest. Maybe one day we won't need this
+ */
+export type Simplify<T1 extends object, T2 extends object> = {
+  [Key in keyof (T1 & T2)]: (T1 & T2)[Key];
+};


### PR DESCRIPTION
## Requirements

| Requirement | Implementation | Notes |
| --- | --- | --- |
| Instantiation is clear when using the pattern | `new` syntax is straightforward | This means we're using constructor functions |
| Single source of truth of object properties | Object input and instance type definitions are used as the source of truth | TypeScript intellisense will only show an alias if it is the first instance of that type, so the object type must be the source of truth  |
| Constructor input is a single object argument | buildNamedConstructorFunction enforces this | It is easier to read code that instantiates an object when the parameters are named |
| Prevent developers from having to manually reassign property values | Constructor function definition uses Object.assign to modify the instance | If we used the class syntax with constructor object parameters then we would have to manually define and initialize each property on the class 😞 |
| Prevent polluting the instance with extraneous properties | The builder takes a property name tuple that is used to limit the properties that are added with Object.assign | Unfortunately this requires duplicating the property list |
| Provide a signal to keep the type aliases and property name tuple in sync | The second method in the builder chain takes an object with some keys that should be left hardcoded to `''`. In the event of a type mismatch you will get a type error detailing the issue | I'm aware that using the type system to relay error messages via static string types is probably a terrible idea. But other solutions would take to long to implement right now |
| Constructor function input type and instantiated type are not coupled | The builder pattern takes two independent types and a transformer for deriving the instance from the input | I can make a reusable passthrough transformer if we end up with types  that share an input and instance type
| The constructor function name is statically defined by the owning file | The builder takes a name argument that is used to control the available variable in the output | 🤔 since I'm going to make a code generator that uses this pattern, then this might not be needed |

## Non Requirements

- mutable properties: these objects are intended to be used with the engine, so they must be immutable
- prototype methods: All getters can be implemented in `transformInput`. Other use cases for methods imply we are mutating a property (don't do that), or that the property can be computed up front.
    - One potential use case for prototype methods is for asymmetric collections. The object that enters a collection could have a function that delays some work in case the collection has the result cached. But that's a problem for another day
