### PR TITLE
Update the default adapted collection

### DIFF
--- a/packages/mdd-engine/src/adapted-programs/programmable-units/datum-test-case-input/datumTestCaseInput.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/datum-test-case-input/datumTestCaseInput.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 
 /**
  * Used for testing serialization. It contains a datum of any type, and a
@@ -15,7 +15,7 @@ type DatumTestCaseInputCollectionId =
   typeof DATUM_TEST_CASE_INPUT_COLLECTION_ID;
 
 export type DatumTestCaseInputStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     DatumTestCaseInputCollectionId,
     DatumTestCaseInput
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/collection-definition/collectionDefinitionModel.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/collection-definition/collectionDefinitionModel.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { CollectionDefinitionId } from './collectionDefinitionId';
 import { CollectionDefinitionLocator } from './collectionDefinitionLocator';
 
@@ -43,7 +43,7 @@ type CollectionDefinitionModelCollectionId =
   typeof COLLECTION_DEFINITION_MODEL_COLLECTION_ID;
 
 export type CollectionDefinitionModelStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     CollectionDefinitionModelCollectionId,
     CollectionDefinitionModel
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/collection-instance/collectionInstanceModel.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/collection-instance/collectionInstanceModel.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { CollectionDefinitionModel } from '../collection-definition/collectionDefinitionModel';
 import { ItemDefinitionModel } from '../item-definition/itemDefinitionModel';
 import { ProgramLocator } from '../program/programLocator';
@@ -41,7 +41,7 @@ type CollectionInstanceModelCollectionId =
   typeof COLLECTION_INSTANCE_MODEL_COLLECTION_ID;
 
 export type CollectionInstanceModelStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     CollectionInstanceModelCollectionId,
     CollectionInstanceModel
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/engineProgram3.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/engineProgram3.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import {
   ObjectWithPrototype,
   buildConstructorFunctionWithName,
@@ -52,7 +52,7 @@ export const ENGINE_PROGRAM_3_COLLECTION_ID = 'engine-program-3';
 type EngineProgram3CollectionId = typeof ENGINE_PROGRAM_3_COLLECTION_ID;
 
 export type EngineProgram3StreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     EngineProgram3CollectionId,
     EngineProgram3
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/engineProgramLocator3.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/engineProgramLocator3.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import {
   ObjectWithPrototype,
   buildConstructorFunctionWithName,
@@ -72,7 +72,7 @@ type EngineProgramLocator3CollectionId =
   typeof ENGINE_PROGRAM_LOCATOR_3_COLLECTION_ID;
 
 export type EngineProgramLocator3StreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     EngineProgramLocator3CollectionId,
     EngineProgramLocator3
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/engineProgrammedTransform3.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/engineProgrammedTransform3.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import {
   ObjectWithPrototype,
   buildConstructorFunctionWithName,
@@ -64,7 +64,7 @@ type EngineProgrammedTransform3CollectionId =
   typeof ENGINE_PROGRAMMED_TRANSFORM_3_COLLECTION_ID;
 
 export type EngineProgrammedTransform3StreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     EngineProgrammedTransform3CollectionId,
     EngineProgrammedTransform3
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/engineProgrammedTransformLocator2.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/engineProgrammedTransformLocator2.ts
@@ -1,5 +1,5 @@
 import { TSESTree } from '@typescript-eslint/typescript-estree';
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import {
   ObjectWithPrototype,
   buildConstructorFunctionWithName,
@@ -117,7 +117,7 @@ type EngineProgrammedTransformLocator2CollectionId =
   typeof ENGINE_PROGRAMMED_TRANSFORM_LOCATOR_2_COLLECTION_ID;
 
 export type EngineProgrammedTransformLocator2StreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     EngineProgrammedTransformLocator2CollectionId,
     EngineProgrammedTransformLocator2
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/engineStreamMetatype2.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/engineStreamMetatype2.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import {
   ObjectWithPrototype,
   buildConstructorFunctionWithName,
@@ -54,7 +54,7 @@ type EngineStreamMetatype2CollectionId =
   typeof ENGINE_STREAM_METATYPE_2_COLLECTION_ID;
 
 export type EngineStreamMetatype2StreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     EngineStreamMetatype2CollectionId,
     EngineStreamMetatype2
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/engineStreamMetatypeLocator2.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/engineStreamMetatypeLocator2.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import {
   ObjectWithPrototype,
   buildConstructorFunctionWithName,
@@ -66,7 +66,7 @@ type EngineStreamMetatypeLocatorCollectionId =
   typeof ENGINE_STREAM_METATYPE_LOCATOR_2_COLLECTION_ID;
 
 export type EngineStreamMetatypeLocator2StreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     EngineStreamMetatypeLocatorCollectionId,
     EngineStreamMetatypeLocator2
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/exportLocator.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/exportLocator.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import {
   GenericComplexIdTemplate,
   ComplexId,
@@ -61,7 +61,7 @@ export const EXPORT_LOCATOR_COLLECTION_ID = 'export-locator';
 type ExportLocatorCollectionId = typeof EXPORT_LOCATOR_COLLECTION_ID;
 
 export type ExportLocatorStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     ExportLocatorCollectionId,
     ExportLocator
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/getEngineProgrammedTransformLocatorCollection2.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/getEngineProgrammedTransformLocatorCollection2.ts
@@ -28,8 +28,8 @@ export const getEngineProgrammedTransformLocatorCollection2 =
     .toItemTuple2<EngineProgrammedTransformLocator2StreamMetatype>({
       collectionId: ENGINE_PROGRAMMED_TRANSFORM_LOCATOR_2_COLLECTION_ID,
     })
-    .onTransform((relationshipList) => {
-      const entries = relationshipList
+    .onTransform((relationshipCollection) => {
+      const entries = relationshipCollection.list
         .map((relationship) => relationship.programmedTransformLocator)
         .map(
           (

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/getEngineStreamMetatypeLocatorCollection2.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/getEngineStreamMetatypeLocatorCollection2.ts
@@ -41,13 +41,13 @@ export const getEngineStreamMetatypeLocatorCollection2 =
     })
     .onTransform(
       (
-        programRelationshipList,
-        programmedTransformStreamMetatypeRelationshipList,
+        programRelationshipCollection,
+        programmedTransformStreamMetatypeRelationshipCollection,
       ) => {
         const streamMetatypeLocatorById = new Map(
           [
-            ...programRelationshipList,
-            ...programmedTransformStreamMetatypeRelationshipList,
+            ...programRelationshipCollection.list,
+            ...programmedTransformStreamMetatypeRelationshipCollection.list,
           ].map((relationship) => {
             return [
               relationship.streamMetatypeLocator.id,

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/input-output/engineProgrammedTransformInput2.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/input-output/engineProgrammedTransformInput2.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import {
   ObjectWithPrototype,
   buildConstructorFunctionWithName,
@@ -76,7 +76,7 @@ type ProgrammedTransformInput2CollectionId =
   typeof PROGRAMMED_TRANSFORM_INPUT_2_COLLECTION_ID;
 
 export type EngineProgrammedTransformInput2StreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     ProgrammedTransformInput2CollectionId,
     EngineProgrammedTransformInput2
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/input-output/engineProgrammedTransformOutput2.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/input-output/engineProgrammedTransformOutput2.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import {
   ObjectWithPrototype,
   buildConstructorFunctionWithName,
@@ -56,7 +56,7 @@ type ProgrammedTransformOutput2CollectionId =
   typeof PROGRAMMED_TRANSFORM_OUTPUT_2_COLLECTION_ID;
 
 export type EngineProgrammedTransformOutput2StreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     ProgrammedTransformOutput2CollectionId,
     EngineProgrammedTransformOutput2
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/input-output/programProgrammedTransformInputRelationship.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/input-output/programProgrammedTransformInputRelationship.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import {
   ObjectWithPrototype,
   buildConstructorFunctionWithName,
@@ -67,7 +67,7 @@ type ProgramProgrammedTransformInputRelationshipCollectionId =
   typeof PROGRAM_PROGRAMMED_TRANSFORM_INPUT_RELATIONSHIP_COLLECTION_ID;
 
 export type ProgramProgrammedTransformInputRelationshipStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     ProgramProgrammedTransformInputRelationshipCollectionId,
     ProgramProgrammedTransformInputRelationship
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/input-output/programProgrammedTransformOutputRelationship.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/input-output/programProgrammedTransformOutputRelationship.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import {
   ObjectWithPrototype,
   buildConstructorFunctionWithName,
@@ -47,7 +47,7 @@ type ProgramProgrammedTransformOutputRelationshipCollectionId =
   typeof PROGRAM_PROGRAMMED_TRANSFORM_OUTPUT_RELATIONSHIP_COLLECTION_ID;
 
 export type ProgramProgrammedTransformOutputRelationshipStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     ProgramProgrammedTransformOutputRelationshipCollectionId,
     ProgramProgrammedTransformOutputRelationship
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/item-definition/itemDefinitionModel.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/item-definition/itemDefinitionModel.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { ItemDefinitionId } from './itemDefinitionId';
 import { ItemDefinitionLocator } from './itemDefinitionLocator';
 
@@ -37,7 +37,7 @@ type ItemDefinitionModelCollectionId =
   typeof ITEM_DEFINITION_MODEL_COLLECTION_ID;
 
 export type ItemDefinitionModelStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     ItemDefinitionModelCollectionId,
     ItemDefinitionModel
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/program/programLocator.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/program/programLocator.ts
@@ -1,5 +1,5 @@
 import Case from 'case';
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 
 import { TypeScriptFile } from '../../type-script-file/typeScriptFile';
 import {
@@ -111,7 +111,7 @@ export const PROGRAM_LOCATOR_COLLECTION_ID = 'program-locator';
 type ProgramLocatorCollectionId = typeof PROGRAM_LOCATOR_COLLECTION_ID;
 
 export type ProgramLocatorStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     ProgramLocatorCollectionId,
     ProgramLocator
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/programProgrammedTransformRelationship.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/programProgrammedTransformRelationship.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import {
   ObjectWithPrototype,
   buildConstructorFunctionWithName,
@@ -48,7 +48,7 @@ type ProgramProgrammedTransformRelationshipCollectionId =
   typeof PROGRAM_PROGRAMMED_TRANSFORM_RELATIONSHIP_COLLECTION_ID;
 
 export type ProgramProgrammedTransformRelationshipStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     ProgramProgrammedTransformRelationshipCollectionId,
     ProgramProgrammedTransformRelationship
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/programStreamMetatypeRelationship2.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/programStreamMetatypeRelationship2.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import {
   ObjectWithPrototype,
   buildConstructorFunctionWithName,
@@ -49,7 +49,7 @@ type ProgramStreamMetatypeRelationship2CollectionId =
   typeof PROGRAM_STREAM_METATYPE_RELATIONSHIP_2_COLLECTION_ID;
 
 export type ProgramStreamMetatypeRelationship2StreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     ProgramStreamMetatypeRelationship2CollectionId,
     ProgramStreamMetatypeRelationship2
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/programmedTransformStreamMetatypeRelationship2.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/engine-program-model/programmedTransformStreamMetatypeRelationship2.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import {
   ObjectWithPrototype,
   buildConstructorFunctionWithName,
@@ -49,7 +49,7 @@ type ProgrammedTransformStreamMetatypeRelationship2CollectionId =
   typeof PROGRAMMED_TRANSFORM_STREAM_METATYPE_RELATIONSHIP_2_COLLECTION_ID;
 
 export type ProgrammedTransformStreamMetatypeRelationship2StreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     ProgrammedTransformStreamMetatypeRelationship2CollectionId,
     ProgrammedTransformStreamMetatypeRelationship2
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/file/fileAncestorDirectoryPathSet.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/file/fileAncestorDirectoryPathSet.ts
@@ -1,5 +1,5 @@
 import { posix } from 'path';
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { buildNamedConstructorFunction } from '../../../package-agnostic-utilities/constructor-function/buildNamedConstructorFunction';
 import {
   GenericComplexIdTemplate,
@@ -87,7 +87,7 @@ type FileAncestorDirectoryPathSetCollectionId =
   typeof FILE_ANCESTOR_DIRECTORY_PATH_SET_COLLECTION_ID;
 
 export type FileAncestorDirectoryPathSetStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     FileAncestorDirectoryPathSetCollectionId,
     FileAncestorDirectoryPathSet
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/graph-visualization/directed-graph/directedGraph.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/graph-visualization/directed-graph/directedGraph.ts
@@ -1,6 +1,6 @@
 import { DirectedGraphEdge } from './directedGraphEdge';
 import { DirectedGraphNode } from './directedGraphNode';
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { SpreadN } from '../../../../package-agnostic-utilities/type/spreadN';
 import { AttributeByKeyGSCNE } from './attributeByKeyGSCNE';
 import { AttributeByKeyGSC } from './attributeByKeyGSC';
@@ -38,7 +38,7 @@ export const DIRECTED_GRAPH_COLLECTION_ID = 'directed-graph';
 type DirectedGraphCollectionId = typeof DIRECTED_GRAPH_COLLECTION_ID;
 
 export type DirectedGraphStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     DirectedGraphCollectionId,
     DirectedGraph
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/graph-visualization/directed-graph/directedGraphElement2.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/graph-visualization/directed-graph/directedGraphElement2.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { DirectedCluster2 } from './directedCluster2';
 import { DirectedGraph2 } from './directedGraph2';
 import { DirectedGraphEdge2 } from './directedGraphEdge2';
@@ -22,7 +22,7 @@ type DirectedGraphElement2CollectionId =
   typeof DIRECTED_GRAPH_ELEMENT_2_COLLECTION_ID;
 
 export type DirectedGraphElement2StreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     DirectedGraphElement2CollectionId,
     DirectedGraphElement2
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/graph-visualization/directedGraphMetadataById.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/graph-visualization/directedGraphMetadataById.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 
 export type DirectedGraphMetadatumField = {
   label: string;
@@ -26,7 +26,7 @@ type DirectedGraphMetadataByIdCollectionId =
   typeof DIRECTED_GRAPH_METADATA_BY_ID_COLLECTION_ID;
 
 export type DirectedGraphMetadataByIdStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     DirectedGraphMetadataByIdCollectionId,
     DirectedGraphMetadataById
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/graph-visualization/directedGraphMetadataEntry.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/graph-visualization/directedGraphMetadataEntry.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import {
   ObjectWithPrototype,
   buildConstructorFunctionWithName,
@@ -45,7 +45,7 @@ type DirectedGraphMetadataEntryCollectionId =
   typeof DIRECTED_GRAPH_METADATA_ENTRY_COLLECTION_ID;
 
 export type DirectedGraphMetadataEntryStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     DirectedGraphMetadataEntryCollectionId,
     DirectedGraphMetadataEntry
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/graph-visualization/graphvizCode.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/graph-visualization/graphvizCode.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 
 /**
  * See https://graphviz.org/doc/info/lang.html for the specification of
@@ -14,7 +14,7 @@ export const GRAPHVIZ_CODE_COLLECTION_ID = 'graphviz-code';
 type GraphvizCodeCollectionId = typeof GRAPHVIZ_CODE_COLLECTION_ID;
 
 export type GraphvizCodeStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     GraphvizCodeCollectionId,
     GraphvizCode
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/graph-visualization/svgDocument.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/graph-visualization/svgDocument.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 
 /**
  * HTML SVG representation of a Graphviz graph
@@ -12,8 +12,7 @@ export const SVG_DOCUMENT_COLLECTION_ID = 'svg-document';
 
 type SvgDocumentCollectionId = typeof SVG_DOCUMENT_COLLECTION_ID;
 
-export type SvgDocumentStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
-    SvgDocumentCollectionId,
-    SvgDocument
-  >;
+export type SvgDocumentStreamMetatype = InMemoryIdentifiableItem3StreamMetatype<
+  SvgDocumentCollectionId,
+  SvgDocument
+>;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/linting/auditLintAssertionOmissions.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/linting/auditLintAssertionOmissions.ts
@@ -49,7 +49,7 @@ export const auditLintAssertionOmissions = buildProgrammedTransform({
   })
   .onTransform((omissionCollection, assertionCollection) => {
     const assertionSet = new Set(
-      assertionCollection.map((assertion) => {
+      assertionCollection.list.map((assertion) => {
         return assertion.id.forHuman;
       }),
     );

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/linting/lintAssertion.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/linting/lintAssertion.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import {
   GenericComplexIdTemplate,
   ComplexId,
@@ -96,7 +96,7 @@ export const LINT_ASSERTION_COLLECTION_ID = 'lint-assertion';
 type LintAssertionCollectionId = typeof LINT_ASSERTION_COLLECTION_ID;
 
 export type LintAssertionStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     LintAssertionCollectionId,
     GenericLintAssertion
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/sanity-snapshot/sanitySnapshot.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/sanity-snapshot/sanitySnapshot.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 
 /**
  * Information to be committed that is expected to change if a program
@@ -14,7 +14,7 @@ export const SANITY_SNAPSHOT_COLLECTION_ID = 'sanity-snapshot';
 type SanitySnapshotCollectionId = typeof SANITY_SNAPSHOT_COLLECTION_ID;
 
 export type SanitySnapshotStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     SanitySnapshotCollectionId,
     SanitySnapshot
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/snapshot-refresh/constructSnapshotScript.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/snapshot-refresh/constructSnapshotScript.ts
@@ -21,9 +21,9 @@ export const constructSnapshotScript = buildProgrammedTransform({
   .toItem2<OutputFileStreamMetatype>({
     collectionId: OUTPUT_FILE_COLLECTION_ID,
   })
-  .onTransform((inputList) => {
+  .onTransform((programFileCollection) => {
     const filePathSet = new Set(
-      inputList.map((input) => input.file.filePath.serialized),
+      programFileCollection.list.map((input) => input.file.filePath.serialized),
     );
 
     const text = [...filePathSet]

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/type-script-file-relationships/engineProgramFile.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/type-script-file-relationships/engineProgramFile.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { EngineFunctionConfiguration } from '../engine-program-model/engineFunctionConfiguration';
 import { TypeScriptFile } from '../type-script-file/typeScriptFile';
 
@@ -16,7 +16,7 @@ export const ENGINE_PROGRAM_FILE_COLLECTION_ID = 'engine-program-file';
 type EngineProgramFileCollectionId = typeof ENGINE_PROGRAM_FILE_COLLECTION_ID;
 
 export type EngineProgramFileStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     EngineProgramFileCollectionId,
     EngineProgramFile
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/type-script-file/fileCommentedProgramBodyDeclarationGroup.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/type-script-file/fileCommentedProgramBodyDeclarationGroup.ts
@@ -1,5 +1,5 @@
 import Case from 'case';
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { buildNamedConstructorFunction } from '../../../package-agnostic-utilities/constructor-function/buildNamedConstructorFunction';
 import {
   GenericComplexIdTemplate,
@@ -538,7 +538,7 @@ type FileCommentedProgramBodyDeclarationGroupCollectionId =
   typeof FILE_COMMENTED_PROGRAM_BODY_DECLARATION_GROUP_COLLECTION_ID;
 
 export type FileCommentedProgramBodyDeclarationGroupStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     FileCommentedProgramBodyDeclarationGroupCollectionId,
     FileCommentedProgramBodyDeclarationGroup
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/type-script-file/fileParsedCommentGroup.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/type-script-file/fileParsedCommentGroup.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { buildNamedConstructorFunction } from '../../../package-agnostic-utilities/constructor-function/buildNamedConstructorFunction';
 import {
   GenericComplexIdTemplate,
@@ -93,7 +93,7 @@ type FileParsedCommentGroupCollectionId =
   typeof FILE_PARSED_COMMENT_GROUP_COLLECTION_ID;
 
 export type FileParsedCommentGroupStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     FileParsedCommentGroupCollectionId,
     FileParsedCommentGroup
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/type-script-file/parsedTypeScriptFile.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/type-script-file/parsedTypeScriptFile.ts
@@ -1,5 +1,5 @@
 import { TSESTree } from '@typescript-eslint/typescript-estree';
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { FilePath } from '../file/filePath';
 
 /**
@@ -22,7 +22,7 @@ type ParsedTypeScriptFileCollectionId =
   typeof PARSED_TYPE_SCRIPT_FILE_COLLECTION_ID;
 
 export type ParsedTypeScriptFileStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     ParsedTypeScriptFileCollectionId,
     ParsedTypeScriptFile
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/type-script-file/typeScriptFileConfiguration.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/type-script-file/typeScriptFileConfiguration.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { FilePath } from '../file/filePath';
 
 /**
@@ -22,7 +22,7 @@ type TypeScriptFileConfigurationCollectionId =
   typeof TYPE_SCRIPT_FILE_CONFIGURATION_COLLECTION_ID;
 
 export type TypeScriptFileConfigurationStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     TypeScriptFileConfigurationCollectionId,
     TypeScriptFileConfiguration
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/type-script-file/typeScriptFileExportList.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/type-script-file/typeScriptFileExportList.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 
 export type TypeScriptFileExport = {
   identifierName: string;
@@ -20,7 +20,7 @@ type TypeScriptFileExportListCollectionId =
   typeof TYPE_SCRIPT_FILE_EXPORT_LIST_COLLECTION_ID;
 
 export type TypeScriptFileExportListStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     TypeScriptFileExportListCollectionId,
     TypeScriptFileExportList
   >;

--- a/packages/mdd-engine/src/adapted-programs/programmable-units/type-script-file/typeScriptFileImportList.ts
+++ b/packages/mdd-engine/src/adapted-programs/programmable-units/type-script-file/typeScriptFileImportList.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 
 export type TypeScriptFileImport = {
   isInternal: boolean;
@@ -54,7 +54,7 @@ type TypeScriptFileImportListCollectionId =
   typeof TYPE_SCRIPT_FILE_IMPORT_LIST_COLLECTION_ID;
 
 export type TypeScriptFileImportListStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     TypeScriptFileImportListCollectionId,
     TypeScriptFileImportList
   >;

--- a/packages/mdd-engine/src/adapted-programs/programs/develop-knowledge-graph/developKnowledgeGraph.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/develop-knowledge-graph/developKnowledgeGraph.ts
@@ -1,4 +1,3 @@
-import { InMemoryCollection } from '../../../layer-agnostic-utilities/collection/inMemoryCollection';
 import {
   buildCollectionByCollectionId,
   runEngine,
@@ -16,6 +15,7 @@ import {
   AppRendererDelayerInstance,
 } from '../render-knowledge-graph/appRendererDelayer';
 import { renderApp } from '../render-knowledge-graph/app/node/renderApp';
+import { InMemoryIdentifiableItem3Collection } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 
 const programFileCache = new ProgramFileCache({
   namespace: 'develop-knowledge-graph',
@@ -32,7 +32,7 @@ const programFileCache = new ProgramFileCache({
  */
 runEngine({
   explicitCollectionTuple: [
-    new InMemoryCollection<AppRendererDelayerStreamMetatype>({
+    new InMemoryIdentifiableItem3Collection<AppRendererDelayerStreamMetatype>({
       collectionId: APP_RENDERER_DELAYER_COLLECTION_ID,
       initialItemEggTuple: [
         new AppRendererDelayerInstance({

--- a/packages/mdd-engine/src/adapted-programs/programs/find-unused-exports/markUnusedExports.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/find-unused-exports/markUnusedExports.ts
@@ -64,7 +64,7 @@ export const markUnusedExports = buildProgrammedTransform({
   .toItemTuple2<LintAssertionStreamMetatype>({
     collectionId: LINT_ASSERTION_COLLECTION_ID,
   })
-  .onTransform((importListList, exportListList) => {
+  .onTransform((importListCollection, exportListCollection) => {
     type FilePath = string;
     type IdentifierName = string;
 
@@ -79,7 +79,7 @@ export const markUnusedExports = buildProgrammedTransform({
     class OuterMap extends Map<FilePath, InnerMap> {}
 
     const outerMap = new OuterMap(
-      exportListList.map((exportList) => {
+      exportListCollection.list.map((exportList) => {
         const filePath = exportList.id;
         const stateList: MutableExportState[] = exportList.list.map(
           (exportItem) => {
@@ -101,7 +101,7 @@ export const markUnusedExports = buildProgrammedTransform({
       }),
     );
 
-    const importItemList = importListList.flatMap((importList) => {
+    const importItemList = importListCollection.list.flatMap((importList) => {
       return importList.list
         .filter((importItem) => importItem.isInternal)
         .flatMap((importItem) => {

--- a/packages/mdd-engine/src/adapted-programs/programs/lint-file-system-node-path-literals/filePathLikeStringLiteral.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/lint-file-system-node-path-literals/filePathLikeStringLiteral.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { buildNamedConstructorFunction } from '../../../package-agnostic-utilities/constructor-function/buildNamedConstructorFunction';
 import {
   GenericComplexIdTemplate,
@@ -96,7 +96,7 @@ type FilePathLikeStringLiteralCollectionId =
   typeof FILE_PATH_LIKE_STRING_LITERAL_COLLECTION_ID;
 
 export type FilePathLikeStringLiteralStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     FilePathLikeStringLiteralCollectionId,
     FilePathLikeStringLiteral
   >;

--- a/packages/mdd-engine/src/adapted-programs/programs/lint-file-system-node-path-literals/stringLiteralNodeLocator.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/lint-file-system-node-path-literals/stringLiteralNodeLocator.ts
@@ -1,5 +1,5 @@
 import { TSESTree } from '@typescript-eslint/typescript-estree';
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { AstNodeLocator } from '../rename-nonsense/astNodeLocator';
 
 /**
@@ -14,7 +14,7 @@ type StringLiteralNodeLocatorCollectionId =
   typeof STRING_LITERAL_NODE_LOCATOR_COLLECTION_ID;
 
 export type StringLiteralNodeLocatorStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     StringLiteralNodeLocatorCollectionId,
     StringLiteralNodeLocator
   >;

--- a/packages/mdd-engine/src/adapted-programs/programs/model-ci/expectedProgramTestFile.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/model-ci/expectedProgramTestFile.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { buildNamedConstructorFunction } from '../../../package-agnostic-utilities/constructor-function/buildNamedConstructorFunction';
 import { SimplifyN } from '../../../package-agnostic-utilities/type/simplify';
 import { BashFile } from '../../programmable-units/bash-file/bashFile';
@@ -63,7 +63,7 @@ type ExpectedProgramTestFileCollectionId =
   typeof EXPECTED_PROGRAM_TEST_FILE_COLLECTION_ID;
 
 export type ExpectedProgramTestFileStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     ExpectedProgramTestFileCollectionId,
     ExpectedProgramTestFile
   >;

--- a/packages/mdd-engine/src/adapted-programs/programs/model-ci/expectedProgramTestFileConfiguration.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/model-ci/expectedProgramTestFileConfiguration.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { buildNamedConstructorFunction } from '../../../package-agnostic-utilities/constructor-function/buildNamedConstructorFunction';
 import {
   GenericComplexIdTemplate,
@@ -80,7 +80,7 @@ type ExpectedProgramTestFileConfigurationCollectionId =
   typeof EXPECTED_PROGRAM_TEST_FILE_CONFIGURATION_COLLECTION_ID;
 
 export type ExpectedProgramTestFileConfigurationStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     ExpectedProgramTestFileConfigurationCollectionId,
     ExpectedProgramTestFileConfiguration
   >;

--- a/packages/mdd-engine/src/adapted-programs/programs/model-ci/serializedCiModel.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/model-ci/serializedCiModel.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 
 /**
  * The expected ci.sh generated from the CI model
@@ -13,7 +13,7 @@ export const SERIALIZED_CI_MODEL_COLLECTION_ID = 'serialized-ci-model';
 type SerializedCiModelCollectionId = typeof SERIALIZED_CI_MODEL_COLLECTION_ID;
 
 export type SerializedCiModelStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     SerializedCiModelCollectionId,
     SerializedCiModel
   >;

--- a/packages/mdd-engine/src/adapted-programs/programs/model-programs/getDirectedGraphMetadataById2.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/model-programs/getDirectedGraphMetadataById2.ts
@@ -23,13 +23,13 @@ export const getDirectedGraphMetadataById2 = buildProgrammedTransform({
   .toItemTuple2<DirectedGraphMetadataByIdStreamMetatype>({
     collectionId: DIRECTED_GRAPH_METADATA_BY_ID_COLLECTION_ID,
   })
-  .onTransform((entryList) => {
+  .onTransform((entryCollection) => {
     const metadataByIdByRootGraphDebugName = new Map<
       string,
       DirectedGraphMetadataById
     >();
 
-    entryList.forEach((entry) => {
+    entryCollection.list.forEach((entry) => {
       const metadataById: DirectedGraphMetadataById =
         metadataByIdByRootGraphDebugName.get(
           entry.rootGraphLocator.id.forHuman,

--- a/packages/mdd-engine/src/adapted-programs/programs/model-programs/graphElementGroup.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/model-programs/graphElementGroup.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import {
   ObjectWithPrototype,
   buildConstructorFunctionWithName,
@@ -36,7 +36,7 @@ export const GRAPH_ELEMENT_GROUP_COLLECTION_ID = 'graph-element-group';
 type GraphElementGroupCollectionId = typeof GRAPH_ELEMENT_GROUP_COLLECTION_ID;
 
 export type GraphElementGroupStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     GraphElementGroupCollectionId,
     GraphElementGroup
   >;

--- a/packages/mdd-engine/src/adapted-programs/programs/model-programs/groupGraphElements.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/model-programs/groupGraphElements.ts
@@ -22,10 +22,10 @@ export const groupGraphElements = buildProgrammedTransform({
   .toItemTuple2<GraphElementGroupStreamMetatype>({
     collectionId: GRAPH_ELEMENT_GROUP_COLLECTION_ID,
   })
-  .onTransform((allGraphElementList) => {
+  .onTransform((allGraphElementCollection) => {
     const elementGroupByRootLocatorId = new Map<string, GraphElementGroup>();
 
-    allGraphElementList.forEach((element) => {
+    allGraphElementCollection.list.forEach((element) => {
       const key = element.rootGraphLocator.id.forHuman;
 
       const group =

--- a/packages/mdd-engine/src/adapted-programs/programs/rename-nonsense/applyRenaming.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/rename-nonsense/applyRenaming.ts
@@ -60,8 +60,8 @@ export const applyRenaming = buildProgrammedTransform({
   .onTransform(
     (
       directoryCollection,
-      fileSystemNodeConfigurationList,
-      identifierConfigurationList,
+      fileSystemNodeConfigurationCollection,
+      identifierConfigurationCollection,
     ) => {
       const mutableGroupList: ConfigurationGroup[] =
         directoryCollection.list.map((directory) => {
@@ -94,7 +94,7 @@ export const applyRenaming = buildProgrammedTransform({
         }),
       );
 
-      fileSystemNodeConfigurationList.forEach((configuration) => {
+      fileSystemNodeConfigurationCollection.list.forEach((configuration) => {
         const key = configuration.isDirectory
           ? configuration.oldNodePath.serialized
           : configuration.oldNodePath.parentDirectoryPath;
@@ -109,7 +109,7 @@ export const applyRenaming = buildProgrammedTransform({
         }
       });
 
-      identifierConfigurationList.forEach((configuration) => {
+      identifierConfigurationCollection.list.forEach((configuration) => {
         const key =
           configuration.identifierLocator.filePath.parentDirectoryPath;
 

--- a/packages/mdd-engine/src/adapted-programs/programs/rename-nonsense/astNodeLocator.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/rename-nonsense/astNodeLocator.ts
@@ -1,5 +1,5 @@
 import { TSESTree } from '@typescript-eslint/typescript-estree';
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { buildNamedConstructorFunction } from '../../../package-agnostic-utilities/constructor-function/buildNamedConstructorFunction';
 import {
   GenericComplexIdTemplate,
@@ -81,7 +81,7 @@ export const AST_NODE_LOCATOR_COLLECTION_ID = 'ast-node-locator';
 type AstNodeLocatorCollectionId = typeof AST_NODE_LOCATOR_COLLECTION_ID;
 
 export type AstNodeLocatorStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     AstNodeLocatorCollectionId,
     GenericAstNodeLocator
   >;

--- a/packages/mdd-engine/src/adapted-programs/programs/rename-nonsense/fileAstList.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/rename-nonsense/fileAstList.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { buildNamedConstructorFunction } from '../../../package-agnostic-utilities/constructor-function/buildNamedConstructorFunction';
 import { FilePath } from '../../programmable-units/file/filePath';
 import { FileSystemNodeId } from '../../programmable-units/file/fileSystemNode';
@@ -56,8 +56,7 @@ export const FILE_AST_LIST_COLLECTION_ID = 'file-ast-list';
 
 type FileAstListCollectionId = typeof FILE_AST_LIST_COLLECTION_ID;
 
-export type FileAstListStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
-    FileAstListCollectionId,
-    FileAstList
-  >;
+export type FileAstListStreamMetatype = InMemoryIdentifiableItem3StreamMetatype<
+  FileAstListCollectionId,
+  FileAstList
+>;

--- a/packages/mdd-engine/src/adapted-programs/programs/rename-nonsense/fileSystemNodeRenameConfiguration.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/rename-nonsense/fileSystemNodeRenameConfiguration.ts
@@ -1,5 +1,5 @@
 import { posix } from 'path';
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { buildNamedConstructorFunction } from '../../../package-agnostic-utilities/constructor-function/buildNamedConstructorFunction';
 import { SpreadN } from '../../../package-agnostic-utilities/type/spreadN';
 import { FileSystemNodeId } from '../../programmable-units/file/fileSystemNode';
@@ -69,7 +69,7 @@ type FileSystemNodeRenameConfigurationCollectionId =
   typeof FILE_SYSTEM_NODE_RENAME_CONFIGURATION_COLLECTION_ID;
 
 export type FileSystemNodeRenameConfigurationStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     FileSystemNodeRenameConfigurationCollectionId,
     FileSystemNodeRenameConfiguration
   >;

--- a/packages/mdd-engine/src/adapted-programs/programs/rename-nonsense/identifierNodeLocator.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/rename-nonsense/identifierNodeLocator.ts
@@ -1,5 +1,5 @@
 import { TSESTree } from '@typescript-eslint/typescript-estree';
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { AstNodeLocator } from './astNodeLocator';
 
 /**
@@ -13,7 +13,7 @@ type IdentifierNodeLocatorCollectionId =
   typeof IDENTIFIER_NODE_LOCATOR_COLLECTION_ID;
 
 export type IdentifierNodeLocatorStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     IdentifierNodeLocatorCollectionId,
     IdentifierNodeLocator
   >;

--- a/packages/mdd-engine/src/adapted-programs/programs/rename-nonsense/renameConfiguration.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/rename-nonsense/renameConfiguration.ts
@@ -1,5 +1,5 @@
 import { posix } from 'path';
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { buildNamedConstructorFunction } from '../../../package-agnostic-utilities/constructor-function/buildNamedConstructorFunction';
 import {
   GenericComplexIdTemplate,
@@ -103,7 +103,7 @@ type RenameConfigurationCollectionId =
   typeof RENAME_CONFIGURATION_COLLECTION_ID;
 
 export type RenameConfigurationStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     RenameConfigurationCollectionId,
     RenameConfiguration
   >;

--- a/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/appRendererDelayer.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/appRendererDelayer.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { buildNamedConstructorFunction } from '../../../package-agnostic-utilities/constructor-function/buildNamedConstructorFunction';
 import {
   GenericComplexIdTemplate,
@@ -77,7 +77,7 @@ export const APP_RENDERER_DELAYER_COLLECTION_ID = 'app-renderer-delayer';
 type AppRendererDelayerCollectionId = typeof APP_RENDERER_DELAYER_COLLECTION_ID;
 
 export type AppRendererDelayerStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     AppRendererDelayerCollectionId,
     AppRendererDelayer
   >;

--- a/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/boundary/boundary.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/boundary/boundary.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { buildNamedConstructorFunction } from '../../../../package-agnostic-utilities/constructor-function/buildNamedConstructorFunction';
 import {
   GenericComplexIdTemplate,
@@ -86,5 +86,7 @@ export const BOUNDARY_COLLECTION_ID = 'boundary';
 
 type BoundaryCollectionId = typeof BOUNDARY_COLLECTION_ID;
 
-export type BoundaryStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<BoundaryCollectionId, Boundary>;
+export type BoundaryStreamMetatype = InMemoryIdentifiableItem3StreamMetatype<
+  BoundaryCollectionId,
+  Boundary
+>;

--- a/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/boundary/boundaryFact.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/boundary/boundaryFact.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { buildNamedConstructorFunction } from '../../../../package-agnostic-utilities/constructor-function/buildNamedConstructorFunction';
 import { SimplifyN } from '../../../../package-agnostic-utilities/type/simplify';
 import { Metadata } from '../app/browser/dynamicComponentTypes';
@@ -74,7 +74,7 @@ export const BOUNDARY_FACT_COLLECTION_ID = 'boundary-fact';
 type BoundaryFactCollectionId = typeof BOUNDARY_FACT_COLLECTION_ID;
 
 export type BoundaryFactStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     BoundaryFactCollectionId,
     BoundaryFact
   >;

--- a/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/boundary/getPartitionedBoundaryListTrie.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/boundary/getPartitionedBoundaryListTrie.ts
@@ -22,10 +22,10 @@ export const getPartitionedBoundaryListTrie = buildProgrammedTransform({
   .toItem2<PartitionedBoundaryListTrieStreamMetatype>({
     collectionId: PARTITIONED_BOUNDARY_LIST_TRIE_COLLECTION_ID,
   })
-  .onTransform((partitionedBoundaryList) => {
+  .onTransform((partitionedBoundaryCollection) => {
     const trie = new PartitionedBoundaryListTrie([]);
 
-    partitionedBoundaryList.forEach((partitionedBoundary) => {
+    partitionedBoundaryCollection.list.forEach((partitionedBoundary) => {
       trie.addSubtrie(
         partitionedBoundary.boundary.directory.directoryPath.partList,
         () => {

--- a/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/boundary/partitionedBoundary.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/boundary/partitionedBoundary.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { buildNamedConstructorFunction } from '../../../../package-agnostic-utilities/constructor-function/buildNamedConstructorFunction';
 import { SimplifyN } from '../../../../package-agnostic-utilities/type/simplify';
 import { PartitionFact } from '../partition-fact/partitionFact';
@@ -56,7 +56,7 @@ type PartitionedBoundaryCollectionId =
   typeof PARTITIONED_BOUNDARY_COLLECTION_ID;
 
 export type PartitionedBoundaryStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     PartitionedBoundaryCollectionId,
     PartitionedBoundary
   >;

--- a/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/common-boundary-root/commonBoundaryRoot.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/common-boundary-root/commonBoundaryRoot.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import {
   ObjectWithPrototype,
   buildConstructorFunctionWithName,
@@ -33,7 +33,7 @@ export const COMMON_BOUNDARY_ROOT_COLLECTION_ID = 'common-boundary-root';
 type CommonBoundaryRootCollectionId = typeof COMMON_BOUNDARY_ROOT_COLLECTION_ID;
 
 export type CommonBoundaryRootStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     CommonBoundaryRootCollectionId,
     CommonBoundaryRoot
   >;

--- a/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/common-boundary-root/getCommonBoundaryRoot.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/common-boundary-root/getCommonBoundaryRoot.ts
@@ -37,8 +37,8 @@ export const getCommonBoundaryRoot = buildProgrammedTransform({
   .toItemTuple2<BoundaryFactStreamMetatype>({
     collectionId: BOUNDARY_FACT_COLLECTION_ID,
   })
-  .onTransform((boundaryList, directoryCollection) => {
-    const boundaryDirectoryList = boundaryList.map((boundary) => {
+  .onTransform((boundaryCollection, directoryCollection) => {
+    const boundaryDirectoryList = boundaryCollection.list.map((boundary) => {
       const directory = directoryCollection.byNodePath.get(
         boundary.directory.directoryPath.serialized,
       );
@@ -75,7 +75,7 @@ export const getCommonBoundaryRoot = buildProgrammedTransform({
       directoryPath: partListCopy.join(posix.sep),
     });
 
-    const boundaryFactList = boundaryList.map((boundary) => {
+    const boundaryFactList = boundaryCollection.list.map((boundary) => {
       return new BoundaryFactInstance({
         boundary,
         commonBoundaryRoot,

--- a/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/constructDynamicIndexFile.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/constructDynamicIndexFile.ts
@@ -87,7 +87,7 @@ export const constructDynamicIndexFile = buildProgrammedTransform({
       ]
     >;
 
-    const sortedLayerCollection = layerCollection
+    const sortedLayerCollection = layerCollection.list
       .slice()
       .sort((layerA, layerB) => {
         return layerA.sortOrder - layerB.sortOrder;

--- a/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/constructDynamicMetadataFile.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/constructDynamicMetadataFile.ts
@@ -118,8 +118,8 @@ export const constructDynamicMetadataFile = buildProgrammedTransform({
   .onTransform(
     (boundaryFactCollection, [commonBoundaryRoot], fileFactCollection) => {
       const metadataList: Metadata[] = [
-        ...boundaryFactCollection,
-        ...fileFactCollection,
+        ...boundaryFactCollection.list,
+        ...fileFactCollection.list,
       ].map((fact) => fact.graphMetadata);
 
       const metadataById = Object.fromEntries(

--- a/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/dependency/dependency-path/fileDependencyPathNodeFact.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/dependency/dependency-path/fileDependencyPathNodeFact.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { buildNamedConstructorFunction } from '../../../../../package-agnostic-utilities/constructor-function/buildNamedConstructorFunction';
 import { SimplifyN } from '../../../../../package-agnostic-utilities/type/simplify';
 import { DirectedGraphElement2 } from '../../../../programmable-units/graph-visualization/directed-graph/directedGraphElement2';
@@ -89,7 +89,7 @@ type FileDependencyPathNodeFactCollectionId =
   typeof FILE_DEPENDENCY_PATH_NODE_FACT_COLLECTION_ID;
 
 export type FileDependencyPathNodeFactStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     FileDependencyPathNodeFactCollectionId,
     FileDependencyPathNodeFact
   >;

--- a/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/dependency/dependency-path/fileDependencyPathSegmentFact.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/dependency/dependency-path/fileDependencyPathSegmentFact.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { buildNamedConstructorFunction } from '../../../../../package-agnostic-utilities/constructor-function/buildNamedConstructorFunction';
 import {
   GenericComplexIdTemplate,
@@ -119,7 +119,7 @@ type FileDependencyPathSegmentFactCollectionId =
   typeof FILE_DEPENDENCY_PATH_SEGMENT_FACT_COLLECTION_ID;
 
 export type FileDependencyPathSegmentFactStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     FileDependencyPathSegmentFactCollectionId,
     FileDependencyPathSegmentFact
   >;

--- a/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/dependency/dependency-path/partitionedFileDependencyPathNode.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/dependency/dependency-path/partitionedFileDependencyPathNode.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { buildNamedConstructorFunction } from '../../../../../package-agnostic-utilities/constructor-function/buildNamedConstructorFunction';
 import {
   GenericComplexIdTemplate,
@@ -103,7 +103,7 @@ type PartitionedFileDependencyPathNodeCollectionId =
   typeof PARTITIONED_FILE_DEPENDENCY_PATH_NODE_COLLECTION_ID;
 
 export type PartitionedFileDependencyPathNodeStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     PartitionedFileDependencyPathNodeCollectionId,
     PartitionedFileDependencyPathNode
   >;

--- a/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/dependency/getPartitionedFileDependencyPathConstituents.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/dependency/getPartitionedFileDependencyPathConstituents.ts
@@ -53,7 +53,7 @@ export const getPartitionedFileDependencyPathConstituents =
         keyTemplate,
       });
 
-      fileDependencyCollection
+      fileDependencyCollection.list
         .map<MappableFileDependency>((fileDependency) => {
           return {
             partitionId: fileDependency.partitionFact.id.forHuman,

--- a/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/dependency/partitionedFileDependency.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/dependency/partitionedFileDependency.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { buildNamedConstructorFunction } from '../../../../package-agnostic-utilities/constructor-function/buildNamedConstructorFunction';
 import {
   GenericComplexIdTemplate,
@@ -87,7 +87,7 @@ type PartitionedFileDependencyCollectionId =
   typeof PARTITIONED_FILE_DEPENDENCY_COLLECTION_ID;
 
 export type PartitionedFileDependencyStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     PartitionedFileDependencyCollectionId,
     PartitionedFileDependency
   >;

--- a/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/directory/assertDirectoriesHaveBoundaries.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/directory/assertDirectoriesHaveBoundaries.ts
@@ -44,7 +44,7 @@ export const assertDirectoriesHaveBoundaries = buildProgrammedTransform({
     collectionId: PROGRAM_ERROR_COLLECTION_ID,
   })
   .onTransform((directoryWithFileCollection, boundedDirectoryCollection) => {
-    const unboundedDirectoryList = directoryWithFileCollection.filter(
+    const unboundedDirectoryList = directoryWithFileCollection.list.filter(
       (directory) => {
         const boundedDirectory = boundedDirectoryCollection.byNodePath.get(
           directory.directoryPath.serialized,

--- a/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/directory/directoryFact2.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/directory/directoryFact2.ts
@@ -14,7 +14,7 @@ import {
 } from '../partition-fact/partitionFact';
 import { THEME } from '../theme';
 import { BoundedDirectory } from './boundedDirectory';
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { DirectedCluster2Instance } from '../../../programmable-units/graph-visualization/directed-graph/directedCluster2';
 import { DirectedGraphElement2 } from '../../../programmable-units/graph-visualization/directed-graph/directedGraphElement2';
 import { FactTypeName } from '../fact/factTypeName';
@@ -119,7 +119,7 @@ export const DIRECTORY_FACT_2_COLLECTION_ID = 'directory-fact-2';
 type DirectoryFact2CollectionId = typeof DIRECTORY_FACT_2_COLLECTION_ID;
 
 export type DirectoryFact2StreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     DirectoryFact2CollectionId,
     DirectoryFact2
   >;

--- a/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/directory/directoryWithFile.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/directory/directoryWithFile.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { Directory } from '../../../programmable-units/file/directory';
 
 /**
@@ -11,7 +11,7 @@ export const DIRECTORY_WITH_FILE_COLLECTION_ID = 'directory-with-file';
 type DirectoryWithFileCollectionId = typeof DIRECTORY_WITH_FILE_COLLECTION_ID;
 
 export type DirectoryWithFileStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     DirectoryWithFileCollectionId,
     DirectoryWithFile
   >;

--- a/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/directory/partitionedDirectory.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/directory/partitionedDirectory.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { buildNamedConstructorFunction } from '../../../../package-agnostic-utilities/constructor-function/buildNamedConstructorFunction';
 import {
   GenericComplexIdTemplate,
@@ -81,7 +81,7 @@ type PartitionedDirectoryCollectionId =
   typeof PARTITIONED_DIRECTORY_COLLECTION_ID;
 
 export type PartitionedDirectoryStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     PartitionedDirectoryCollectionId,
     PartitionedDirectory
   >;

--- a/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/fact/aggregateFacts.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/fact/aggregateFacts.ts
@@ -55,10 +55,10 @@ export const aggregateFacts = buildProgrammedTransform({
     ) => {
       return [
         ...partitionFactCollection.list,
-        ...directoryFact2Collection,
-        ...fileFact2Collection,
-        ...fileDependencyPathNodeFactCollection,
-        ...fileDependencyPathSegmentFactCollection,
+        ...directoryFact2Collection.list,
+        ...fileFact2Collection.list,
+        ...fileDependencyPathNodeFactCollection.list,
+        ...fileDependencyPathSegmentFactCollection.list,
       ];
     },
   )

--- a/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/file/fileFact2.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/file/fileFact2.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { buildNamedConstructorFunction } from '../../../../package-agnostic-utilities/constructor-function/buildNamedConstructorFunction';
 import {
   GenericComplexIdTemplate,
@@ -181,5 +181,7 @@ export const FILE_FACT_2_COLLECTION_ID = 'file-fact-2';
 
 type FileFact2CollectionId = typeof FILE_FACT_2_COLLECTION_ID;
 
-export type FileFact2StreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<FileFact2CollectionId, FileFact2>;
+export type FileFact2StreamMetatype = InMemoryIdentifiableItem3StreamMetatype<
+  FileFact2CollectionId,
+  FileFact2
+>;

--- a/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/layer/getLayerListTrie.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/layer/getLayerListTrie.ts
@@ -22,7 +22,7 @@ export const getLayerListTrie = buildProgrammedTransform({
   .onTransform((layerCollection) => {
     const trie = new LayerListTrie([]);
 
-    layerCollection.forEach((layer) => {
+    layerCollection.list.forEach((layer) => {
       trie.addSubtrie(
         layer.directory.directoryPath.partList,
         () => {

--- a/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/layer/layer.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/render-knowledge-graph/layer/layer.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { buildNamedConstructorFunction } from '../../../../package-agnostic-utilities/constructor-function/buildNamedConstructorFunction';
 import { SimplifyN } from '../../../../package-agnostic-utilities/type/simplify';
 import { Directory } from '../../../programmable-units/file/directory';
@@ -56,7 +56,7 @@ export const LAYER_COLLECTION_ID = 'layer';
 
 type LayerCollectionId = typeof LAYER_COLLECTION_ID;
 
-export type LayerStreamMetatype = InMemoryIdentifiableItem2ListStreamMetatype<
+export type LayerStreamMetatype = InMemoryIdentifiableItem3StreamMetatype<
   LayerCollectionId,
   Layer
 >;

--- a/packages/mdd-engine/src/adapted-programs/programs/test-graph-render/testGraphRender.ts
+++ b/packages/mdd-engine/src/adapted-programs/programs/test-graph-render/testGraphRender.ts
@@ -21,7 +21,7 @@ import {
   DirectedGraphMetadataByIdStreamMetatype,
 } from '../../programmable-units/graph-visualization/directedGraphMetadataById';
 import { InMemoryCollection } from '../../../layer-agnostic-utilities/collection/inMemoryCollection';
-import { InMemoryIdentifiableItem2ListCollection } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3Collection } from '../../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import { ProgramFileCache } from '../../../layer-agnostic-utilities/program/programFileCache';
 import { SANITY_SNAPSHOT_COLLECTION_ID } from '../../programmable-units/sanity-snapshot/sanitySnapshot';
 import { OutputFileCollection } from '../../programmable-units/output-file/outputFileCollection';
@@ -51,7 +51,7 @@ runEngine({
         ],
       },
     ),
-    new InMemoryIdentifiableItem2ListCollection<DirectedGraphStreamMetatype>({
+    new InMemoryIdentifiableItem3Collection<DirectedGraphStreamMetatype>({
       collectionId: DIRECTED_GRAPH_COLLECTION_ID,
       initialItemEggTuple: [
         {
@@ -130,7 +130,7 @@ runEngine({
         },
       ],
     }),
-    new InMemoryIdentifiableItem2ListCollection<DirectedGraphMetadataByIdStreamMetatype>(
+    new InMemoryIdentifiableItem3Collection<DirectedGraphMetadataByIdStreamMetatype>(
       {
         collectionId: DIRECTED_GRAPH_METADATA_BY_ID_COLLECTION_ID,
         initialItemEggTuple: [

--- a/packages/mdd-engine/src/adapter/engine/runEngine.ts
+++ b/packages/mdd-engine/src/adapter/engine/runEngine.ts
@@ -28,8 +28,8 @@ import {
   CollectionIdTuple,
 } from '../../core/types/collection/collectionId';
 import {
-  GenericInMemoryIdentifiableItem2ListStreamMetatype,
-  InMemoryIdentifiableItem2ListCollection,
+  GenericInMemoryIdentifiableItem3StreamMetatype,
+  InMemoryIdentifiableItem3Collection,
 } from '../../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import {
   GenericCollection2,
@@ -118,7 +118,7 @@ type StreamMetatypeUnionFromProgrammedTransformTuple<
 >;
 
 type GenericInferableStreamMetatype =
-  | GenericInMemoryIdentifiableItem2ListStreamMetatype
+  | GenericInMemoryIdentifiableItem3StreamMetatype
   | GenericFileSystemNodeStreamMetatype;
 
 type UninferableStreamMetatypeUnion<
@@ -349,7 +349,7 @@ const getInferredInMemoryCollectionTuple = (
 
   const inferredCollectionTuple = missingCollectionIdList.map(
     (collectionId) => {
-      return new InMemoryIdentifiableItem2ListCollection({
+      return new InMemoryIdentifiableItem3Collection({
         collectionId,
         initialItemEggTuple: [],
       });

--- a/packages/mdd-engine/src/core-programs/serializableTypeName.ts
+++ b/packages/mdd-engine/src/core-programs/serializableTypeName.ts
@@ -1,4 +1,4 @@
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 
 /**
  * A data structure to snapshot when testing if a utility can detect the right
@@ -19,7 +19,7 @@ type SerializableTypeNameCollectionId =
   typeof SERIALIZABLE_TYPE_NAME_COLLECTION_ID;
 
 export type SerializableTypeNameStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     SerializableTypeNameCollectionId,
     SerializableTypeName
   >;

--- a/packages/mdd-engine/src/core-programs/testBuildAddMetadataForSerialization.ts
+++ b/packages/mdd-engine/src/core-programs/testBuildAddMetadataForSerialization.ts
@@ -1,5 +1,5 @@
 import { runEngine2 } from '../core/engine/runEngine';
-import { InMemoryIdentifiableItem2ListCollection } from '../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3Collection } from '../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import {
   DATUM_TEST_CASE_INPUT_COLLECTION_ID,
   DATUM_TEST_CASE_INPUT_IDENTIFIABLE_ITEM_LIST,
@@ -24,12 +24,10 @@ const programFileCache = new ProgramFileCache({
  */
 runEngine2({
   inputCollectionList: [
-    new InMemoryIdentifiableItem2ListCollection<DatumTestCaseInputStreamMetatype>(
-      {
-        collectionId: DATUM_TEST_CASE_INPUT_COLLECTION_ID,
-        initialItemEggTuple: DATUM_TEST_CASE_INPUT_IDENTIFIABLE_ITEM_LIST,
-      },
-    ),
+    new InMemoryIdentifiableItem3Collection<DatumTestCaseInputStreamMetatype>({
+      collectionId: DATUM_TEST_CASE_INPUT_COLLECTION_ID,
+      initialItemEggTuple: DATUM_TEST_CASE_INPUT_IDENTIFIABLE_ITEM_LIST,
+    }),
     new JsonSerializableCollection<SerializedConfiguration>({
       collectionId: 'serialized',
       programFileCache,

--- a/packages/mdd-engine/src/core-programs/testGetCustomTypedDatum.ts
+++ b/packages/mdd-engine/src/core-programs/testGetCustomTypedDatum.ts
@@ -2,7 +2,7 @@ import { ProgrammedTransform2 } from '../core/types/programmed-transform/program
 import { LeftInputItemStreamConnectionMetatype } from '../core/types/stream-connection-metatype/leftInputStreamConnectionMetatype';
 import { OutputStreamConnectionMetatype } from '../core/types/stream-connection-metatype/outputStreamConnectionMetatype';
 import { runEngine2 } from '../core/engine/runEngine';
-import { InMemoryIdentifiableItem2ListCollection } from '../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3Collection } from '../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import {
   DATUM_TEST_CASE_INPUT_COLLECTION_ID,
   DATUM_TEST_CASE_INPUT_IDENTIFIABLE_ITEM_LIST,
@@ -71,13 +71,11 @@ const getCustomTypedTestCaseInputTypeName: ProgrammedTransform2<
  */
 runEngine2({
   inputCollectionList: [
-    new InMemoryIdentifiableItem2ListCollection<DatumTestCaseInputStreamMetatype>(
-      {
-        collectionId: DATUM_TEST_CASE_INPUT_COLLECTION_ID,
-        initialItemEggTuple: DATUM_TEST_CASE_INPUT_IDENTIFIABLE_ITEM_LIST,
-      },
-    ),
-    new InMemoryIdentifiableItem2ListCollection<SerializableTypeNameStreamMetatype>(
+    new InMemoryIdentifiableItem3Collection<DatumTestCaseInputStreamMetatype>({
+      collectionId: DATUM_TEST_CASE_INPUT_COLLECTION_ID,
+      initialItemEggTuple: DATUM_TEST_CASE_INPUT_IDENTIFIABLE_ITEM_LIST,
+    }),
+    new InMemoryIdentifiableItem3Collection<SerializableTypeNameStreamMetatype>(
       {
         collectionId: SERIALIZABLE_TYPE_NAME_COLLECTION_ID,
         initialItemEggTuple: [],

--- a/packages/mdd-engine/src/core-programs/testGetTypeScriptTypedDatum.ts
+++ b/packages/mdd-engine/src/core-programs/testGetTypeScriptTypedDatum.ts
@@ -2,7 +2,7 @@ import { ProgrammedTransform2 } from '../core/types/programmed-transform/program
 import { LeftInputItemStreamConnectionMetatype } from '../core/types/stream-connection-metatype/leftInputStreamConnectionMetatype';
 import { OutputStreamConnectionMetatype } from '../core/types/stream-connection-metatype/outputStreamConnectionMetatype';
 import { runEngine2 } from '../core/engine/runEngine';
-import { InMemoryIdentifiableItem2ListCollection } from '../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3Collection } from '../layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2';
 import {
   DATUM_TEST_CASE_INPUT_COLLECTION_ID,
   DATUM_TEST_CASE_INPUT_IDENTIFIABLE_ITEM_LIST,
@@ -71,13 +71,11 @@ const getTypedTestCaseInputTypeName: ProgrammedTransform2<
  */
 runEngine2({
   inputCollectionList: [
-    new InMemoryIdentifiableItem2ListCollection<DatumTestCaseInputStreamMetatype>(
-      {
-        collectionId: DATUM_TEST_CASE_INPUT_COLLECTION_ID,
-        initialItemEggTuple: DATUM_TEST_CASE_INPUT_IDENTIFIABLE_ITEM_LIST,
-      },
-    ),
-    new InMemoryIdentifiableItem2ListCollection<SerializableTypeNameStreamMetatype>(
+    new InMemoryIdentifiableItem3Collection<DatumTestCaseInputStreamMetatype>({
+      collectionId: DATUM_TEST_CASE_INPUT_COLLECTION_ID,
+      initialItemEggTuple: DATUM_TEST_CASE_INPUT_IDENTIFIABLE_ITEM_LIST,
+    }),
+    new InMemoryIdentifiableItem3Collection<SerializableTypeNameStreamMetatype>(
       {
         collectionId: SERIALIZABLE_TYPE_NAME_COLLECTION_ID,
         initialItemEggTuple: [],

--- a/packages/mdd-engine/src/layer-agnostic-utilities/assertion/fileExistenceAsserterInput.ts
+++ b/packages/mdd-engine/src/layer-agnostic-utilities/assertion/fileExistenceAsserterInput.ts
@@ -10,7 +10,7 @@ import {
   ComplexId,
 } from '../../package-agnostic-utilities/data-structure/id';
 import { SimplifyN } from '../../package-agnostic-utilities/type/simplify';
-import { InMemoryIdentifiableItem2ListStreamMetatype } from '../collection/inMemoryIdentifiableItemCollection2';
+import { InMemoryIdentifiableItem3StreamMetatype } from '../collection/inMemoryIdentifiableItemCollection2';
 
 const FILE_EXISTENCE_ASSERTER_INPUT_ID_TEMPLATE = [
   ['requestor', ComplexId.ANY],
@@ -97,7 +97,7 @@ type FileExistenceAsserterInputCollectionId =
   typeof FILE_EXISTENCE_ASSERTER_INPUT_COLLECTION_ID;
 
 export type FileExistenceAsserterInputStreamMetatype =
-  InMemoryIdentifiableItem2ListStreamMetatype<
+  InMemoryIdentifiableItem3StreamMetatype<
     FileExistenceAsserterInputCollectionId,
     FileExistenceAsserterInput
   >;

--- a/packages/mdd-engine/src/layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2.ts
+++ b/packages/mdd-engine/src/layer-agnostic-utilities/collection/inMemoryIdentifiableItemCollection2.ts
@@ -198,29 +198,32 @@ export class InMemoryIdentifiableItem2ListCollection<
   }
 }
 
-type InMemoryOdeshin3VoictentPelie<TOdeshinPelie> = {
-  byId: Map<string, TOdeshinPelie>;
-  list: TOdeshinPelie[];
+type InMemoryIdentifiableItem3CollectionStreamable<
+  TIdentifiableItemStreamable,
+> = {
+  byId: Map<string, TIdentifiableItemStreamable>;
+  list: TIdentifiableItemStreamable[];
 };
 
 export type InMemoryIdentifiableItem3StreamMetatype<
   TGepp extends CollectionId,
-  TOdeshin extends GenericIdentifiableItem,
+  TIdentifiableItem extends GenericIdentifiableItem,
 > = InMemoryIdentifiableItem2StreamMetatype<
   TGepp,
-  TOdeshin,
-  InMemoryOdeshin3VoictentPelie<TOdeshin>
+  TIdentifiableItem,
+  InMemoryIdentifiableItem3CollectionStreamable<TIdentifiableItem>
 >;
 
-type GenericInMemoryOdeshin3Voque = InMemoryIdentifiableItem3StreamMetatype<
-  CollectionId,
-  GenericIdentifiableItem
->;
+export type GenericInMemoryIdentifiableItem3StreamMetatype =
+  InMemoryIdentifiableItem3StreamMetatype<
+    CollectionId,
+    GenericIdentifiableItem
+  >;
 
 export class InMemoryIdentifiableItem3Collection<
-  TVoque extends GenericInMemoryOdeshin3Voque,
+  TVoque extends GenericInMemoryIdentifiableItem3StreamMetatype,
 > extends BaseInMemoryIdentifiableItem2Collection<
-  GenericInMemoryOdeshin3Voque,
+  GenericInMemoryIdentifiableItem3StreamMetatype,
   TVoque
 > {
   constructor({


### PR DESCRIPTION
The new identifiable item collection will index each item by id, as well as providing a list of all of the items. The old one only provided a list.