### PR TITLE
Disambiguate collections and items as streamables

### DIFF
--- a/packages/voictents-and-estinants-engine/src/adapted-programs/programmable-units/file/defaultFileGeppCombination.ts
+++ b/packages/voictents-and-estinants-engine/src/adapted-programs/programmable-units/file/defaultFileGeppCombination.ts
@@ -44,7 +44,7 @@ type DefaultFileGepp = ValueOf<
 >;
 
 /**
- * The set of collection ids for streamable metatypes that use the
+ * The set of collection ids for item metatypes that use the
  * FileSystemNodeVoque
  *
  * @todo remove this so that the adapted engine doesn't have to know about FileSystemNode collections and instead provide a builder for a default set of collections

--- a/packages/voictents-and-estinants-engine/src/adapted-programs/programmable-units/file/fileSystemNodeVoictent.ts
+++ b/packages/voictents-and-estinants-engine/src/adapted-programs/programmable-units/file/fileSystemNodeVoictent.ts
@@ -47,7 +47,7 @@ export type GenericFileSystemNodeVoque = FileSystemNodeVoque<
 
 /**
  * A collection for objects that have the same shape as FileSystemNode. It
- * indexes streamables by identifier and node path, and provides these
+ * indexes items with node paths by identifier and node path, and provides these
  * datastructures as the collection streamable
  *
  * @readableName FileSystemNodeCollection

--- a/packages/voictents-and-estinants-engine/src/adapter/estinant-builder/left-input/leftInputHubblepupAppreffingeBuilder2.ts
+++ b/packages/voictents-and-estinants-engine/src/adapter/estinant-builder/left-input/leftInputHubblepupAppreffingeBuilder2.ts
@@ -37,10 +37,10 @@ type EmptyAdaptedRightInputVickenTuple = [];
 type EmptyAdaptedOutputVickenTuple = [];
 
 /**
- * Builds the left input context for an estinant that consumes each streamable
+ * Builds the left input context for an estinant that consumes each item
  * from the left collection
  *
- * @readableName LeftInputStreamableStreamConfigurationBuilder
+ * @readableName LeftInputItemStreamConfigurationBuilder
  */
 type LeftInputHubblepupAppreffingeBuilder2 = <TInputVoque extends GenericVoque>(
   partialLeftInputAppreffinge: PartialLeftInputAppreffinge<TInputVoque>,

--- a/packages/voictents-and-estinants-engine/src/adapter/estinant-builder/output/outputHubblepupAppreffingeBuilder2.ts
+++ b/packages/voictents-and-estinants-engine/src/adapter/estinant-builder/output/outputHubblepupAppreffingeBuilder2.ts
@@ -31,7 +31,7 @@ type NextAdaptedOutputVickenTuple<
 /**
  * Builds the context needed to enable outputing a single hubblepup
  *
- * @readableName OutputStreamableStreamConfigurationBuilder
+ * @readableName OutputItemStreamConfigurationBuilder
  */
 type OutputHubblepupAppreffingeBuilder2<
   TAdaptedLeftInputVicken extends GenericAdaptedLeftInputVicken,

--- a/packages/voictents-and-estinants-engine/src/adapter/estinant-builder/output/outputHubblepupConditionalAppreffingeBuilder.ts
+++ b/packages/voictents-and-estinants-engine/src/adapter/estinant-builder/output/outputHubblepupConditionalAppreffingeBuilder.ts
@@ -42,7 +42,7 @@ type PartialOutputAppreffinge<
  * Builds the context needed to output the input hubblepup based on a condition.
  * Each conditional appreffinge is independent of the others.
  *
- * @readableName OutputStreamableConditionalStreamConfigurationBuilder
+ * @readableName OutputItemConditionalStreamConfigurationBuilder
  */
 type OutputHubblepupConditionalAppreffingeBuilder<
   TAdaptedLeftInputVicken extends GenericAdaptedLeftInputHubblepupVicken,

--- a/packages/voictents-and-estinants-engine/src/adapter/estinant-builder/output/outputHubblepupTupleAppreffingeBuilder2.ts
+++ b/packages/voictents-and-estinants-engine/src/adapter/estinant-builder/output/outputHubblepupTupleAppreffingeBuilder2.ts
@@ -27,7 +27,7 @@ type NextAdaptedOutputVickenTuple<
 /**
  * Builds the context needed to output zero or more hubblepups
  *
- * @readableName OutputStreamableTupleStreamConfigurationBuilder
+ * @readableName OutputItemTupleStreamConfigurationBuilder
  */
 type OutputHubblepupTupleAppreffingeBuilder2<
   TAdaptedLeftInputVicken extends GenericAdaptedLeftInputVicken,

--- a/packages/voictents-and-estinants-engine/src/adapter/estinant-builder/right-input/rightInputHubblepupTupleAppreffingeBuilder2.ts
+++ b/packages/voictents-and-estinants-engine/src/adapter/estinant-builder/right-input/rightInputHubblepupTupleAppreffingeBuilder2.ts
@@ -47,7 +47,7 @@ type EmptyAdaptedOutputVickenTuple = [];
  * Constructs the context needed to build a right input stream connection for
  * zero or more hubblepups.
  *
- * @readableName RightInputStreamableTupleStreamConfigurationBuilder
+ * @readableName RightInputItemTupleStreamConfigurationBuilder
  */
 type RightInputHubblepupTupleAppreffingeBuilder2<
   TAdaptedLeftInputVicken extends GenericAdaptedLeftInputVicken,

--- a/packages/voictents-and-estinants-engine/src/adapter/odeshin/grition.ts
+++ b/packages/voictents-and-estinants-engine/src/adapter/odeshin/grition.ts
@@ -2,6 +2,6 @@
  * The thing that a Concrete Programmer wants to operate on, but it is part of an Odeshin, which also contains an identifier.
  * Therefore, it is like a Hubblepup, but it is a property of a special type of Hubblepup
  *
- * @readableName Substreamable
+ * @readableName Subitem
  */
 export type Grition<TGrition = unknown> = TGrition;

--- a/packages/voictents-and-estinants-engine/src/adapter/odeshin/odeshin2.ts
+++ b/packages/voictents-and-estinants-engine/src/adapter/odeshin/odeshin2.ts
@@ -9,9 +9,9 @@ import {
 export type OdeshinZorn = StringZorn | UnsafeZorn2;
 
 /**
- * An identifiable streamable
+ * An identifiable item
  *
- * @readableName GenericIdentifiableStreamable
+ * @readableName GenericIdentifiableItem
  */
 export type GenericOdeshin2 = {
   zorn: OdeshinZorn;

--- a/packages/voictents-and-estinants-engine/src/core-programs/engine-behavior/testJoiningOneToVoictent.ts
+++ b/packages/voictents-and-estinants-engine/src/core-programs/engine-behavior/testJoiningOneToVoictent.ts
@@ -62,7 +62,7 @@ const gatherCollection: Estinant2<
  *
  * @canonicalComment
  *
- * @readableName testJoiningOneStreamableToCollection
+ * @readableName testJoiningOneItemToCollection
  */
 digikikify2({
   inputVoictentList: [

--- a/packages/voictents-and-estinants-engine/src/core-programs/engine-behavior/testUntriggeredCologyError.ts
+++ b/packages/voictents-and-estinants-engine/src/core-programs/engine-behavior/testUntriggeredCologyError.ts
@@ -71,7 +71,7 @@ const joinCollectionsByValue: Estinant2<
  *
  * @canonicalComment
  *
- * @readableName testUntriggeredTransformInputIdGroupError
+ * @readableName testUntriggeredTransformInputKeyGroupError
  */
 digikikify2({
   inputVoictentList: [

--- a/packages/voictents-and-estinants-engine/src/core/engine/dreanor/prected.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine/dreanor/prected.ts
@@ -2,9 +2,9 @@ import { Zorn } from '../../../package-agnostic-utilities/datastructure/zorn';
 import { Hubblepup } from '../../types/hubblepup/hubblepup';
 
 /**
- * A cache of streamables keyed by id. This allows the engine to know if every
- * id in a transform input id group has a corresponding streamable.
+ * A cache of items keyed by id. This allows the engine to know if every
+ * id in a transform input key group has a corresponding item.
  *
- * @readableName StreamableCache
+ * @readableName ItemCache
  */
 export class Prected extends Map<Zorn, Hubblepup> {}

--- a/packages/voictents-and-estinants-engine/src/core/engine/procody/ajorken.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine/procody/ajorken.ts
@@ -2,14 +2,14 @@ import { Zorn } from '../../../package-agnostic-utilities/datastructure/zorn';
 import { CologySet } from './cology';
 
 /**
- * A set of transform input id groups keyed by streamable id (can be a left or right streamable id).
- * This lets the engine find any transform input id group that might be ready for
+ * A set of transform input key groups keyed by item key (can be a left or right item key).
+ * This lets the engine find any transform input key group that might be ready for
  * processing whenever an element of that input groups changes. A left
- * streamable will only ever be part of one input group, but a right streamable
+ * item will only ever be part of one input group, but a right item
  * can be part of multiple input groups.
  *
  * @todo Fact check that last sentence about left stremables only being in one group
  *
- * @readableName TransformInputIdGroupSetCache
+ * @readableName TransformInputKeyGroupSetCache
  */
 export class Ajorken extends Map<Zorn, CologySet> {}

--- a/packages/voictents-and-estinants-engine/src/core/engine/procody/cology.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine/procody/cology.ts
@@ -6,10 +6,10 @@ import { Mabz } from './mabz';
  * A left input and its stream connection plus every right input id tuple and
  * their respective stream connections (one connection per tuple). This helps
  * the engine find all of the right inputs associated with the left input. The
- * engine does not assume the shape of a streamable, so the id of the left input
+ * engine does not assume the shape of an item, so the id of the left input
  * is unknown, and therefore the group must store the left input itself.
  *
- * @readableName TransformInputIdGroup
+ * @readableName TransformInputKeyGroup
  */
 export type Cology = {
   leftDreanor: LeftDreanor;

--- a/packages/voictents-and-estinants-engine/src/core/engine/procody/procody.ts
+++ b/packages/voictents-and-estinants-engine/src/core/engine/procody/procody.ts
@@ -2,12 +2,12 @@ import { Gepp } from '../../types/voictent/gepp';
 import { Ajorken } from './ajorken';
 
 /**
- * A cache of transform input id group caches where the key at this level is the
- * collection id. Streamable ids should be unique within a collection, but don't have to be
+ * A cache of transform input key group caches where the key at this level is the
+ * collection id. Item keys should be unique within a collection, but don't have to be
  * universally unique, which necessitates this parent map.
  *
  * @todo look into replacing this data structure and its nested datastructures with a ComplexMap
  *
- * @readableName TransformInputIdGroupSetCacheCache
+ * @readableName TransformInputKeyGroupSetCacheCache
  */
 export class Procody extends Map<Gepp, Ajorken> {}

--- a/packages/voictents-and-estinants-engine/src/core/types/appreffinge/input/right/croarder.ts
+++ b/packages/voictents-and-estinants-engine/src/core/types/appreffinge/input/right/croarder.ts
@@ -3,9 +3,9 @@ import { GenericIndexedHubblepup } from '../../../hubblepup/hubblepup';
 import { GenericRightInputHubblepupTupleVicken } from '../../../vicken/rightInputVicken';
 
 /**
- * A function that gets the id for a streamable. The engine does not assume the
- * shape of any streamable, so this information has to be supplied by the
- * programmer. This is used by the engine to associate streamables from different
+ * A function that gets the key for an item. The engine does not assume the
+ * shape of any item, so this information has to be supplied by the
+ * programmer. This is used by the engine to associate items from different
  * collections when a transform has multiple inputs.
  *
  * @readableName IdAccessor

--- a/packages/voictents-and-estinants-engine/src/core/types/appreffinge/input/right/framation.ts
+++ b/packages/voictents-and-estinants-engine/src/core/types/appreffinge/input/right/framation.ts
@@ -5,9 +5,9 @@ import { GenericRightInputHubblepupTupleVicken } from '../../../vicken/rightInpu
 
 /**
  * A function that takes the leftmost input of a transform input group and
- * outputs an id tuple for the associated right inputs of a particular stream
- * connection. This allows the engine to look up the associated right inputs by id and
- * coordinate triggering a transform when an input group has all streamables.
+ * outputs a key tuple for the associated right inputs of a particular stream
+ * connection. This allows the engine to look up the associated right inputs by key and
+ * coordinate triggering a transform when an input group has all items.
  *
  * @readableName AssociatedIdTupleAccessor
  */

--- a/packages/voictents-and-estinants-engine/src/core/types/hubblepup/hubblepup.ts
+++ b/packages/voictents-and-estinants-engine/src/core/types/hubblepup/hubblepup.ts
@@ -7,7 +7,7 @@ import { TypeScriptObject } from '../../../package-agnostic-utilities/object/typ
  *
  * It is of type "unknown" because it can be anything!
  *
- * @readableName Streamable
+ * @readableName Item
  */
 export type Hubblepup = unknown;
 

--- a/packages/voictents-and-estinants-engine/src/core/types/lanbe/lanbe.ts
+++ b/packages/voictents-and-estinants-engine/src/core/types/lanbe/lanbe.ts
@@ -63,10 +63,10 @@ export type GenericVoictentItemLanbe2 = HubblepupPelieLanbe2<
 >;
 
 /**
- * A data structure that facilitates streaming streamables from a collection, or
- * streaming the entire collection at once. It encapsulates stream operations on
- * a collection. This allows an external entity to read a collection without
- * needing a direct reference to it.
+ * A data structure that facilitates streaming streamables,
+ * including streaming an entire collection at once. It encapsulates stream
+ * operations on a collection. This allows an external entity to read a
+ * collection without needing a direct reference to it.
  *
  * @readableName Stream
  */

--- a/packages/voictents-and-estinants-engine/src/core/types/lanbe/referenceTypeName.ts
+++ b/packages/voictents-and-estinants-engine/src/core/types/lanbe/referenceTypeName.ts
@@ -1,9 +1,7 @@
 /**
  * An enum to distinguish data that is currently being streamed
  *
- * @readableName StreamableReferenceTypeName
- *
- * @todo turn this into StreamTypeName when we have input streams
+ * @readableName StreamableTypeName
  */
 export enum ReferenceTypeName {
   VoictentPelie = 'Voictent',

--- a/packages/voictents-and-estinants-engine/src/core/types/voque/voque.ts
+++ b/packages/voictents-and-estinants-engine/src/core/types/voque/voque.ts
@@ -15,16 +15,16 @@ import { Gepp } from '../voictent/gepp';
  */
 export type Voque<
   TGepp extends Gepp,
-  THubblepupPelue extends Hubblepup,
-  THubblepupPelie extends Hubblepup,
+  TItemEgg extends Hubblepup,
+  TItem extends Hubblepup,
   IndexByName extends HubblepupIndexByName,
   TVoictentPelie,
 > = {
   gepp: TGepp;
   indexByName: IndexByName;
-  hubblepupPelue: THubblepupPelue;
-  hubblepupPelie: THubblepupPelie;
-  indexedHubblepupPelie: IndexedHubblepup<THubblepupPelie, IndexByName>;
+  hubblepupPelue: TItemEgg;
+  hubblepupPelie: TItem;
+  indexedHubblepupPelie: IndexedHubblepup<TItem, IndexByName>;
   voictentPelie: TVoictentPelie;
 };
 

--- a/packages/voictents-and-estinants-engine/src/layer-agnostic-utilities/voictent/inMemoryOdeshinVoictent2.ts
+++ b/packages/voictents-and-estinants-engine/src/layer-agnostic-utilities/voictent/inMemoryOdeshinVoictent2.ts
@@ -1,11 +1,11 @@
 /**
- * An in memory collection for identifiable streamables (version 2) ... (also
+ * An in memory collection for identifiable items (version 2) ... (also
  * version 3, and by the time you're reading this theres probably a version 4.
  * who knows?)
  *
  * @noCanonicalDeclaration
  *
- * @readableName InMemoryIdentifiableStreamableCollection
+ * @readableName InMemoryIdentifiableItemCollection
  *
  * @todo find a better name for this file
  */


### PR DESCRIPTION
- A streamable is anything that can be streamed (so anything)
- An item is a single unit in a collection (so anything)
- An item egg is something that is not quite an item, but can be turned into one (so anything).